### PR TITLE
Add filter to API request meta

### DIFF
--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -220,6 +220,9 @@ class Request {
 		$bundles = array_unique( $bundles );
 		$content = '';
 
+		// Add custom meta for request.
+		$meta = apply_filters( 'apple_news_api_post_meta', $meta );
+
 		if ( $meta ) {
 			$content .= $this->mime_builder->add_metadata( $meta );
 		}


### PR DESCRIPTION
You can specify a variety of API request meta before pushing to Apple News - [docs example](https://developer.apple.com/library/ios/documentation/General/Conceptual/News_API_Ref/CreateArticle.html#//apple_ref/doc/uid/TP40015409-CH14-SW11).

You can specify, for example, links -> sections, so that a post is published in the channel by default and also in the specified sections. Currently, there is no way to add custom meta to request.

Feel free to rename the filter name if required. 