### PR TITLE
Ensure get_plugin_data function exists before using it

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -76,6 +76,9 @@ add_action( 'plugins_loaded', 'apple_news_load_textdomain' );
  * @since 1.0.4
  */
 function apple_news_get_plugin_data() {
+	if ( ! function_exists( 'get_plugin_data' ) ) {
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+	}
 	return get_plugin_data( plugin_dir_path( __FILE__ ) . '/apple-news.php' );
 }
 


### PR DESCRIPTION
If the plugin is loaded due a cron process - for example, when a scheduled post is published, or the async method is used - everything dies with a php error because the get_plugin_data function does not exist.