### PR TITLE
Asynchronous publishing

### DIFF
--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Handles asynchronous actions for the Apple News plugin.
+ *
+ * @author  Bradford Campeau-Laurion
+ * @since   1.0.0
+ */
+
+/**
+ * Entry-point class for the plugin.
+ */
+class Admin_Apple_Async extends Apple_News {
+
+	/**
+	 * Current plugin settings.
+	 *
+	 * @var array
+	 * @access private
+	 */
+	private $settings;
+
+	/**
+	 * Hook name for publishing in async mode
+	 *
+	 * @access public
+	 */
+	const ASYNC_PUSH_HOOK = 'apple_news_async_push';
+
+	/**
+	 * Constructor.
+	 */
+	function __construct( $settings ) {
+		$this->settings = $settings;
+
+		// If async mode is enabled create the action hook
+		if ( 'yes' === $settings->get( 'api_async' ) ) {
+			add_action( self::ASYNC_PUSH_HOOK, array( $this, 'async_push' ), 10, 2 );
+
+			// If we're on VIP, set async mode to use the jobs system
+			if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
+				add_filter( 'wpcom_vip_passthrough_cron_to_jobs', array( $this, 'passthrough_cron_to_jobs' ) );
+			}
+		}
+	}
+
+	/**
+	 * Handle performing an asynchronous push request.
+	 *
+	 * @access public
+	 * @param int $post_id,
+	 * @param int $user_id
+	 * @since 1.0.0
+	 */
+	public function async_push( $post_id, $user_id ) {
+		// This hook could be used for an ini_set to increase max execution time
+		// for asynchronous publishing to handle large push requests.
+		// Since some hosts wouldn't support it, the code isn't added directly here.
+		//
+		// On WordPress VIP this isn't necessary since the plugin
+		// will automatically use the jobs system which can handle requests up to 12 hours.
+		do_action( 'apple_news_before_async_push' );
+
+		$action = new Apple_Actions\Index\Push( $this->settings, $post_id );
+		try {
+			$action->perform( true );
+
+			$post = get_post( $post_id );
+			Admin_Apple_Notice::success( sprintf(
+				__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
+				$post->post_title
+			), $user_id );
+		} catch ( Apple_Actions\Action_Exception $e ) {
+			Admin_Apple_Notice::error( $e->getMessage() );
+		}
+
+		do_action( 'apple_news_after_async_push' );
+	}
+
+	/**
+	 * On WordPress VIP only, run async publishing requests through the jobs system.
+	 * This will allow for a maximum publishing time up to 12 hours, which is
+	 * well in excess of even the most lengthy API request.
+	 *
+	 * @access public
+	 * @since 1.0.0
+	 */
+	public function passthrough_cron_to_jobs( $hooks ) {
+		$hooks[] = $this->async_hook;
+		return $hooks;
+	}
+}

