### PR TITLE
Pass $user_id to Admin_Apple_Notice::error method

### DIFF
--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -78,7 +78,7 @@ class Admin_Apple_Async extends Apple_News {
 				$post->post_title
 			), $user_id );
 		} catch ( Apple_Actions\Action_Exception $e ) {
-			Admin_Apple_Notice::error( $e->getMessage() );
+			Admin_Apple_Notice::error( $e->getMessage(), $user_id );
 		}
 
 		do_action( 'apple_news_after_async_push' );


### PR DESCRIPTION
The async_push is running either in WP_Cron or in Jobs system on the WordPress.com VIP platform. In both cases, the current_user_id is 0 and thus Notices about failures are not being properly saved either to user_meta or user_attributes