### PR TITLE
updating default retrieval to check for it's existence first

### DIFF
--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -589,7 +589,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 * @access private
 	 */
 	private function get_default_for( $name ) {
-		return $this->base_settings[ $name ];
+		return isset( $this->base_settings[ $name ] ) ? $this->base_settings[ $name ] : '';
 	}
 
 	/**


### PR DESCRIPTION
makes sure the key for a default value exists before trying to retrieve and return it