--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -85,7 +85,7 @@ class Admin_Apple_Async extends Apple_News {
 	 * @since 1.0.0
 	 */
 	public function passthrough_cron_to_jobs( $hooks ) {
-		$hooks[] = $this->async_hook;
+		$hooks[] = self::ASYNC_PUSH_HOOK;
 		return $hooks;
 	}
 }

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -276,7 +276,13 @@ class Admin_Apple_Index_Page extends Apple_News {
 		$action = new Apple_Actions\Index\Push( $this->settings, $id );
 		try {
 			$action->perform();
-			$this->notice_success( __( 'Your article has been pushed successfully!', 'apple-news' ) );
+
+			// In async mode, success or failure will be displayed later
+			if ( 'yes' !== $this->settings->get( 'api_async' ) ) {
+				$this->notice_success( __( 'Your article has been pushed successfully!', 'apple-news' ) );
+			} else {
+				$this->notice_success( __( 'Your article will be pushed shortly.', 'apple-news' ) );
+			}
 		} catch ( Apple_Actions\Action_Exception $e ) {
 			$this->notice_error( $e->getMessage() );
 		}

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -12,6 +12,7 @@ require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-index-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-bulk-export-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-notice.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-meta-boxes.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-async.php';
 
 /**
  * Entry-point class for the plugin.
@@ -25,9 +26,6 @@ class Admin_Apple_News extends Apple_News {
 		// This is required to download files and setting headers.
 		ob_start();
 
-		// Initialize notice messaging utility
-		new Admin_Apple_Notice;
-
 		// Register hooks
 		add_action( 'admin_print_styles-toplevel_page_apple_news_index', array( $this, 'plugin_styles' ) );
 
@@ -36,6 +34,9 @@ class Admin_Apple_News extends Apple_News {
 		// $settings.
 		$admin_settings = new Admin_Apple_Settings;
 		$settings       = $admin_settings->fetch_settings();
+
+		// Initialize notice messaging utility
+		new Admin_Apple_Notice( $settings );
 
 		// Set up main page
 		new Admin_Apple_Index_Page( $settings );
@@ -48,6 +49,9 @@ class Admin_Apple_News extends Apple_News {
 
 		// Set up the publish meta box if enabled in the settings
 		new Admin_Apple_Meta_Boxes( $settings );
+
+		// Set up asynchronous publishing features
+		new Admin_Apple_Async( $settings );
 	}
 
 	/**

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -14,9 +14,20 @@ class Admin_Apple_Notice {
 	const KEY = 'apple_news_notice';
 
 	/**
+	 * Current plugin settings.
+	 *
+	 * @var array
+	 * @access private
+	 * @static
+	 */
+	private static $settings;
+
+	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	function __construct( $settings ) {
+		self::$settings = $settings;
+
 		add_action( 'admin_notices', array( $this, 'show' ) );
 	}
 
@@ -25,11 +36,16 @@ class Admin_Apple_Notice {
 	 *
 	 * @param string $message
 	 * @param string $type
+	 * @param int $user_id
 	 * @static
 	 * @access public
 	 */
-	public static function message( $message, $type ) {
-		update_user_meta( get_current_user_id(), self::KEY, array(
+	public static function message( $message, $type, $user_id = null ) {
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
+
+		add_user_meta( $user_id, self::KEY, array(
 			'message' => sanitize_text_field( $message ),
 			'type' => sanitize_text_field( $type )
 		) );
@@ -39,33 +55,36 @@ class Admin_Apple_Notice {
 	 * Add an info message.
 	 *
 	 * @param string $message
+	 * @param int $user_id
 	 * @static
 	 * @access public
 	 */
-	public static function info( $message ) {
-		self::message( $message, 'updated' );
+	public static function info( $message, $user_id = null ) {
+		self::message( $message, 'updated', $user_id );
 	}
 
 	/**
 	 * Add a success message.
 	 *
 	 * @param string $message
+	 * @param int $user_id
 	 * @static
 	 * @access public
 	 */
-	public static function success( $message ) {
-		self::message( $message, 'updated' );
+	public static function success( $message, $user_id = null ) {
+		self::message( $message, 'updated', $user_id );
 	}
 
 	/**
 	 * Add an error message.
 	 *
 	 * @param string $message
+	 * @param int $user_id
 	 * @static
 	 * @access public
 	 */
-	public static function error( $message ) {
-		self::message( $message, 'error' );
+	public static function error( $message, $user_id = null ) {
+		self::message( $message, 'error', $user_id );
 	}
 
 	/**
@@ -88,21 +107,27 @@ class Admin_Apple_Notice {
 	 * @access public
 	 */
 	public static function show() {
-		// Only execute on Apple admin pages
+		// Only execute on Apple admin pages unless this is in async mode.
+		// In that case, messages should be displayed everywhere since publishing
+		// may complete after the user has navigated away from Apple News.
 		$current_screen = get_current_screen();
-		if ( false === stripos( $current_screen->base, '_apple' ) ) {
+		if ( 'yes' !== self::$settings->get( 'api_async' ) && false === stripos( $current_screen->base, '_apple' ) ) {
 			return;
 		}
 
 		// Check for notices
-		$notice = get_user_meta( get_current_user_id(), self::KEY, true );
-		if ( empty( $notice['message'] ) ) {
+		$notices = get_user_meta( get_current_user_id(), self::KEY );
+		if ( empty( $notices ) ) {
 			return;
 		}
 
-		// Show the notice
-		$type = isset( $notice['type'] ) ? $notice['type'] : 'updated';
-		self::show_notice( $notice['message'], $type );
+		// Show the notices
+		foreach ( $notices as $notice ) {
+			if ( ! empty( $notice['message'] ) ) {
+				$type = isset( $notice['type'] ) ? $notice['type'] : 'updated';
+				self::show_notice( $notice['message'], $type );
+			}
+		}
 
 		// Clear the notice
 		delete_user_meta( get_current_user_id(), self::KEY );

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -46,6 +46,11 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 				'label'   => __( 'Automatically update Apple News', 'apple-news' ),
 				'type'    => array( 'yes', 'no' ),
 			),
+			'api_async' => array(
+				'label'   			=> __( 'Asynchronously publish to Apple News', 'apple-news' ),
+				'type'    			=> array( 'yes', 'no' ),
+				'description' 	=> $this->get_async_description(),
+			),
 		);
 
 		// Add the groups
@@ -53,7 +58,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 			'apple_news' => array(
 				'label'       => __( 'Apple News API', 'apple-news' ),
 				'description' => __( 'All of these settings are required for publishing to Apple News', 'apple-news' ),
-				'settings'    => array( 'api_key', 'api_secret', 'api_channel', 'api_autosync', 'api_autosync_update' ),
+				'settings'    => array( 'api_key', 'api_secret', 'api_channel', 'api_autosync', 'api_autosync_update', 'api_async' ),
 			),
 		);
 
@@ -72,6 +77,25 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 			__( 'Enter your Apple News credentials below. See', 'apple-news' ),
 			__( 'the Apple News documentation', 'apple-news' ),
 			__( 'for detailed information', 'apple-news' )
+		);
+	}
+
+	/**
+	 * Generates the description for the async field since this varies by environment.
+	 *
+	 * @return string
+	 * @access private
+	 */
+	private function get_async_description() {
+		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
+			$system = __( 'the WordPress VIP jobs system', 'apple-news' );
+		} else {
+			$system = __( 'a single scheduled event', 'apple-news' );
+		}
+
+		return sprintf(
+			__( 'This will cause publishing to happen asynchronously using %s.', 'apple_news' ),
+			$system
 		);
 	}
 

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -376,6 +376,11 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'type' => array(),
 			'required' => array(),
 		),
+		'br' => array(),
+		'b' => array(),
+		'strong' => array(),
+		'i' => array(),
+		'em' => array(),
 	);
 
 	/**
@@ -552,6 +557,12 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field = '<input required type="text" name="%s" value="%s">';
 		}
 
+		// Add a description, if set.
+		$description = $this->get_description_for( $name );
+		if ( ! empty( $description ) ) {
+			$field .= apply_filters( 'apple_news_field_description_output_html', '<br/><i>' . $description . '</i>', $name );
+		}
+
 		return sprintf(
 			$field,
 			esc_attr( $name ),
@@ -568,6 +579,17 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 */
 	private function get_type_for( $name ) {
 		return empty( $this->settings[ $name ]['type'] ) ? 'string' : $this->settings[ $name ]['type'];
+	}
+
+	/**
+	 * Get the description for a field.
+	 *
+	 * @param string $name
+	 * @return string
+	 * @access private
+	 */
+	private function get_description_for( $name ) {
+		return empty( $this->settings[ $name ]['description'] ) ? '' : $this->settings[ $name ]['description'];
 	}
 
 	/**

--- a/apple-news.php
+++ b/apple-news.php
@@ -12,7 +12,7 @@
  * Plugin Name: Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     0.9.0
+ * Version:     1.0.0
  * Author:      Beezwax, Alley Interactive
  * Author URI:  http://beezwax.net, http://alleyinteractive.com
  * Text Domain: apple-news

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -20,6 +20,7 @@ class Settings {
 		'api_channel'     => '',
 		'api_autosync'    => 'yes',
 		'api_autosync_update'    => 'yes',
+		'api_async'    => 'no',
 
 		'post_types'      => array( 'post' ),
 		'show_metabox'    => 'no',

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -30,7 +30,7 @@ class Apple_News {
 	 * @var string
 	 * @access protected
 	 */
-	protected $version = '0.9.2';
+	protected $version = '1.0.0';
 
 	/**
 	 * Extracts the filename for bundling an asset.


### PR DESCRIPTION
This update adds a major feature to Apple News, asynchronous publishing. The intent is that push actions can be offloaded to a single scheduled event so the editor is not forced to wait for a massive push request to finish.

On WordPress VIP, this will automatically use the Jobs system which has a very high max execution time and therefore will avoid timeouts for articles with lots of images that often take longer than 30 seconds to publish to Apple News.

This also adds a minor feature to allow for descriptions for individual settings, required to explain this feature. It also confidently brands this as a 1.0.0 release as this is the last major lacking component.