### PR TITLE
Added multiple checks for publish status throughout built-in publishi…

### DIFF
--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -68,11 +68,20 @@ class Admin_Apple_Async extends Apple_News {
 
 		update_post_meta( $post_id, 'apple_news_api_async_in_progress', time() );
 
+		// Ensure that the post is still published
+		$post = get_post( $post_id );
+		if ( 'publish' != $post->post_status ) {
+			Admin_Apple_Notice::error( sprintf(
+				__( 'Article %s is no longer published and cannot be pushed to Apple News.', 'apple-news' ),
+				$post->post_title
+			), $user_id );
+			return;
+		}
+
 		$action = new Apple_Actions\Index\Push( $this->settings, $post_id );
 		try {
 			$action->perform( true );
 
-			$post = get_post( $post_id );
 			Admin_Apple_Notice::success( sprintf(
 				__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
 				$post->post_title

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -96,7 +96,27 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 		// Sanitize input data
 		$id = absint( $_GET['id'] );
 
-		// TODO: Move push action to shared
+		// Ensure the post exists and that it's published
+		$post = get_post( $id );
+		if ( empty( $post ) ) {
+			echo json_encode( array(
+				'success' => false,
+				'error'   => __( 'This post no longer exists.', 'apple-news' ),
+			) );
+			wp_die();
+		}
+
+		if ( 'publish' != $post->post_status ) {
+			echo json_encode( array(
+				'success' => false,
+				'error'   => sprintf(
+					__( 'Article %s is not published and cannot be pushed to Apple News.', 'apple-news' ),
+					$id
+				),
+			) );
+			wp_die();
+		}
+
 		$action = new Apple_Actions\Index\Push( $this->settings, $id );
 		try {
 			$errors = $action->perform();

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -273,6 +273,16 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @access private
 	 */
 	private function push_action( $id ) {
+		// Ensure the post is published
+		if ( 'publish' != get_post_status( $id ) ) {
+			$this->notice_error( sprintf(
+				__( 'Article %s is not published and cannot be pushed to Apple News.', 'apple-news' ),
+				$id
+			) );
+			return;
+		}
+
+		// Push the post
 		$action = new Apple_Actions\Index\Push( $this->settings, $id );
 		try {
 			$action->perform();

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -52,7 +52,9 @@ class Admin_Apple_Post_Sync {
 	 * @access public
 	 */
 	public function do_publish( $id, $post ) {
-		if ( 'publish' != $post->post_status || ! current_user_can( apply_filters( 'apple_news_publish_capability', 'manage_options' ) ) ) {
+		if ( 'publish' != $post->post_status
+			|| ! in_array( $post->post_type, $this->settings->get( 'post_types' ) )
+			|| ! current_user_can( apply_filters( 'apple_news_publish_capability', 'manage_options' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
…ng scenarios. Still allowing non-published posts to be pushed at the API level to not prevent custom scenarios.