### PR TITLE
New component to handle `<pre>` tags

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -226,7 +226,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 			),
 			'pre' => array(
 				'label'       => __( 'Pre', 'apple-news' ),
-				'description' => 'Text in &lt;pre> tags.',
+				'description' => 'Text in &lt;pre&gt; tags.',
 				'settings'    => array( 'pre_font', 'pre_size', 'pre_color', 'pre_line_height' ),
 			),
 			'gallery' => array(

--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -149,6 +149,22 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'label'   => __( 'Pull quote transformation', 'apple-news' ),
 				'type'    => array( 'none', 'uppercase' ),
 			),
+			'pre_font' => array(
+				'label'   => '',
+				'type'    => 'font',
+			),
+			'pre_size' => array(
+				'label'   => __( 'Pre font size', 'apple-news' ),
+				'type'    => 'integer',
+			),
+			'pre_color' => array(
+				'label'   => __( 'Pre color', 'apple-news' ),
+				'type'    => 'color',
+			),
+			'pre_line_height' => array(
+				'label'   => __( 'Pre line height', 'apple-news' ),
+				'type'    => 'integer',
+			),
 			'gallery_type' => array(
 				'label'   => __( 'Gallery type', 'apple-news' ),
 				'type'    => array( 'gallery', 'mosaic' ),
@@ -207,6 +223,11 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 					__( 'Pull quote', 'apple-news' )
 				),
 				'settings'    => array( 'pullquote_font', 'pullquote_size', 'pullquote_color', 'pullquote_border_color', 'pullquote_border_style', 'pullquote_border_width', 'pullquote_transform' ),
