### PR TITLE
Matching dashes and extra query parameters in YouTube URLs

### DIFF
--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -12,7 +12,7 @@ class Embed_Web_Video extends Component {
 	/**
 	 * Regex patterns to match supported embed types.
 	 */
-	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/watch\?v=(\w+)|youtu\.be/(\w+))?$#';
+	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/watch\?v=([\w\-]+)|youtu\.be/([\w\-]+))[^ ]+$#';
 	const VIMEO_MATCH   = '#^https?://(?:.+\.)?vimeo\.com/(:?.+/)?(\d+)$#';
 
 	/**


### PR DESCRIPTION
A dash is a valid character in a YouTube identifier - this wasn't being matched by the \w character.

The plugin also wasn't matching YouTube URLs which had other query parameters which are sometimes present - eg:

https://www.youtube.com/watch?v=xxxxxxx&feature=youtu.be

This could possibly be fixed by removing the $ from the regex, but have used [^ ] so it allows any non-space character, just to prevent a match in the rare cases there was a space followed by a paragraph of text.