### PR TITLE
Add installer compatibility to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,12 @@
 {
+    "name"       : "alleyinteractive/apple-news",
+    "description": "Apple News delivery for WordPress.",
+    "homepage"   : "https://github.com/alleyinteractive/apple-news",
+    "type"       : "wordpress-plugin",
+    "license"    : "GPL-3.0+",
+    "require"    : {
+        "composer/installers": "~1.0"
+    }
     "require-dev": {
         "phpspec/prophecy": "~1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name"       : "alleyinteractive/apple-news",
-    "description": "Apple News delivery for WordPress.",
+    "description": "Enable your WordPress blog content to be published to your Apple News channel.",
     "homepage"   : "https://github.com/alleyinteractive/apple-news",
     "type"       : "wordpress-plugin",
     "license"    : "GPL-3.0+",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license"    : "GPL-3.0+",
     "require"    : {
         "composer/installers": "~1.0"
-    }
+    },
     "require-dev": {
         "phpspec/prophecy": "~1.0"
     }


### PR DESCRIPTION
Allows people to utilize `composer` to add, install, and update the plugin from the source repo.