### PR TITLE
Always remove penging and async_in_progress metas

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -176,20 +176,27 @@ class Push extends API_Action {
 			// If it's marked as deleted, remove the mark. Ignore otherwise.
 			delete_post_meta( $this->id, 'apple_news_api_deleted' );
 
+		// Remove the pending designation if it exists
+		delete_post_meta( $this->id, 'apple_news_api_pending' );
+
+		// Remove the async in progress flag
+		delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
+
 			do_action( 'apple_news_after_push', $this->id, $result );
 		} catch ( \Apple_Push_API\Request\Request_Exception $e ) {
+			
+			// Remove the pending designation if it exists
+			delete_post_meta( $this->id, 'apple_news_api_pending' );
+
+			// Remove the async in progress flag
+			delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
+			
 			if ( preg_match( '#WRONG_REVISION#', $e->getMessage() ) ) {
 				throw new \Apple_Actions\Action_Exception( __( 'It seems like the article was updated by another call. If the problem persists, try removing and pushing again.', 'apple-news' ) );
 			} else {
 				throw new \Apple_Actions\Action_Exception( __( 'There has been an error with the API. Please make sure your API settings are correct and try again: ', 'apple-news' ) .  $e->getMessage() );
 			}
 		}
-
-		// Remove the pending designation if it exists
-		delete_post_meta( $this->id, 'apple_news_api_pending' );
-
-		// Remove the async in progress flag
-		delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
 
 		$this->clean_workspace();
 	}

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -176,11 +176,11 @@ class Push extends API_Action {
 			// If it's marked as deleted, remove the mark. Ignore otherwise.
 			delete_post_meta( $this->id, 'apple_news_api_deleted' );
 
-		// Remove the pending designation if it exists
-		delete_post_meta( $this->id, 'apple_news_api_pending' );
+			// Remove the pending designation if it exists
+			delete_post_meta( $this->id, 'apple_news_api_pending' );
 
-		// Remove the async in progress flag
-		delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
+			// Remove the async in progress flag
+			delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
 
 			do_action( 'apple_news_after_push', $this->id, $result );
 		} catch ( \Apple_Push_API\Request\Request_Exception $e ) {

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -176,12 +176,6 @@ class Push extends API_Action {
 			// If it's marked as deleted, remove the mark. Ignore otherwise.
 			delete_post_meta( $this->id, 'apple_news_api_deleted' );
 
-			// Remove the pending designation if it exists
-			delete_post_meta( $this->id, 'apple_news_api_pending' );
-
-			// Remove the async in progress flag
-			delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
-
 			do_action( 'apple_news_after_push', $this->id, $result );
 		} catch ( \Apple_Push_API\Request\Request_Exception $e ) {
 			if ( preg_match( '#WRONG_REVISION#', $e->getMessage() ) ) {
@@ -190,6 +184,12 @@ class Push extends API_Action {
 				throw new \Apple_Actions\Action_Exception( __( 'There has been an error with the API. Please make sure your API settings are correct and try again: ', 'apple-news' ) .  $e->getMessage() );
 			}
 		}
+
+		// Remove the pending designation if it exists
+		delete_post_meta( $this->id, 'apple_news_api_pending' );
+
+		// Remove the async in progress flag
+		delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
 
 		$this->clean_workspace();
 	}


### PR DESCRIPTION
Pending and in progress post metas are removed only in case the post is successfully published. That's preventing users from re-publishing their posts in case something goes wrong.

I'm not moving the metas to clean_workspace method as that one is also called early within the try block.