### PR TITLE
Ignore auto sync/update conditions if metabox button used to publish

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -77,7 +77,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Do the publish
 		$post_sync = new Admin_Apple_Post_Sync( $this->settings );
-		$post_sync->do_publish( $post_id, $post );
+		$post_sync->do_publish( $post_id, $post, 'manual' );
 	}
 
 	/**

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -49,7 +49,7 @@ class Admin_Apple_Post_Sync {
 	 * @param WP_Post $post
 	 * @access public
 	 */
-	public function do_publish( $id, $post ) {
+	public function do_publish( $id, $post, $type = 'automatic' ) {
 		if ( 'publish' != $post->post_status
 			|| ! in_array( $post->post_type, $this->settings->get( 'post_types' ) )
 			|| ! current_user_can( apply_filters( 'apple_news_publish_capability', 'manage_options' ) ) ) {
@@ -64,8 +64,8 @@ class Admin_Apple_Post_Sync {
 
 		// Proceed based on the current settings for auto publish and update.
 		$updated = get_post_meta( $id, 'apple_news_api_id', true );
-		if ( $updated && 'yes' != $this->settings->get( 'api_autosync_update' )
-			|| ! $updated && 'yes' != $this->settings->get( 'api_autosync' ) ) {
+		if ( 'automatic' == $type && $updated && 'yes' != $this->settings->get( 'api_autosync_update' )
+			|| 'automatic' == $type && ! $updated && 'yes' != $this->settings->get( 'api_autosync' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The manual publish button from the meta box does not work, since it hooks into the same `do_publish` function as the auto sync / auto update code, which returns early if the corresponding checkbox is not checked. This passes an extra parameter to the function so it knows when it should return based on the checkboxes and when it was user initiated.