### PR TITLE
Minor Bug Fix Save Button Settings Page

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -151,9 +151,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'type'    => 'integer',
 				'description'	=> __( 'The margin to use above and below inserted ads.', 'apple-news' ),
 			),
-			'meta_component_order' => array(
-				'callback'	=> array( get_class( $this ), 'render_meta_component_order' ),
-			),
+
 		);
 
 		// Add the groups


### PR DESCRIPTION
The line of code removed here is a temp fix for the bug that is present in the admin settings page that caused the save changes button not to display. Without the button displaying the plugin became unusable when settings were required to be changed.
There might be a better fix for this but as mentioned it is a temp fix that i have tested and can confirm fixes the bug.