### PR TITLE
adding check for component with index variable

### DIFF
--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -232,6 +232,11 @@ class Components extends Builder {
 		$len = count( $components );
 
 		for ( $i = 0; $i < $len; $i++ ) {
+
+			if ( ! isset( $components[ $i ] ) ) {
+				continue;
+			}
+
 			$component = $components[ $i ];
 
 			if ( $component->is_anchor_target() || Component::ANCHOR_NONE == $component->get_anchor_position() ) {


### PR DESCRIPTION
currently an export or publish action for Apple News will fail if there is a missing component in the `anchor_components` functions. this adds a check to ensure it is there before proceeding.