### PR TITLE
AN-55 Fix for widescreen text width

### DIFF
--- a/includes/apple-exporter/builders/class-builder.php
+++ b/includes/apple-exporter/builders/class-builder.php
@@ -1,9 +1,24 @@
 <?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Builders\Builder abstract class
+ *
+ * Contains an abstract class to form the foundation of component builders.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.4.0
+ */
+
 namespace Apple_Exporter\Builders;
 
+use Apple_Exporter\Exporter_Content;
+use Apple_Exporter\Exporter_Content_Settings;
+
 /**
- * A base abstract builder. All builders must implement a build method, in
- * which they return an array to represent a part of the final article.
+ * A base abstract builder from which all other builders inherit.
+ *
+ * All builders must implement a build method, in which they return an array to
+ * represent a part of the final article.
  *
  * @since 0.4.0
  */
@@ -29,9 +44,14 @@ abstract class Builder {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param Exporter_Content $content The content object to load.
+	 * @param Exporter_Content_Settings $settings The settings object to load.
+	 *
+	 * @access public
 	 */
-	function __construct( $content, $settings ) {
-		$this->content  = $content;
+	public function __construct( $content, $settings ) {
+		$this->content = $content;
 		$this->settings = $settings;
 	}
 
@@ -39,7 +59,7 @@ abstract class Builder {
 	 * Returns an array of the content.
 	 *
 	 * @access public
-	 * @return array
+	 * @return array The content in array format.
 	 */
 	public function to_array() {
 		return $this->build();
@@ -48,92 +68,102 @@ abstract class Builder {
 	/**
 	 * Builds the content.
 	 *
-	 * @abstract
 	 * @access protected
 	 */
 	protected abstract function build();
-
-	// Isolate dependencies
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Gets the content ID.
-	 *
-	 * @access protected
-	 * @return mixed
-	 */
-	protected function content_id() {
-		return $this->content->id();
-	}
-
-	/**
-	 * Gets the content title.
-	 *
-	 * @access protected
-	 * @return string
-	 */
-	protected function content_title() {
-		return $this->content->title() ?: __( 'Untitled Article', 'apple-news' );
-	}
-
-	/**
-	 * Gets the content body.
-	 *
-	 * @access protected
-	 * @return string
-	 */
-	protected function content_text() {
-		return $this->content->content();
-	}
-
-	/**
-	 * Gets the content intro.
-	 *
-	 * @access protected
-	 * @return Intro
-	 */
-	protected function content_intro() {
-		return $this->content->intro();
-	}
-
-	/**
-	 * Gets the content cover.
-	 *
-	 * @access protected
-	 * @return Cover
-	 */
-	protected function content_cover() {
-		return $this->content->cover();
-	}
-
-	/**
-	 * Gets a content setting.
-	 * @access protected
-	 * @param string $name
-	 * @return string
-	 */
-	protected function content_setting( $name ) {
-		return $this->content->get_setting( $name );
-	}
 
 	/**
 	 * Gets the content byline.
 	 *
 	 * @access protected
-	 * @return Byline
+	 * @return string The byline from the content object.
 	 */
 	protected function content_byline() {
 		return $this->content->byline();
 	}
 
 	/**
+	 * Gets the content cover.
+	 *
+	 * @access protected
+	 * @return string The URL for the cover image from the content object.
+	 */
+	protected function content_cover() {
+		return $this->content->cover();
+	}
+
+	/**
+	 * Gets the content ID.
+	 *
+	 * @access protected
+	 * @return int The ID from the content object.
+	 */
+	protected function content_id() {
+		return $this->content->id();
+	}
+
+	/**
+	 * Gets the content intro.
+	 *
+	 * @access protected
+	 * @return string The intro from the content object.
+	 */
+	protected function content_intro() {
+		return $this->content->intro();
+	}
+
+	/**
 	 * Gets the content nodes.
 	 *
 	 * @access protected
-	 * @return array
+	 * @return array The nodes from the content object.
 	 */
 	protected function content_nodes() {
 		return $this->content->nodes();
+	}
+
+	/**
+	 * Gets a content setting.
+	 *
+	 * @param string $name The setting name to retrieve.
+	 *
+	 * @access protected
+	 * @return mixed The value for the setting.
+	 */
+	protected function content_setting( $name ) {
+		return $this->content->get_setting( $name );
+	}
+
+	/**
+	 * Gets the content body.
+	 *
+	 * @access protected
+	 * @return string The body text from the content object.
+	 */
+	protected function content_text() {
+		return $this->content->content();
+	}
+
+	/**
+	 * Gets the content title.
+	 *
+	 * @access protected
+	 * @return string The title from the content object, or a fallback title.
+	 */
+	protected function content_title() {
+		return $this->content->title() ?: __( 'Untitled Article', 'apple-news' );
+	}
+
+	/**
+	 * Gets a content setting by key.
+	 *
+	 * @param string $name The setting name to retrieve.
+	 *
+	 * @access protected
+	 * @return mixed The value of the setting.
+	 */
+	protected function get_setting( $name ) {
+		return $this->settings->$name;
 	}
 
 	/**
@@ -142,18 +172,6 @@ abstract class Builder {
 	 * @access protected
 	 */
 	protected function set_content_property( $name, $value ) {
-		return $this->content->set_property( $name, $value );
+		$this->content->set_property( $name, $value );
 	}
-
-	/**
-	 * Gets a content setting by key.
-	 *
-	 * @access protected
-	 * @param string $name
-	 * @return mixed
-	 */
-	protected function get_setting( $name ) {
-		return $this->settings->get( $name );
-	}
-
 }

--- a/includes/apple-exporter/builders/class-builder.php
+++ b/includes/apple-exporter/builders/class-builder.php
@@ -171,6 +171,9 @@ abstract class Builder {
 	/**
 	 * Updates a content property.
 	 *
+	 * @param string $name The setting key to modify.
+	 * @param mixed $value The new value for the setting.
+	 *
 	 * @access protected
 	 */
 	protected function set_content_property( $name, $value ) {

--- a/includes/apple-exporter/builders/class-builder.php
+++ b/includes/apple-exporter/builders/class-builder.php
@@ -151,7 +151,9 @@ abstract class Builder {
 	 * @return string The title from the content object, or a fallback title.
 	 */
 	protected function content_title() {
-		return $this->content->title() ?: __( 'Untitled Article', 'apple-news' );
+		return $this->content->title()
+			? $this->content->title()
+			: __( 'Untitled Article', 'apple-news' );
 	}
 
 	/**

--- a/includes/apple-exporter/builders/class-component-layouts.php
+++ b/includes/apple-exporter/builders/class-component-layouts.php
@@ -114,6 +114,8 @@ class Component_Layouts extends Builder {
 			if ( 'right' == $position ) {
 				if ( $component->is_anchor_target() ) {
 					$col_start = $alignment_offset;
+				} elseif ( 'center' === $this->get_setting( 'body_orientation' ) ) {
+					$col_start = $layout_columns - $alignment_offset;
 				} else {
 					$col_start = $body_column_span - $alignment_offset;
 				}

--- a/includes/apple-exporter/builders/class-component-layouts.php
+++ b/includes/apple-exporter/builders/class-component-layouts.php
@@ -113,7 +113,7 @@ class Component_Layouts extends Builder {
 			$col_start = 0;
 			if ( 'right' == $position ) {
 				if ( $component->is_anchor_target() ) {
-					$col_start = $layout_columns - $body_column_span + $alignment_offset;
+					$col_start = $alignment_offset;
 				} else {
 					$col_start = $body_column_span - $alignment_offset;
 				}
@@ -126,7 +126,7 @@ class Component_Layouts extends Builder {
 			if ( $component->is_anchor_target() ) {
 				$col_span = $body_column_span - $alignment_offset;
 			} else {
-				$col_span = $layout_columns - $body_column_span + $alignment_offset;
+				$col_span = $alignment_offset;
 			}
 
 			// Finally, register the layout

--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -153,7 +153,7 @@ class Exporter_Content {
 	 * @access public
 	 */
 	public function get_setting( $name ) {
-		return $this->settings->get( $name );
+		return $this->settings->$name;
 	}
 
 	/**

--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -153,7 +153,7 @@ class Exporter_Content {
 	 * @access public
 	 */
 	public function get_setting( $name ) {
-		return $this->settings->$name;
+		return $this->settings->get( $name );
 	}
 
 	/**

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -8,6 +8,7 @@
  * @subpackage Apple_Exporter
  * @since 0.4.0
  */
+
 namespace Apple_Exporter;
 
 /**

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -1,165 +1,158 @@
 <?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Settings class
+ *
+ * Contains a class which is used to manage user-defined and computed settings.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.4.0
+ */
 namespace Apple_Exporter;
 
 /**
- * Settings used in exporting. In a WordPress context, these can be loaded
- * as WordPress options defined in the plugin.
+ * Manages user-defined and computed settings used in exporting.
+ *
+ * In a WordPress context, these can be loaded as WordPress options defined in the
+ * plugin.
+ *
+ * @since 0.4.0
  */
 class Settings {
 
 	/**
 	 * Exporter's default settings.
 	 *
+	 * These settings can be overridden on the plugin settings screen.
+	 *
 	 * @var array
 	 * @access private
 	 */
-	private $settings = array(
+	private $_settings = array(
+
 		// API information.
-		'api_key'         				=> '',
-		'api_secret'      				=> '',
-		'api_channel'     				=> '',
-		'api_autosync'    				=> 'yes',
-		'api_autosync_update'			=> 'yes',
-		'api_async'    						=> 'no',
+		'api_key' => '',
+		'api_secret' => '',
+		'api_channel' => '',
+		'api_autosync' => 'yes',
+		'api_autosync_update' => 'yes',
+		'api_async' => 'no',
 
-		'post_types'      				=> array( 'post' ),
-		'show_metabox'    				=> 'yes',
+		'post_types' => array( 'post' ),
+		'show_metabox' => 'yes',
 
-		'layout_margin'   				=> 100,
-		'layout_gutter'   				=> 20,
+		'layout_margin' => 100,
+		'layout_gutter' => 20,
 
-		'body_font'        				=> 'AvenirNext-Regular',
-		'body_size'        				=> 18,
-		'body_color'       				=> '#4f4f4f',
-		'body_link_color'  				=> '#428bca',
-		'body_background_color'   => '#fafafa',
-		'body_orientation' 				=> 'left',
-		'body_line_height' 				=> 24,
+		'body_font' => 'AvenirNext-Regular',
+		'body_size' => 18,
+		'body_color' => '#4f4f4f',
+		'body_link_color' => '#428bca',
+		'body_background_color' => '#fafafa',
+		'body_orientation' => 'left',
+		'body_line_height' => 24,
 
-		'initial_dropcap' 				=> 'yes',
-		'dropcap_font'    				=> 'AvenirNext-Bold',
-		'dropcap_color'   				=> '#4f4f4f',
+		'initial_dropcap' => 'yes',
+		'dropcap_font' => 'AvenirNext-Bold',
+		'dropcap_color' => '#4f4f4f',
 
-		'byline_font'     				=> 'AvenirNext-Medium',
-		'byline_size'     				=> 13,
-		'byline_color'    				=> '#7c7c7c',
-		'byline_format'						=> 'by #author# | #M j, Y | g:i A#',
+		'byline_font' => 'AvenirNext-Medium',
+		'byline_size' => 13,
+		'byline_color' => '#7c7c7c',
+		'byline_format' => 'by #author# | #M j, Y | g:i A#',
 
-		'header_font'     				=> 'AvenirNext-Bold',
-		'header_color'    				=> '#333333',
-		'header1_size'    				=> 48,
-		'header2_size'						=> 32,
-		'header3_size'    				=> 24,
-		'header4_size'    				=> 21,
-		'header5_size'    				=> 18,
-		'header6_size'    				=> 16,
-		'header_line_height' 			=> 52,
+		'header_font' => 'AvenirNext-Bold',
+		'header_color' => '#333333',
+		'header1_size' => 48,
+		'header2_size' => 32,
+		'header3_size' => 24,
+		'header4_size' => 21,
+		'header5_size' => 18,
+		'header6_size' => 16,
+		'header_line_height' => 52,
 
-		'pullquote_font'  				=> 'AvenirNext-Bold',
-		'pullquote_size'  				=> 48,
-		'pullquote_color' 				=> '#53585f',
-		'pullquote_border_color' 	=> '#53585f',
-		'pullquote_border_style' 	=> 'solid',
-		'pullquote_border_width' 	=> '3',
-		'pullquote_transform'			=> 'uppercase',
-		'pullquote_line_height' 	=> 48,
+		'pullquote_font' => 'AvenirNext-Bold',
+		'pullquote_size' => 48,
+		'pullquote_color' => '#53585f',
+		'pullquote_border_color' => '#53585f',
+		'pullquote_border_style' => 'solid',
+		'pullquote_border_width' => '3',
+		'pullquote_transform' => 'uppercase',
+		'pullquote_line_height' => 48,
 
-		'component_alerts' 				=> 'none',
-		'json_alerts'							=> 'warn',
+		'component_alerts' => 'none',
+		'json_alerts' => 'warn',
 
-		'use_remote_images' 			=> 'no',
+		'use_remote_images' => 'no',
 
 		// This can either be gallery or mosaic.
-		'gallery_type'   					=> 'gallery',
+		'gallery_type' => 'gallery',
 
 		// Ad settings
-		'enable_advertisement' 		=> 'yes',
-		'ad_frequency' 						=> 1,
-		'ad_margin' 							=> 15,
+		'enable_advertisement' => 'yes',
+		'ad_frequency' => 1,
+		'ad_margin' => 15,
 
 		// Default component order
-		'meta_component_order' 		=> array( 'cover', 'title', 'byline' ),
+		'meta_component_order' => array( 'cover', 'title', 'byline' ),
 	);
 
 	/**
-	 * Get a setting.
+	 * Magic method to get a computed or stored settings value.
 	 *
-	 * @param string $name
-	 * @return mixed
+	 * @param string $name The setting name to retrieve.
+	 *
 	 * @access public
+	 * @return mixed The value for the setting.
 	 */
-	public function get( $name ) {
-		// Check for computed settings
+	public function __get( $name ) {
+
+		// Check for computed settings.
 		if ( method_exists( $this, $name ) ) {
 			return $this->$name();
 		}
 
-		// Check for regular settings
-		if ( ! array_key_exists( $name, $this->settings ) ) {
-			return null;
+		// Check for regular settings.
+		if ( isset( $this->_settings[ $name ] ) ) {
+			return $this->_settings[ $name ];
 		}
 
-		return $this->settings[ $name ];
+		return null;
 	}
 
 	/**
-	 * Set a setting.
+	 * Magic method to determine whether a given property is set.
 	 *
-	 * @param string $name
-	 * @param mixed $value
-	 * @return mixed
+	 * @param string $name The setting name to check.
+	 *
 	 * @access public
+	 * @return bool Whether the property is set or not.
 	 */
-	public function set( $name, $value ) {
-		$this->settings[ $name ] = $value;
-		return $value;
+	public function __isset( $name ) {
+
+		// Check for computed settings.
+		if ( method_exists( $this, $name ) ) {
+			return true;
+		}
+
+		// Check for regular settings.
+		if ( isset( $this->_settings[ $name ] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
-	 * Get all settings.
+	 * Magic method for setting property values.
 	 *
-	 * @return array
+	 * @param string $name The setting name to update.
+	 * @param mixed $value The new value for the setting.
+	 *
 	 * @access public
 	 */
-	public function all() {
-		return $this->settings;
-	}
-
-	// COMPUTED SETTINGS are those settings which are not shown in the frontend
-	// and cannot be changed directly, instead, they are a logical representation
-	// of a combination of other settings. For example, if the body orientation
-	// is "center", the layout_width computed property is 768, otherwise, it's
-	// 1024.
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Get the layout width.
-	 *
-	 * @return string
-	 * @access public
-	 */
-	public function layout_width() {
-		return 'center' == $this->get( 'body_orientation' ) ? 768 : 1024;
-	}
-
-	/**
-	 * Get the layout columns.
-	 *
-	 * @return string
-	 * @access public
-	 */
-	public function layout_columns() {
-		return 'center' == $this->get( 'body_orientation' ) ? 9 : 7;
-	}
-
-	/**
-	 * Get the body column span.
-	 *
-	 * @return string
-	 * @access public
-	 */
-	public function body_column_span() {
-		return 'center' == $this->get( 'body_orientation' ) ? 7 : 5;
+	public function __set( $name, $value ) {
+		$this->_settings[ $name ] = $value;
 	}
 
 	/**
@@ -168,11 +161,86 @@ class Settings {
 	 * layouts, as centered layouts have more columns.
 	 *
 	 * @since 0.4.0
-	 * @return string
+	 *
 	 * @access public
+	 * @return int The number of columns for aligned components to span.
 	 */
 	public function alignment_offset() {
-		return 'center' == $this->get( 'body_orientation' ) ? 3 : 2;
+		return ( 'center' === $this->body_orientation ) ? 5 : 4;
 	}
 
+	/**
+	 * Get all settings.
+	 *
+	 * @access public
+	 * @return array The array of all settings defined in this class.
+	 */
+	public function all() {
+		return $this->_settings;
+	}
+
+	/**
+	 * Get the body column span.
+	 *
+	 * @access public
+	 * @return int The number of columns for the body to span.
+	 */
+	public function body_column_span() {
+		return 7;
+	}
+
+	/**
+	 * Get a setting.
+	 *
+	 * @param string $name The setting key to retrieve.
+	 *
+	 * @deprecated 1.2.1 Replaced by magic __get() method.
+	 *
+	 * @see \Apple_Exporter\Settings::__get()
+	 *
+	 * @access public
+	 * @return mixed The value for the requested setting.
+	 */
+	public function get( $name ) {
+		return $this->$name;
+	}
+
+	/**
+	 * Get the computed layout columns.
+	 *
+	 * @access public
+	 * @return int The number of layout columns to use.
+	 */
+	public function layout_columns() {
+		return ( 'center' === $this->body_orientation ) ? 9 : 7;
+	}
+
+	/**
+	 * Get the computed layout width.
+	 *
+	 * @access public
+	 * @return int The correct layout width based on the body orientation.
+	 */
+	public function layout_width() {
+		return ( 'center' === $this->body_orientation ) ? 768 : 1024;
+	}
+
+	/**
+	 * Set a setting.
+	 *
+	 * @param string $name The setting key to modify.
+	 * @param mixed $value The new value for the setting.
+	 *
+	 * @deprecated 1.2.1 Replaced by magic __set() method.
+	 *
+	 * @see \Apple_Exporter\Settings::__set()
+	 *
+	 * @access public
+	 * @return mixed The new value for the setting.
+	 */
+	public function set( $name, $value ) {
+		$this->$name = $value;
+
+		return $value;
+	}
 }


### PR DESCRIPTION
* Sets the body text column span on non-center aligned layouts to be the same as the number of columns so that the text goes edge-to-edge.
* Fixes the logic for positioning images in centered and non-centered layouts to prevent bleed-over from the margins on non-centered layouts.
* Refactors the following classes for adherence to WordPress standards and PHP best practices:
  * Apple_Exporter\Builders\Builder
  * Apple_Exporter\Settings

Fixes #233.