### PR TITLE
Use WP built-in color picker

### DIFF
--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -152,10 +152,11 @@ class Admin_Apple_Settings extends Apple_News {
 		wp_enqueue_style( 'apple-news-settings-css', plugin_dir_url( __FILE__ ) .
 			'../assets/css/settings.css', array() );
 
+		wp_enqueue_script( 'iris' );
 		wp_enqueue_script( 'apple-news-select2-js', plugin_dir_url( __FILE__ ) .
 			'../vendor/select2/select2.full.min.js', array( 'jquery' ) );
 		wp_enqueue_script( 'apple-news-settings-js', plugin_dir_url( __FILE__ ) .
-			'../assets/js/settings.js', array( 'jquery', 'jquery-ui-draggable', 'jquery-ui-sortable', 'apple-news-select2-js' )
+			'../assets/js/settings.js', array( 'jquery', 'jquery-ui-draggable', 'jquery-ui-sortable', 'apple-news-select2-js', 'iris' )
 		);
 	}
 

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -542,7 +542,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		} else if ( 'float' == $type ) {
 			$field = '<input class="input-float" placeholder="' . esc_attr( $default_value ) . '" type="text" step="any" name="%s" value="%s" size="%s">';
 		} else if ( 'color' == $type ) {
-			$field = '<input type="color" name="%s" value="%s" %s>';
+			$field = '<input type="text" name="%s" value="%s" class="apple-news-color-picker" %s>';
 		} else if ( 'password' == $type ) {
 			$field = '<input type="password" name="%s" value="%s" size="%s" %s>';
 		} else {

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -41,6 +41,11 @@
 		$( '.apple-news-color-picker' ).iris({
 			palettes: true
 		});
+
+		$( '.apple-news-color-picker' ).on( 'click', function() {
+			$( '.apple-news-color-picker' ).iris( 'hide' );
+			$( this ).iris( 'show' );
+		});
 	}
 
 }( jQuery ) );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -39,7 +39,8 @@
 
 	function appleNewsColorPickerInit() {
 		$( '.apple-news-color-picker' ).iris({
-			palettes: true
+			palettes: true,
+			width: 320
 		});
 
 		$( '.apple-news-color-picker' ).on( 'click', function() {

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -3,6 +3,7 @@
 	$(document).ready(function () {
 		$( '.select2' ).select2();
 		appleNewsSettingsSortInit( '#meta-component-order-sort', 'meta_component_order' );
+		appleNewsColorPickerInit();
 	});
 
 	function appleNewsSettingsSortInit( selector, key ) {
@@ -34,6 +35,12 @@
 				$sortableElement.after( $hidden );
 			} );
 		}
+	}
+
+	function appleNewsColorPickerInit() {
+		$( '.apple-news-color-picker' ).iris({
+			palettes: true
+		});
 	}
 
 }( jQuery ) );

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -31,8 +31,8 @@ class Settings {
 		'body_font'        				=> 'AvenirNext-Regular',
 		'body_size'        				=> 18,
 		'body_color'       				=> '#4f4f4f',
-		'body_link_color'  				=> '#428BCA',
-		'body_background_color'   => '#FAFAFA',
+		'body_link_color'  				=> '#428bca',
+		'body_background_color'   => '#fafafa',
 		'body_orientation' 				=> 'left',
 		'body_line_height' 				=> 24,
 
@@ -57,8 +57,8 @@ class Settings {
 
 		'pullquote_font'  				=> 'AvenirNext-Bold',
 		'pullquote_size'  				=> 48,
-		'pullquote_color' 				=> '#53585F',
-		'pullquote_border_color' 	=> '#53585F',
+		'pullquote_color' 				=> '#53585f',
+		'pullquote_border_color' 	=> '#53585f',
 		'pullquote_border_style' 	=> 'solid',
 		'pullquote_border_width' 	=> '3',
 		'pullquote_transform'			=> 'uppercase',


### PR DESCRIPTION
This offers wider browser compatibility than using an HTML color field.

Closes #244 