### PR TITLE
Add canonical URL to the article metadata

### DIFF
--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -28,6 +28,9 @@ class Metadata extends Builder {
 			$meta['thumbnailURL'] = $thumb_url;
 		}
 
+		// Add canonical URL.
+		$meta['canonicalURL'] = get_permalink( $this->content_id() );
+
 		return apply_filters( 'apple_news_metadata', $meta, $this->content_id() );
 	}
 


### PR DESCRIPTION
As recommended by Apple News this [improves share-ability](https://developer.apple.com/library/ios/documentation/General/Conceptual/Apple_News_Format_Ref/Metadata.html#//apple_ref/doc/uid/TP40015408-CH3-SW1). An article is displayed on other devices that don't support Apple News **if** canonical URL is specified.