### PR TITLE
Add JSON error handling

### DIFF
--- a/admin/apple-actions/class-action-exception.php
+++ b/admin/apple-actions/class-action-exception.php
@@ -1,0 +1,4 @@
+<?php
+namespace Apple_Actions;
+
+class Action_Exception extends \Exception {}

--- a/admin/apple-actions/class-action.php
+++ b/admin/apple-actions/class-action.php
@@ -27,5 +27,3 @@ abstract class Action {
 	}
 
 }
-
-class Action_Exception extends \Exception {}

--- a/admin/apple-actions/class-api-action.php
+++ b/admin/apple-actions/class-api-action.php
@@ -3,6 +3,7 @@
 namespace Apple_Actions;
 
 require_once plugin_dir_path( __FILE__ ) . 'class-action.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-action-exception.php';
 require_once plugin_dir_path( __FILE__ ) . '../../includes/apple-push-api/autoload.php';
 
 use Apple_Actions\Action as Action;

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -3,6 +3,7 @@
 namespace Apple_Actions\Index;
 
 require_once plugin_dir_path( __FILE__ ) . '../class-action.php';
+require_once plugin_dir_path( __FILE__ ) . '../class-action-exception.php';
 require_once plugin_dir_path( __FILE__ ) . '../../../includes/apple-exporter/autoload.php';
 
 use Apple_Actions\Action as Action;

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -136,42 +136,8 @@ class Push extends API_Action {
 		$this->clean_workspace();
 		list( $json, $bundles, $errors ) = $this->generate_article();
 
-		// If there were errors, decide how to proceed based on the component alert settings
-		if ( ! empty( $errors[0]['component_errors'] ) ) {
-			// Build an list of the components that caused errors
-			$component_names = implode( ', ', $errors[0]['component_errors'] );
-
-			// Decide if we need to handle this
-			$component_alerts = $this->get_setting( 'component_alerts' );
-
-			if ( 'warn' === $component_alerts ) {
-				$alert_message = sprintf(
-					__( 'The following components are unsupported by Apple News and were removed: %s', 'apple-news' ),
-					$component_names
-				);
-
-				if ( empty( $user_id ) ) {
-					$user_id = get_current_user_id();
-				}
-
-				\Admin_Apple_Notice::error( $alert_message, $user_id );
-			} elseif ( 'fail' === $component_alerts ) {
-				$alert_message = sprintf(
-					__( 'The following components are unsupported by Apple News and prevented publishing: %s', 'apple-news' ),
-					$component_names
-				);
-
-				// Remove the pending designation if it exists
-				delete_post_meta( $this->id, 'apple_news_api_pending' );
-
-				// Remove the async in progress flag
-				delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
-
-				$this->clean_workspace();
-
-				throw new \Apple_Actions\Action_Exception( $alert_message );
-			}
-		}
+		// Process errors
+		$this->process_errors( $errors );
 
 		// Validate the data before using since it's filterable.
 		// JSON should just be a string.
@@ -259,6 +225,88 @@ class Push extends API_Action {
 		}
 
 		$this->clean_workspace();
+	}
+
+	/**
+	 * Processes errors, halts publishing if needed.
+	 *
+	 * @param array $errors
+	 * @access private
+	 */
+	private function process_errors( $errors ) {
+		// Get the current alert settings
+		$component_alerts = $this->get_setting( 'component_alerts' );
+
+		// Initialize the alert message
+		$alert_message = '';
+
+		// Get the current user id
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
+
+		// Build the component alert error message, if required
+		if ( ! empty( $errors[0]['component_errors'] ) ) {
+			// Build an list of the components that caused errors
+			$component_names = implode( ', ', $errors[0]['component_errors'] );
+
+			if ( 'warn' === $component_alerts ) {
+				$alert_message .= sprintf(
+					__( 'The following components are unsupported by Apple News and were removed: %s', 'apple-news' ),
+					$component_names
+				);
+			} elseif ( 'fail' === $component_alerts ) {
+				$alert_message .= sprintf(
+					__( 'The following components are unsupported by Apple News and prevented publishing: %s', 'apple-news' ),
+					$component_names
+				);
+			}
+		}
+
+		// Check for JSON errors
+		if ( ! empty( $errors[0]['json_errors'] ) ) {
+			if ( ! empty( $alert_message ) ) {
+				$alert_message .= '<br />';
+			}
+
+			// Merge all errors into a single message
+			$json_errors = implode( ', ', $errors[0]['json_errors'] );
+
+			// Add these to the message
+			if ( 'warn' === $component_alerts ) {
+				$alert_message .= sprintf(
+					__( 'The following JSON errors were detected: %s', 'apple-news' ),
+					$json_errors
+				);
+			} elseif ( 'fail' === $component_alerts ) {
+				$alert_message .= sprintf(
+					__( 'The following JSON errors were detected and prevented publishing: %s', 'apple-news' ),
+					$json_errors
+				);
+			}
+		}
+
+		// See if we found any errors
+		if ( empty( $alert_message ) ) {
+			return;
+		}
+
+		// Proceed based on component alert settings
+		if ( 'warn' === $component_alerts ) {
+				\Admin_Apple_Notice::error( $alert_message, $user_id );
+		} elseif ( 'fail' === $component_alerts ) {
+			// Remove the pending designation if it exists
+			delete_post_meta( $this->id, 'apple_news_api_pending' );
+
+			// Remove the async in progress flag
+			delete_post_meta( $this->id, 'apple_news_api_async_in_progress' );
+
+			// Clean the workspace
+			$this->clean_workspace();
+
+			// Throw an exception
+			throw new \Apple_Actions\Action_Exception( $alert_message );
+		}
 	}
 
 	/**

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -1,4 +1,7 @@
 <?php
+
+use \Apple_News as Apple_News;
+
 /**
  * This class manages admin notices.
  *
@@ -135,6 +138,7 @@ class Admin_Apple_Notice {
 	 */
 	private static function show_notice( $message, $type ) {
 		// Format messages a little nicer
+		$message = str_replace( '|', '<br />', $message );
 		$message_array = explode( ':', $message );
 		if ( 2 === count( $message_array ) ) {
 			// If it's not 2, it's too unclear how to proceed.
@@ -149,6 +153,11 @@ class Admin_Apple_Notice {
 					$errors_formatted
 				);
 			}
+		}
+
+		// Add the support tagline to errors
+		if ( 'error' === $type ) {
+			$message .= Apple_News::get_support_info();
 		}
 		?>
 		<div class="notice <?php echo esc_attr( $type ) ?> is-dismissible">

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -46,6 +46,11 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'type'    => array( 'none', 'warn', 'fail' ),
 				'description' => __( 'If a post has a component that is unsupported by Apple News, choose "none" to generate no alert, "warn" to provide an admin warning notice, or "fail" to generate a notice and stop publishing.', 'apple-news' ),
 			),
