### PR TITLE
Cleanup the workspace after the export action is executed

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -155,7 +155,12 @@ class Exporter {
 		$this->generate();
 
 		// Some use cases for this function expect it to return the JSON.
-		return $this->get_json();
+		$json = $this->get_json();
+
+		// Clean after the export action.
+		$this->clean_workspace();
+
+		return $json;
 	}
 
 	/**


### PR DESCRIPTION
We have some custom code hooked into the `clean_workspace()` function's actions. The `clean_workspace()` is called before and after the `push` action correctly, but for `export` action it's only called before the action. To be consistent, we need to cleanup after the `export` action too.

PR adds `clean_workspace()` after the `export` action is performed.