### PR TITLE
When pushing, clean workspace if an exception is thrown.

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -190,7 +190,9 @@ class Push extends API_Action {
 
 			// Remove the async in progress flag
 			delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
-			
+
+			$this->clean_workspace();
+
 			if ( preg_match( '#WRONG_REVISION#', $e->getMessage() ) ) {
 				throw new \Apple_Actions\Action_Exception( __( 'It seems like the article was updated by another call. If the problem persists, try removing and pushing again.', 'apple-news' ) );
 			} else {

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -184,7 +184,7 @@ class Push extends API_Action {
 
 			do_action( 'apple_news_after_push', $this->id, $result );
 		} catch ( \Apple_Push_API\Request\Request_Exception $e ) {
-			
+
 			// Remove the pending designation if it exists
 			delete_post_meta( $this->id, 'apple_news_api_pending' );
 


### PR DESCRIPTION
We have some custom code hooked into the clean_workspace actions that triggers correctly during pushing to Apple, but if an exception is thrown, it's not called.

PR adds clean_workspace into the exception catch block.