+			'json_alerts' => array(
+				'label'   => __( 'JSON Alerts', 'apple-news' ),
+				'type'    => array( 'none', 'warn', 'fail' ),
+				'description' => __( 'If a post has invalid JSON that may cause display issues in Apple News, choose "none" to generate no alert, "warn" to provide an admin warning notice, or "fail" to generate a notice and stop publishing.', 'apple-news' ),
+			),
 			'use_remote_images' => array(
 				'label'   => __( 'Use Remote Images?', 'apple-news' ),
 				'type'    => array( 'yes', 'no' ),
@@ -61,7 +66,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			),
 			'alerts' => array(
 				'label'       => __( 'Alerts', 'apple-news' ),
-				'settings'    => array( 'component_alerts' ),
+				'settings'    => array( 'component_alerts', 'json_alerts' ),
 			),
 			'images' => array(
 				'label'       => __( 'Image Settings', 'apple-news' ),

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -197,11 +197,23 @@ class Exporter {
 		// For now, we'll assume that multiple unicode characters in sequence
 		// containing the Â (\u00C2) indicate a problem as that has been the
 		// most common indication of the issue.
-		//preg_match( '/(\\u[0-9a-fA-F]{4}){2,}/', $json, $matches );
+		preg_match_all( '/(\\\u[0-9a-fA-F]{4}){2,}/', $json, $matches );
+		if ( ! empty( $matches[0] ) ) {
+			// Get a unique list of character sequences
+			$character_sequences = array_unique( $matches[0] );
+			foreach ( $character_sequences as &$sequence ) {
+				// Convert back to a display format
+				$sequence = json_decode( '{ "value":"' . $sequence . '"}' );
+				$sequence = $sequence->value;
+			}
 
-		//$this->clean_workspace();
-	//	print_r( $matches );
-//		die();
+			$this->workspace->log_error( 'json_errors', sprintf(
+				__( 'Invalid unicode character sequences were found that could cause display issues on Apple News: %s', 'apple-news' ),
+				implode( ', ', $character_sequences )
+			) );
+		}
+
+		return $json;
 	}
 
 	/**

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -191,7 +191,17 @@ class Exporter {
 
 		$json = apply_filters( 'apple_news_generate_json', $json, $this->content_id() );
 
-		return json_encode( $json );
+		$json = json_encode( $json );
+
+		// Check the JSON for unicode errors.
+		// For now, we'll assume that multiple unicode characters in sequence
+		// containing the Â (\u00C2) indicate a problem as that has been the
+		// most common indication of the issue.
+		//preg_match( '/(\\u[0-9a-fA-F]{4}){2,}/', $json, $matches );
+
+		//$this->clean_workspace();
+	//	print_r( $matches );
+//		die();
 	}
 
 	/**

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -65,6 +65,7 @@ class Settings {
 		'pullquote_line_height' 	=> 48,
 
 		'component_alerts' 				=> 'none',
+		'json_alerts'							=> 'warn',
 
 		'use_remote_images' 			=> 'no',
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -33,6 +33,22 @@ class Apple_News {
 	public static $option_name = 'apple_news_settings';
 
 	/**
+	 * Link to support for the plugin on WordPress.org.
+	 *
+	 * @var string
+	 * @access public
+	 */
+	public static $wordpress_org_support_url = 'https://wordpress.org/support/plugin/publish-to-apple-news';
+
+	/**
+	 * Link to support for the plugin on github.
+	 *
+	 * @var string
+	 * @access public
+	 */
+	public static $github_support_url = 'https://github.com/alleyinteractive/apple-news/issues';
+
+	/**
 	 * Plugin version.
 	 *
 	 * @var string
@@ -85,5 +101,35 @@ class Apple_News {
 		array_map( 'delete_option', array_keys( $migrated_settings ) );
 
 		return $migrated_settings;
+	}
+
+	/**
+	 * Displays support information for the plugin.
+	 *
+	 * @var string $format
+	 * @var boolean $with_padding
+	 * @return string
+	 * @access public
+	 */
+	public static function get_support_info( $format = 'html', $with_padding = true ) {
+		$support_info = sprintf(
+			__( 'If you need assistance with this issue, please reach out for support on <a href="%s">WordPress.org</a> or <a href="%s">github</a>.', 'apple-news' ),
+			esc_attr( self::$wordpress_org_support_url ),
+			esc_attr( self::$github_support_url )
+		);
+
+		if ( 'text' === $format ) {
+			$support_info = strip_tags( $support_info );
+		}
+
+		if ( $with_padding ) {
+			if ( 'text' === $format ) {
+				$support_info = '\n\n' . $support_info;
+			} else {
+				$support_info = '<br /><br />' . $support_info;
+			}
+		}
+
+		return $support_info;
 	}
 }

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -114,8 +114,8 @@ class Apple_News {
 	public static function get_support_info( $format = 'html', $with_padding = true ) {
 		$support_info = sprintf(
 			__( 'If you need assistance with this issue, please reach out for support on <a href="%s">WordPress.org</a> or <a href="%s">github</a>.', 'apple-news' ),
-			esc_attr( self::$wordpress_org_support_url ),
-			esc_attr( self::$github_support_url )
+			esc_url( self::$wordpress_org_support_url ),
+			esc_url( self::$github_support_url )
 		);
 
 		if ( 'text' === $format ) {

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -52,9 +52,9 @@ class Apple_News {
 	 * Plugin version.
 	 *
 	 * @var string
-	 * @access protected
+	 * @access public
 	 */
-	protected $version = '1.1.9';
+	public static $version = '1.1.9';
 
 	/**
 	 * Extracts the filename for bundling an asset.
@@ -124,7 +124,7 @@ class Apple_News {
 
 		if ( $with_padding ) {
 			if ( 'text' === $format ) {
-				$support_info = '\n\n' . $support_info;
+				$support_info = "\n\n" . $support_info;
 			} else {
 				$support_info = '<br /><br />' . $support_info;
 			}

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -11,8 +11,6 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 
 	private $original_user_id;
 
-	private $component_message = 'The following components are unsupported by Apple News and were removed: iframe';
-
 	public function setup() {
 		parent::setup();
 
@@ -202,6 +200,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 
 	public function testComponentErrorsWarn() {
 		$this->settings->set( 'component_alerts', 'warn' );
+		$this->settings->set( 'json_alerts', 'none' );
 
 		$response = $this->dummy_response();
 		$api = $this->prophet->prophesize( '\Apple_Push_API\API' );
@@ -226,7 +225,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $notices );
 
 		$component_notice = end( $notices );
-		$this->assertEquals( $this->component_message, $component_notice['message'] );
+		$this->assertEquals( 'The following components are unsupported by Apple News and were removed: iframe', $component_notice['message'] );
 
 		// The post was still sent to Apple News
 		$this->assertEquals( $response->data->id, get_post_meta( $post_id, 'apple_news_api_id', true ) );
@@ -236,11 +235,9 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_deleted', true ) );
 	}
 
-	/**
-	 * @expectedException \Apple_Actions\Action_Exception
-	 */
 	public function testComponentErrorsFail() {
 		$this->settings->set( 'component_alerts', 'fail' );
+		$this->settings->set( 'json_alerts', 'none' );
 
 		$response = $this->dummy_response();
 		$api = $this->prophet->prophesize( '\Apple_Push_API\API' );
@@ -258,6 +255,47 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 
 		$action = new Push( $this->settings, $post_id );
 		$action->set_api( $api->reveal() );
+
+		try {
+			$action->perform();
+		} catch ( Action_Exception $e ) {
+
+			// An admin error notice was created
+			$notices = get_user_meta( $user_id, 'apple_news_notice', true );
+			$this->assertNotEmpty( $notices );
+
+			$component_notice = end( $notices );
+			$this->assertEquals( 'The following components are unsupported by Apple News and prevented publishing: iframe', $e->getMessage() );
+
+			// The post was not sent to Apple News
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_id', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_created_at', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_modified_at', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_share_url', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_deleted', true ) );
+		}
+	}
+
+	public function testJSONErrorsWarn() {
+		$this->settings->set( 'component_alerts', 'none' );
+		$this->settings->set( 'json_alerts', 'warn' );
+
+		$response = $this->dummy_response();
+		$api = $this->prophet->prophesize( '\Apple_Push_API\API' );
+		$api->post_article_to_channel( Argument::cetera() )
+			->willReturn( $response )
+			->shouldBeCalled();
+
+		// We need to create an iframe, so run as administrator
+		$user_id = $this->set_admin();
+
+		// Create post
+		$post_id = $this->factory->post->create( array(
+			'post_content' => 'ÂÂîî',
+		) );
+
+		$action = new Push( $this->settings, $post_id );
+		$action->set_api( $api->reveal() );
 		$action->perform();
 
 		// An admin error notice was created
@@ -265,19 +303,55 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $notices );
 
 		$component_notice = end( $notices );
-		$this->assertEquals( $this->component_message, $component_notice['message'] );
+		$this->assertEquals( 'The following JSON errors were detected: Invalid unicode character sequences were found that could cause display issues on Apple News: ÂÂîî', $component_notice['message'] );
 
-		// The post was not sent to Apple News
-		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_id', true ) );
-		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_created_at', true ) );
-		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_modified_at', true ) );
-		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_share_url', true ) );
+		// The post was still sent to Apple News
+		$this->assertEquals( $response->data->id, get_post_meta( $post_id, 'apple_news_api_id', true ) );
+		$this->assertEquals( $response->data->createdAt, get_post_meta( $post_id, 'apple_news_api_created_at', true ) );
+		$this->assertEquals( $response->data->modifiedAt, get_post_meta( $post_id, 'apple_news_api_modified_at', true ) );
+		$this->assertEquals( $response->data->shareUrl, get_post_meta( $post_id, 'apple_news_api_share_url', true ) );
 		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_deleted', true ) );
 	}
 
-	public function testJSONErrorsWarn() {}
+	public function testJSONErrorsFail() {
+		$this->settings->set( 'component_alerts', 'none' );
+		$this->settings->set( 'json_alerts', 'fail' );
 
-	public function testJSONErrorsFail() {}
+		$response = $this->dummy_response();
+		$api = $this->prophet->prophesize( '\Apple_Push_API\API' );
+		$api->post_article_to_channel( Argument::cetera() )
+			->willReturn( $response )
+			->shouldNotBeCalled();
+
+		// We need to create an iframe, so run as administrator
+		$user_id = $this->set_admin();
+
+		// Create post
+		$post_id = $this->factory->post->create( array(
+			'post_content' => 'ÂÂîî',
+		) );
+
+		$action = new Push( $this->settings, $post_id );
+		$action->set_api( $api->reveal() );
+
+		try {
+			$action->perform();
+		} catch ( Action_Exception $e ) {
+			// An admin error notice was created
+			$notices = get_user_meta( $user_id, 'apple_news_notice', true );
+			$this->assertNotEmpty( $notices );
+
+			$component_notice = end( $notices );
+			$this->assertEquals( 'The following JSON errors were detected and prevented publishing: Invalid unicode character sequences were found that could cause display issues on Apple News: ÂÂîî', $e->getMessage() );
+
+			// The post was not sent to Apple News
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_id', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_created_at', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_modified_at', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_share_url', true ) );
+			$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_deleted', true ) );
+		}
+	}
 
 }
 

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -275,5 +275,9 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 		$this->assertEquals( null, get_post_meta( $post_id, 'apple_news_api_deleted', true ) );
 	}
 
