### PR TITLE
Remove comments from parsed markdown

### DIFF
--- a/includes/apple-exporter/class-markdown.php
+++ b/includes/apple-exporter/class-markdown.php
@@ -112,6 +112,8 @@ class Markdown {
 		case 'h5':
 		case 'h6':
 			return $this->parse_heading_node( $node );
+		case '#comment':
+			return '';
 		case '#text':
 		default:
 			return $this->parse_text_node( $node );


### PR DESCRIPTION
Currently comments are treated as text nodes, meaning the contents of the comment get displayed as if it were normal text (with the comment tags stripped). Instead, this removes comments altogether.