### PR TITLE
Additional filters

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -166,6 +166,13 @@ class Exporter {
 	 * @access private
 	 */
 	private function generate_json() {
+
+		/**
+		 * Provides access to modify the output from an external plugin
+		 * including the workspace, builders and components
+		 */
+		do_action_ref_array( 'apple_news_pre_generate_json', array( &$this ) );
+
 		// Base JSON
 		$json = array(
 			'version'    => '0.10',


### PR DESCRIPTION
Adds a hook to modify / use the exporter object to actually be able to manipulate the builders and workspace using their methods rather than modifying arrays

The current filters that just offer a content ID as the 2nd parameter but it's difficult to see how to use them to add anything useful without the object methods.

Opening this for discussion mor than anything else.