### PR TITLE
Some YouTube urls not matched correctly

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -77,7 +77,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Do the publish
 		$post_sync = new Admin_Apple_Post_Sync( $this->settings );
-		$post_sync->do_publish( $post_id, $post );
+		$post_sync->do_publish( $post_id, $post, 'manual' );
 	}
 
 	/**

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -49,7 +49,7 @@ class Admin_Apple_Post_Sync {
 	 * @param WP_Post $post
 	 * @access public
 	 */
-	public function do_publish( $id, $post ) {
+	public function do_publish( $id, $post, $type = 'automatic' ) {
 		if ( 'publish' != $post->post_status
 			|| ! in_array( $post->post_type, $this->settings->get( 'post_types' ) )
 			|| ! current_user_can( apply_filters( 'apple_news_publish_capability', 'manage_options' ) ) ) {
@@ -64,8 +64,8 @@ class Admin_Apple_Post_Sync {
 
 		// Proceed based on the current settings for auto publish and update.
 		$updated = get_post_meta( $id, 'apple_news_api_id', true );
-		if ( $updated && 'yes' != $this->settings->get( 'api_autosync_update' )
-			|| ! $updated && 'yes' != $this->settings->get( 'api_autosync' ) ) {
+		if ( 'automatic' == $type && $updated && 'yes' != $this->settings->get( 'api_autosync_update' )
+			|| 'automatic' == $type && ! $updated && 'yes' != $this->settings->get( 'api_autosync' ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -12,7 +12,7 @@ class Embed_Web_Video extends Component {
 	/**
 	 * Regex patterns to match supported embed types.
 	 */
-	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/watch\?v=(\w+)|youtu\.be/(\w+))?$#';
+	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/watch\?v=([\w\-]+)|youtu\.be/([\w\-]+))[^ ]+$#';
 	const VIMEO_MATCH   = '#^https?://(?:.+\.)?vimeo\.com/(:?.+/)?(\d+)$#';
 
 	/**


### PR DESCRIPTION
A dash is a valid character in a YouTube identifier - this wasn't being matched by the \w character.

The plugin also wasn't matching YouTube URLs which had other query parameters which are sometimes present - eg:

https://www.youtube.com/watch?v=xxxxxxx&feature=youtu.be

This could possibly be fixed by removing the `$` from the regex, but have used `[^ ]` so it allows any non-space character, just to prevent a match in the rare cases there was a space followed by a paragraph of text.