### PR TITLE
Meta box and API updates

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -205,9 +205,9 @@ class Push extends API_Action {
 			}
 
 			// Get the isPreview setting
-			$is_preview = get_post_meta( $this->id, 'apple_news_is_preview', true );
-			if ( isset( $is_preview ) ) {
-				$meta['data']['isPreview'] = (bool) $is_preview;
+			$is_preview = (bool) get_post_meta( $this->id, 'apple_news_is_preview', true );
+			if ( true === $is_preview ) {
+				$meta['data']['isPreview'] = $is_preview;
 			}
 
 			if ( $remote_id ) {

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -139,11 +139,6 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access public
 	 */
 	public function add_meta_boxes( $post ) {
-		// Only add if this post is published
-		if ( 'auto-draft' == $post->post_status ) {
-			return;
-		}
-
 		// Add the publish meta box
 		add_meta_box(
 			'apple_news_publish',
@@ -206,6 +201,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		<?php
 		if ( 'yes' != $this->settings->get( 'api_autosync' )
 			&& current_user_can( apply_filters( 'apple_news_publish_capability', 'manage_options' ) )
+			&& 'publish' === $post->post_status
 			&& empty( $api_id )
 			&& empty( $deleted )
 			&& empty( $pending ) ):
@@ -313,7 +309,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access public
 	 */
 	public function register_assets( $hook ) {
-		if ( 'post.php' != $hook ) {
+		if ( 'post.php' !== $hook && 'post-new.php' !== $hook ) {
 			return;
 		}
 

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -57,7 +57,6 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		$this->groups = array(
 			'apple_news' => array(
 				'label'       => __( 'Apple News API', 'apple-news' ),
-				'description' => __( 'All of these settings are required for publishing to Apple News', 'apple-news' ),
 				'settings'    => array( 'api_channel', 'api_key', 'api_secret', 'api_autosync', 'api_autosync_update', 'api_async' ),
 			),
 		);

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -23,7 +23,7 @@ class Settings {
 		'api_async'    						=> 'no',
 
 		'post_types'      				=> array( 'post' ),
-		'show_metabox'    				=> 'no',
+		'show_metabox'    				=> 'yes',
 
 		'layout_margin'   				=> 100,
 		'layout_gutter'   				=> 20,

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -145,7 +145,9 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 			Argument::Any(),
 			Argument::Any(),
 			array(),
-			array()
+			array(
+				'data' => array(),
+			)
 		)
 			->willReturn( $response )
 			->shouldBeCalled();

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -85,7 +85,6 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 							'http://news-api.apple.com/sections/123',
 						),
 					),
-					'isPreview' => false
 				)
 			)
 		)
@@ -146,11 +145,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 			Argument::Any(),
 			Argument::Any(),
 			array(),
-			array(
-				'data' => array(
-					'isPreview' => false
-				)
-			)
+			array()
 		)
 			->willReturn( $response )
 			->shouldBeCalled();


### PR DESCRIPTION
- Always showing the Apple News meta box so settings can be added prior to publish
- Showing the Apple News meta box by default
- Never passively sending `isPreview=false` to the API

Fixes #210 