### PR TITLE
fix excerpt generation when a manual excerpt is not present

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -57,7 +57,7 @@ class Export extends Action {
 		$post       = get_post( $this->id );
 
 		// Build the excerpt if required
-		$excerpt = ( empty( $post->post_excerpt ) ) ? wp_trim_words( strip_shortcodes( $post->post_content, 55 ) ) : $post->post_excerpt;
+		$excerpt = ( empty( $post->post_excerpt ) ) ? wp_trim_words( strip_shortcodes( $post->post_content ), 55 ) : $post->post_excerpt;
 
 		// Get the post thumbnail
 		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) ) ?: null;

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -57,7 +57,7 @@ class Export extends Action {
 		$post       = get_post( $this->id );
 
 		// Build the excerpt if required
-		$excerpt = ( empty( $post->post_excerpt ) ) ? wp_trim_excerpt( $post->post_content ) : $post->post_excerpt;
+		$excerpt = ( empty( $post->post_excerpt ) ) ? wp_trim_words( strip_shortcodes( $post->post_content, 55 ) ) : $post->post_excerpt;
 
 		// Get the post thumbnail
 		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) ) ?: null;

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -26,6 +26,15 @@ class Metadata_Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'This is an intro.', $result[ 'excerpt' ] );
 	}
 
+	public function testEmptyIntro() {
+		$content = new Exporter_Content( 1, 'My Title', '<p>Hello, World!</p>', '' );
+		$builder = new Metadata( $content, $this->settings );
+		$result  = $builder->to_array();
+
+		$this->assertEquals( 5, count( $result ) );
+		$this->assertEquals( 'Hello, World!', $result[ 'excerpt' ] );
+	}
+
 	public function testCover() {
 		$content = new Exporter_Content( 1, 'My Title', '<p>Hello, World!</p>', null, '/etc/somefile.jpg' );
 		$builder = new Metadata( $content, $this->settings );


### PR DESCRIPTION
For posts without a manual excerpt set, 'wp_trim_excerpt` was being called with the full post content as its parameter. That function only generates an excerpt when the supplied text is empty. (see [codex](https://codex.wordpress.org/Function_Reference/wp_trim_excerpt)) The result is that the excerpt metadata field was actually the full post, including any shortcode text as well, which is what I [reported previously](https://github.com/alleyinteractive/apple-news/issues/112).

This is a simple fix that generates a 55 word excerpt after first stripping shortcodes when a manual excerpt is not present.

I suppose you could solve this with a fancier solution by using `setup_postdata()` and then calling `get_the_excerpt()`, if it is important to be able to have more filter controls on generated excerpts for Apple News.

This fixes #112