### PR TITLE
Add filter for skipping push

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -110,6 +110,11 @@ class Push extends API_Action {
 			throw new \Apple_Actions\Action_Exception( __( 'Your API settings seem to be empty. Please fill in the API key, API secret and API channel fields in the plugin configuration page.', 'apple-news' ) );
 		}
 
+		/**
+		 * Should the post be skipped and not pushed to apple news.
+		 *
+		 * Default is false, but filterable.
+		 */
 		if ( apply_filters( 'apple_news_skip_push', false, $this->id ) ) {
 			return;
 		}

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -110,6 +110,10 @@ class Push extends API_Action {
 			throw new \Apple_Actions\Action_Exception( __( 'Your API settings seem to be empty. Please fill in the API key, API secret and API channel fields in the plugin configuration page.', 'apple-news' ) );
 		}
 
+		if ( apply_filters( 'apple_news_skip_push', false, $this->id ) ) {
+			return;
+		}
+
 		// Ignore if the post is already in sync
 		if ( $this->is_post_in_sync() ) {
 			return;


### PR DESCRIPTION
We need to prevent some posts from getting pushed to apple. These may be sponsored posts, or contain embeds that are not supported.

We've been making use of the `apple_news_is_post_in_sync` filter to do this - but its really not intended for this. 

We could simply add a filter in the `Push:push` method to allow a single post to be skipped.

I'm interested in hearing your thoughts - there may be a better way to tackle this.