### PR TITLE
Regex update to match node for twitter

### DIFF
--- a/includes/apple-exporter/components/class-tweet.php
+++ b/includes/apple-exporter/components/class-tweet.php
@@ -20,7 +20,7 @@ class Tweet extends Component {
 	public static function node_matches( $node ) {
 		// Check if the body of a node is solely a tweet URL
 		$is_twitter_url = $node->nodeName == 'p' && preg_match(
-			'#^https?://(?:www\.)?twitter.com/(?:\#!/)?([^/]*)/status(?:es)?/(\d+)$#',
+			'#https?://(www\.)?twitter\.com/.+?/status(es)?/.*#i',
 			trim( $node->nodeValue ) );
 
 		if ( self::node_has_class( $node, 'twitter-tweet' ) || $is_twitter_url ) {
@@ -57,4 +57,3 @@ class Tweet extends Component {
 	}
 
 }
-


### PR DESCRIPTION
Update to match url with a trailing slash, extended resource path, and allow for a soft returns before the URL. Referencing WP:

https://github.com/WordPress/WordPress/blob/master/wp-includes/class-oembed.php#L57