### PR TITLE
Add filter before generate content

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -49,6 +49,9 @@ class Export extends Action {
 	 * @access public
 	 */
 	public function fetch_exporter() {
+
+		do_action( 'apple_news_before_generate_article', $this->id );
+
 		// Fetch WP_Post object, and all required post information to fill up the
 		// Exporter_Content instance.
 		$post       = get_post( $this->id );

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -50,7 +50,7 @@ class Export extends Action {
 	 */
 	public function fetch_exporter() {
 
-		do_action( 'apple_news_before_generate_article', $this->id );
+		do_action( 'apple_news_do_fetch_exporter', $this->id );
 
 		// Fetch WP_Post object, and all required post information to fill up the
 		// Exporter_Content instance.

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -200,6 +200,9 @@ class Push extends API_Action {
 	 * @since 0.6.0
 	 */
 	private function generate_article() {
+
+		do_action( 'apple_news_before_generate_article', $this->id );
+
 		$export_action = new Export( $this->settings, $this->id );
 		$this->exporter = $export_action->fetch_exporter();
 		$this->exporter->generate();

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -201,8 +201,6 @@ class Push extends API_Action {
 	 */
 	private function generate_article() {
 
-		do_action( 'apple_news_before_generate_article', $this->id );
-
 		$export_action = new Export( $this->settings, $this->id );
 		$this->exporter = $export_action->fetch_exporter();
 		$this->exporter->generate();


### PR DESCRIPTION
One issue we've been running into is that we need to modify the content only within the context of an apple news post.

For example we wish to completely remove/modify some shortcodes that aren't relevant. If we have a way we can do stuff immediately before the content is generated, we can easily do this.

Currently we can are abusing some of the existing filters, but isn't very nice. This new action follows a similar pattern to the `apple_news_before_push` action.