### PR TITLE
Fix matching of Instagram URL, so component is generated correctly

### DIFF
--- a/includes/apple-exporter/components/class-instagram.php
+++ b/includes/apple-exporter/components/class-instagram.php
@@ -34,14 +34,17 @@ class Instagram extends Component {
 	 */
 	protected function build( $text ) {
 		// Find instagram URL in HTML string
-		if ( ! preg_match( '#https?://instagr(\.am|am\.com)/p/([^/]+)/#', $text, $matches ) ) {
+		// Include optional `www.` - the embed processing includes `www.` in the resulting blockquote.
+		if ( ! preg_match( '#https?://(www\.)?instagr(\.am|am\.com)/p/([^/]+)/#', $text, $matches ) ) {
 			return null;
 		}
 
 		$url = $matches[0];
+
 		$this->json = array(
 			'role' => 'instagram',
-			'URL'  => $url,
+			// Remove `www.` from URL as AN parser doesn't allow for it.
+			'URL'  => str_replace( 'www.', '', $url ),
 		);
 	}
 


### PR DESCRIPTION
1. After the Instagram URL has been processed by embed into the blockquote, the URL seems to have `www` even if original URL didn't. Allow for optional `www.` in the URL as it's valid - so we actually match it.

2. However, according to [AN docs](https://developer.apple.com/library/ios/documentation/General/Conceptual/Apple_News_Format_Ref/Instagram.html#//apple_ref/doc/uid/TP40015408-CH22-SW1), they don't allow `www` in their parser, so remove `www.` in the AN json markup.