+			),
+			'pre' => array(
+				'label'       => __( 'Pre', 'apple-news' ),
+				'description' => 'Text in &lt;pre> tags.',
+				'settings'    => array( 'pre_font', 'pre_size', 'pre_color', 'pre_line_height' ),
 			),
 			'gallery' => array(
 				'label'       => __( 'Gallery', 'apple-news' ),

--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -80,6 +80,7 @@ class Component_Factory {
 		self::register_component( 'audio'        ,   '\\Apple_Exporter\\Components\\Audio'           );
 		self::register_component( 'heading'      ,   '\\Apple_Exporter\\Components\\Heading'         );
 		self::register_component( 'blockquote'   ,   '\\Apple_Exporter\\Components\\Quote'           );
+		self::register_component( 'pre'          ,   '\\Apple_Exporter\\Components\\Pre'             );
 		self::register_component( 'p'            ,   '\\Apple_Exporter\\Components\\Body'            );
 		self::register_component( 'hr'           ,   '\\Apple_Exporter\\Components\\Divider'         );
 		// Non HTML-based components

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -64,6 +64,11 @@ class Settings {
 		'pullquote_transform'			=> 'uppercase',
 		'pullquote_line_height' 	=> 48,
 
+		'pre_font'  							=> 'Menlo-Regular',
+		'pre_size'  							=> 18,
+		'pre_color' 							=> '#333',
+		'pre_line_height' 				=> 24,
+
 		'component_alerts' 				=> 'none',
 
 		'use_remote_images' 			=> 'no',

--- a/includes/apple-exporter/components/class-pre.php
+++ b/includes/apple-exporter/components/class-pre.php
@@ -4,7 +4,7 @@ namespace Apple_Exporter\Components;
 /**
  * An HTML's blockquote representation.
  *
- * @since 0.2.0
+ * @since 1.1.8
  */
 class Pre extends Component {
 

--- a/includes/apple-exporter/components/class-pre.php
+++ b/includes/apple-exporter/components/class-pre.php
@@ -38,7 +38,7 @@ class Pre extends Component {
       'role' => 'container',
       'components' => array( array(
         'role'   => 'body',
-        'text'   => $this->markdown->parse( $text ),
+        'text'   => $text,
         'format' => 'markdown',
         'layout' => 'pre-layout',
         'textStyle' => 'default-pre',

--- a/includes/apple-exporter/components/class-pre.php
+++ b/includes/apple-exporter/components/class-pre.php
@@ -1,0 +1,82 @@
+<?php
+namespace Apple_Exporter\Components;
+
+/**
+ * An HTML's blockquote representation.
+ *
+ * @since 0.2.0
+ */
+class Pre extends Component {
+
+  /**
+   * Look for node matches for this component.
+   *
+   * @param DomNode $node
+   * @return mixed
+   * @static
+   * @access public
+   */
+  public static function node_matches( $node ) {
+    if ( 'pre' == $node->nodeName ) {
+      return $node;
+    }
+
+    return null;
+  }
+
+  /**
+   * Build the component.
+   *
+   * @param string $text
+   * @access protected
+   */
+  protected function build( $text ) {
+    preg_match( '#<pre.*?>(.*?)</pre>#si', $text, $matches );
+    $text = $matches[1];
+
+    $this->json = array(
+      'role' => 'container',
+      'components' => array( array(
+        'role'   => 'body',
+        'text'   => $this->markdown->parse( $text ),
+        'format' => 'markdown',
+        'layout' => 'pre-layout',
+        'textStyle' => 'default-pre',
+      ) ),
+    );
+
+    $this->set_style();
+    $this->set_layout();
+  }
+
+  /**
+   * Set the layout for the component.
+   *
+   * @access private
+   */
+  private function set_layout() {
+    $this->register_layout( 'pre-layout', array(
+      'margin' => array(
+        'top' => 12,
+        'bottom' => 12,
+      ),
+    ) );
+  }
+
+  /**
+   * Set the style for the component.
+   *
+   * @access private
+   */
+  private function set_style() {
+    $this->json['textStyle'] = 'default-pre';
+    $this->register_style( 'default-pre', array(
+      'fontName'      => $this->get_setting( 'pre_font' ),
+      'fontSize'      => intval( $this->get_setting( 'pre_size' ) ),
+      'textColor'     => $this->get_setting( 'pre_color' ),
+      'lineHeight'    => intval( $this->get_setting( 'pre_line_height' ) ),
+    ) );
+  }
+
+}
+

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -16,7 +16,7 @@ class Pre_Test extends Component_TestCase {
     $result = $result_wrapper['components'][0];
     $this->assertEquals( 'container', $result_wrapper['role'] );
     $this->assertEquals( 'body', $result['role'] );
-    $this->assertEquals( "var x = {\r\n \"foo\": 1;\r\n}", $result['text'] );
+    $this->assertEquals( "<code data-lang=\"javascript\">var x = {var x = {\r\n \"foo\": 1;\r\n}<code>", $result['text'] );
     $this->assertEquals( 'markdown', $result['format'] );
     $this->assertEquals( 'default-pre', $result['textStyle'] );
     $this->assertEquals( 'pre-layout', $result['layout'] );

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -16,7 +16,7 @@ class Pre_Test extends Component_TestCase {
     $result = $result_wrapper['components'][0];
     $this->assertEquals( 'container', $result_wrapper['role'] );
     $this->assertEquals( 'body', $result['role'] );
-    $this->assertEquals( "<code data-lang=\"javascript\">var x = {var x = {\r\n \"foo\": 1;\r\n}<code>", $result['text'] );
+    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n \"foo\": 1;\r\n}<code>", $result['text'] );
     $this->assertEquals( 'markdown', $result['format'] );
     $this->assertEquals( 'default-pre', $result['textStyle'] );
     $this->assertEquals( 'pre-layout', $result['layout'] );

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -7,7 +7,7 @@ use Apple_Exporter\Components\Pre as Pre;
 class Pre_Test extends Component_TestCase {
 
   public function testBuildingRemovesTags() {
-    $component = new Quote( '<pre><code data-lang="javascript">var x = {
+    $component = new Pre( '<pre><code data-lang="javascript">var x = {
   "foo": 1;
 }<code></pre>',
       null, $this->settings, $this->styles, $this->layouts );

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__ . '/class-component-testcase.php';
+
+use Apple_Exporter\Components\Pre as Pre;
+
+class Pre_Test extends Component_TestCase {
+
+  public function testBuildingRemovesTags() {
+    $component = new Quote( '<pre><code data-lang="javascript">var x = {
+  "foo": 1;
+}<code></pre>',
+      null, $this->settings, $this->styles, $this->layouts );
+
+    $result_wrapper = $component->to_array();
+    $result = $result_wrapper['components'][0];
+    $this->assertEquals( 'container', $result_wrapper['role'] );
+    $this->assertEquals( 'body', $result['role'] );
+    $this->assertEquals( "var x = {\r\n \"foo\": 1;\r\n}", $result['text'] );
+    $this->assertEquals( 'markdown', $result['format'] );
+    $this->assertEquals( 'default-pre', $result['textStyle'] );
+    $this->assertEquals( 'pre-layout', $result['layout'] );
+  }
+
+}
+

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -16,7 +16,7 @@ class Pre_Test extends Component_TestCase {
     $result = $result_wrapper['components'][0];
     $this->assertEquals( 'container', $result_wrapper['role'] );
     $this->assertEquals( 'body', $result['role'] );
-    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n\  "foo\": 1;\r\n}<code>", $result['text'] );
+    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n\"foo\": 1;\r\n}<code>", $result['text'] );
     $this->assertEquals( 'markdown', $result['format'] );
     $this->assertEquals( 'default-pre', $result['textStyle'] );
     $this->assertEquals( 'pre-layout', $result['layout'] );

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -9,14 +9,14 @@ class Pre_Test extends Component_TestCase {
   public function testBuildingRemovesTags() {
     $component = new Pre( '<pre><code data-lang="javascript">var x = {
   "foo": 1;
-}<code></pre>',
+}</code></pre>',
       null, $this->settings, $this->styles, $this->layouts );
 
     $result_wrapper = $component->to_array();
     $result = $result_wrapper['components'][0];
     $this->assertEquals( 'container', $result_wrapper['role'] );
     $this->assertEquals( 'body', $result['role'] );
-    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n\"foo\": 1;\r\n}<code>", $result['text'] );
+    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n\"  foo\": 1;\r\n}</code>", $result['text'] );
     $this->assertEquals( 'markdown', $result['format'] );
     $this->assertEquals( 'default-pre', $result['textStyle'] );
     $this->assertEquals( 'pre-layout', $result['layout'] );

--- a/tests/apple-exporter/components/test-class-pre.php
+++ b/tests/apple-exporter/components/test-class-pre.php
@@ -16,7 +16,7 @@ class Pre_Test extends Component_TestCase {
     $result = $result_wrapper['components'][0];
     $this->assertEquals( 'container', $result_wrapper['role'] );
     $this->assertEquals( 'body', $result['role'] );
-    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n \"foo\": 1;\r\n}<code>", $result['text'] );
+    $this->assertEquals( "<code data-lang=\"javascript\">var x = {\r\n\  "foo\": 1;\r\n}<code>", $result['text'] );
     $this->assertEquals( 'markdown', $result['format'] );
     $this->assertEquals( 'default-pre', $result['textStyle'] );
     $this->assertEquals( 'pre-layout', $result['layout'] );


### PR DESCRIPTION
This is specifically for `<pre>` blocks, as they were previously stripped out entirely of articles, making for awkward reading of a tech article that includes them.

I'm no pro at this, so I have no idea if this PR is up-to-snuff.

I did however test it in production and it WorksForMe.

![example](http://d.pr/i/13mzg/368SbK7U+)

Settings:

![settings](http://d.pr/i/KtoH/4ewdTfam+)

Example article of a pre tag making it all the way to production Apple News:

![article](http://d.pr/i/1cDsi/3fZK4eHr+)

Fixes #222 