### PR TITLE
Bugfix for static asset versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 composer.lock
 vendor
 npm-debug.log
+.idea

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -154,6 +154,6 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 			__FILE__ ) .  '../assets/css/bulk-export.css' );
 		wp_enqueue_script( $this->plugin_slug . '_bulk_export_js', plugin_dir_url(
 			__FILE__ ) .  '../assets/js/bulk-export.js', array( 'jquery' ),
-			static::$version, true );
+			self::$version, true );
 	}
 }

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -154,6 +154,6 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 			__FILE__ ) .  '../assets/css/bulk-export.css' );
 		wp_enqueue_script( $this->plugin_slug . '_bulk_export_js', plugin_dir_url(
 			__FILE__ ) .  '../assets/js/bulk-export.js', array( 'jquery' ),
-			$this->version, true );
+			static::$version, true );
 	}
 }

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -262,7 +262,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		wp_enqueue_style( $this->plugin_slug . '_export_table_css', plugin_dir_url(
 			__FILE__ ) .  '../assets/css/export-table.css' );
 		wp_enqueue_script( $this->plugin_slug . '_export_table_js', plugin_dir_url(
-			__FILE__ ) .  '../assets/js/export-table.js', array( 'jquery', 'jquery-ui-datepicker' ), $this->version, true );
+			__FILE__ ) .  '../assets/js/export-table.js', array( 'jquery', 'jquery-ui-datepicker' ), static::$version, true );
 	}
 
 	/**

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -262,7 +262,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		wp_enqueue_style( $this->plugin_slug . '_export_table_css', plugin_dir_url(
 			__FILE__ ) .  '../assets/css/export-table.css' );
 		wp_enqueue_script( $this->plugin_slug . '_export_table_js', plugin_dir_url(
-			__FILE__ ) .  '../assets/js/export-table.js', array( 'jquery', 'jquery-ui-datepicker' ), static::$version, true );
+			__FILE__ ) .  '../assets/js/export-table.js', array( 'jquery', 'jquery-ui-datepicker' ), self::$version, true );
 	}
 
 	/**

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -329,7 +329,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		wp_enqueue_script( $this->plugin_slug . '_meta_boxes_js', plugin_dir_url(
 			__FILE__ ) .  '../assets/js/meta-boxes.js', array( 'jquery' ),
-			$this->version, true );
+			static::$version, true );
 
 		// Localize the JS file for handling frontend actions.
 		wp_localize_script( $this->plugin_slug . '_meta_boxes_js', 'apple_news_meta_boxes', array(

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -329,7 +329,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		wp_enqueue_script( $this->plugin_slug . '_meta_boxes_js', plugin_dir_url(
 			__FILE__ ) .  '../assets/js/meta-boxes.js', array( 'jquery' ),
-			static::$version, true );
+			self::$version, true );
 
 		// Localize the JS file for handling frontend actions.
 		wp_localize_script( $this->plugin_slug . '_meta_boxes_js', 'apple_news_meta_boxes', array(


### PR DESCRIPTION
* Fixes a warning that arises when trying to access static class methods using arrow syntax.