+	public function testJSONErrorsWarn() {}
+
+	public function testJSONErrorsFail() {}
+
 }
 

--- a/tests/admin/test-class-admin-apple-notice.php
+++ b/tests/admin/test-class-admin-apple-notice.php
@@ -1,18 +1,96 @@
 <?php
 
-use \Apple_Exporter\Settings as Settings;
+use \Admin_Apple_Notice as Admin_Apple_Notice;
+use \Apple_News as Apple_News;
 
 class Admin_Apple_Notice_Test extends WP_UnitTestCase {
 
 	public function setup() {
-		parent::setup();
-
-		$this->settings = new Settings();
+		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->user_id );
 	}
 
-	public function testInfo() {}
+	public function testInfo() {
+		Admin_Apple_Notice::info( 'This is an info message', $this->user_id );
 
-	public function testSuccess() {}
+		ob_start();
+		Admin_Apple_Notice::show();
+		$notice = ob_get_contents();
+		ob_end_clean();
 
-	public function testError() {}
+		$expected = preg_replace( '/\s+/', '', '<div class="notice updated is-dismissible"><p><strong>This is an info message</strong></p></div>' );
+		$notice = preg_replace( '/\s+/', '', $notice );
+
+		$this->assertEquals( $expected, $notice );
+	}
+
+	public function testSuccess() {
+		Admin_Apple_Notice::success( 'This is a success message', $this->user_id );
+
+		ob_start();
+		Admin_Apple_Notice::show();
+		$notice = ob_get_contents();
+		ob_end_clean();
+
+		$expected = preg_replace( '/\s+/', '', '<div class="notice updated is-dismissible"><p><strong>This is a success message</strong></p></div>' );
+		$notice = preg_replace( '/\s+/', '', $notice );
+
+		$this->assertEquals( $expected, $notice );
+	}
+
+	public function testError() {
+		Admin_Apple_Notice::error( 'This is an error message', $this->user_id );
+
+		ob_start();
+		Admin_Apple_Notice::show();
+		$notice = ob_get_contents();
+		ob_end_clean();
+
+		$expected = preg_replace( '/\s+/', '', '<div class="notice error is-dismissible"><p><strong>This is an error message' . Apple_News::get_support_info() . '</strong></p></div>' );
+		$notice = preg_replace( '/\s+/', '', $notice );
+
+		$this->assertEquals( $expected, $notice );
+	}
+
+	public function testFormattingSingle() {
+		Admin_Apple_Notice::info( 'One error occurred: error 1', $this->user_id );
+
+		ob_start();
+		Admin_Apple_Notice::show();
+		$notice = ob_get_contents();
+		ob_end_clean();
+
+		$expected = preg_replace( '/\s+/', '', '<div class="notice updated is-dismissible"><p><strong>One error occurred: error 1</strong></p></div>' );
+		$notice = preg_replace( '/\s+/', '', $notice );
+
+		$this->assertEquals( $expected, $notice );
+	}
+
+	public function testFormattingMultiple() {
+		Admin_Apple_Notice::info( 'A number of errors occurred: error 1, error 2, error 3', $this->user_id );
+
+		ob_start();
+		Admin_Apple_Notice::show();
+		$notice = ob_get_contents();
+		ob_end_clean();
+
+		$expected = preg_replace( '/\s+/', '', '<div class="notice updated is-dismissible"><p><strong>A number of errors occurred:<br />error 1<br />error 2<br />error 3</strong></p></div>' );
+		$notice = preg_replace( '/\s+/', '', $notice );
+
+		$this->assertEquals( $expected, $notice );
+	}
+
+	public function testLineBreaks() {
+		Admin_Apple_Notice::info( 'One message|Another message', $this->user_id );
+
+		ob_start();
+		Admin_Apple_Notice::show();
+		$notice = ob_get_contents();
+		ob_end_clean();
+
+		$expected = preg_replace( '/\s+/', '', '<div class="notice updated is-dismissible"><p><strong>One message<br />Another message</strong></p></div>' );
+		$notice = preg_replace( '/\s+/', '', $notice );
+
+		$this->assertEquals( $expected, $notice );
+	}
 }

