### PR TITLE
Improve video

### DIFF
--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -69,13 +69,12 @@ class Embed_Web_Video extends Component {
 			}
 		}
 
-		if ( $src ) {
-			$this->json = array(
-				'role'        => 'embedwebvideo',
-				'aspectRatio' => floatval( $aspect_ratio ),
-				'URL'         => $src,
-			);
-		}
+		$this->json = array(
+			'role'        => 'embedwebvideo',
+			'aspectRatio' => floatval( $aspect_ratio ),
+			'URL'         => $src,
+		);
+
 	}
 
 }

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -62,8 +62,7 @@ class Embed_Web_Video extends Component {
 			$url = trim( $matches[1] );
 			// The URL is either a YouTube or Vimeo video.
 			if ( preg_match( self::YOUTUBE_MATCH, $url, $matches ) ) {
-				$id  = ! empty( $matches[1] ) ? $matches[1] : $matches[2];
-				$src = 'https://www.youtube.com/embed/';
+				$src = 'https://www.youtube.com/embed/' . ( $matches[1] ?: $matches[2] );
 			} else {
 				preg_match( self::VIMEO_MATCH, $url, $matches );
 				$src = 'https://player.vimeo.com/video/' . $matches[2];

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -74,7 +74,6 @@ class Embed_Web_Video extends Component {
 			'aspectRatio' => floatval( $aspect_ratio ),
 			'URL'         => $src,
 		);
-
 	}
 
 }

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -12,7 +12,7 @@ class Embed_Web_Video extends Component {
 	/**
 	 * Regex patterns to match supported embed types.
 	 */
-	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/watch\?v=([^&]+)|youtu\.be/([^/]+)).*?$#';
+	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/watch\?v=(\w+)|youtu\.be/(\w+))?$#';
 	const VIMEO_MATCH   = '#^https?://(?:.+\.)?vimeo\.com/(:?.+/)?(\d+)$#';
 
 	/**

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -69,11 +69,13 @@ class Embed_Web_Video extends Component {
 			}
 		}
 
-		$this->json = array(
-			'role'        => 'embedwebvideo',
-			'aspectRatio' => floatval( $aspect_ratio ),
-			'URL'         => $src,
-		);
+		if ( $src ) {
+			$this->json = array(
+				'role'        => 'embedwebvideo',
+				'aspectRatio' => floatval( $aspect_ratio ),
+				'URL'         => $src,
+			);
+		}
 	}
 
 }

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -62,7 +62,8 @@ class Embed_Web_Video extends Component {
 			$url = trim( $matches[1] );
 			// The URL is either a YouTube or Vimeo video.
 			if ( preg_match( self::YOUTUBE_MATCH, $url, $matches ) ) {
-				$src = 'https://www.youtube.com/embed/' . $matches[1] ?: $matches[2];
+				$id  = ! empty( $matches[1] ) ? $matches[1] : $matches[2];
+				$src = 'https://www.youtube.com/embed/';
 			} else {
 				preg_match( self::VIMEO_MATCH, $url, $matches );
 				$src = 'https://player.vimeo.com/video/' . $matches[2];

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -67,14 +67,6 @@ class Embed_Web_Video extends Component {
 				preg_match( self::VIMEO_MATCH, $url, $matches );
 				$src = 'https://player.vimeo.com/video/' . $matches[2];
 			}
-		} else {
-			preg_match_all( '/(\w+)="([^"]*?)"/im', $text, $matches, PREG_SET_ORDER );
-			$attributes = array();
-			foreach ( $matches as $match ) {
-				$attributes[ $match[1] ] = $match[2];
-			}
-			$aspect_ratio = substr( ( $attributes['width'] / $attributes['height'] ), 0, 5 );
-			$src = $attributes['src'];
 		}
 
 		$this->json = array(


### PR DESCRIPTION
Remove iFrame video embed handler as its causing problems and is no longer supported. See https://github.com/alleyinteractive/apple-news/issues/45

Also fixes bit of an odd issue with embeds like: `youtu.be.com/$id` not finding the video ID. Basically need to wrap the tertiary operator for grabbing the ID in parentheses.

Consider the following code: 

```
$x = ''; 
$y = 'bar'; 

echo $x ?: $y; // echos 'bar';
echo 'foo-' . $x ?: $y; // echos 'foo-';
echo 'foo-' . ( $x ?: $y ); // echos 'foo-bar';
```