--- a/tests/admin/test-class-admin-apple-notice.php
+++ b/tests/admin/test-class-admin-apple-notice.php
@@ -1,0 +1,18 @@
+<?php
+
+use \Apple_Exporter\Settings as Settings;
+
+class Admin_Apple_Notice_Test extends WP_UnitTestCase {
+
+	public function setup() {
+		parent::setup();
+
+		$this->settings = new Settings();
+	}
+
+	public function testInfo() {}
+
+	public function testSuccess() {}
+
+	public function testError() {}
+}

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -1,0 +1,20 @@
+<?php
+
+use \Apple_Exporter\Settings as Settings;
+
+class Apple_News_Test extends WP_UnitTestCase {
+
+	public function setup() {
+		parent::setup();
+
+		$this->settings = new Settings();
+	}
+
+	public function testGetFilename() {}
+
+	public function testVersion() {}
+
+	public function testMigrateSettings() {}
+
+	public function testSupportInfo() {}
+}

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -1,20 +1,53 @@
 <?php
 
+use \Apple_News as Apple_News;
 use \Apple_Exporter\Settings as Settings;
 
 class Apple_News_Test extends WP_UnitTestCase {
 
 	public function setup() {
 		parent::setup();
-
 		$this->settings = new Settings();
 	}
 
-	public function testGetFilename() {}
+	public function testGetFilename() {
+		$url = 'http://someurl.com/image.jpg?w=150&h=150';
+		$filename = Apple_News::get_filename( $url );
 
-	public function testVersion() {}
+		$this->assertEquals( 'image.jpg', $filename );
+	}
 
-	public function testMigrateSettings() {}
+	public function testVersion() {
+		$plugin_data = apple_news_get_plugin_data();
+		$this->assertEquals( $plugin_data['Version'], Apple_News::$version );
+	}
 
-	public function testSupportInfo() {}
+	public function testMigrateSettings() {
+		update_option( 'use_remote_images', 'yes' );
+		$default_settings = $this->settings->all();
+		$apple_news = new Apple_News();
+		$apple_news->migrate_settings( $this->settings );
+
+		$migrated_settings = get_option( $apple_news::$option_name );
+		$this->assertNotEquals( $default_settings, $migrated_settings );
+
+		$default_settings['use_remote_images'] = 'yes';
+		$this->assertEquals( $default_settings, $migrated_settings );
+	}
+
+	public function testSupportInfoHTML() {
+		$this->assertEquals( '<br /><br />If you need assistance with this issue, please reach out for support on <a href="https://wordpress.org/support/plugin/publish-to-apple-news">WordPress.org</a> or <a href="https://github.com/alleyinteractive/apple-news/issues">github</a>.', Apple_News::get_support_info() );
+	}
+
+	public function testSupportInfoHTMLNoPadding() {
+		$this->assertEquals( 'If you need assistance with this issue, please reach out for support on <a href="https://wordpress.org/support/plugin/publish-to-apple-news">WordPress.org</a> or <a href="https://github.com/alleyinteractive/apple-news/issues">github</a>.', Apple_News::get_support_info( 'html', false ) );
+	}
+
+	public function testSupportInfoText() {
+		$this->assertEquals( "\n\nIf you need assistance with this issue, please reach out for support on WordPress.org or github.", Apple_News::get_support_info( 'text' ) );
+	}
+
+	public function testSupportInfoTextNoPadding() {
+		$this->assertEquals( "If you need assistance with this issue, please reach out for support on WordPress.org or github.", Apple_News::get_support_info( 'text', false ) );
+	}
 }


### PR DESCRIPTION
1. Creates a framework for JSON validation and initially introduces checking for unicode character sequences that are symptomatic of display issues that have been witnessed, though not reproduced, in Apple News.
2. Breaks out Action_Exception into its own class file for cleanliness.
3. Adds direct support links to every error message.
4. Adds better formatting of multiple error messages.
5. Adds unit tests for the Apple_News and Admin_Apple_Notice classes
6. Adds new unit tests for Push

Closes #146