### PR TITLE
AN-54 Addition of basic HTML support

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -46,6 +46,17 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'type' => array( 'yes', 'no' ),
 				'description' => __( 'If set to yes, images that are centered or have no alignment will span edge-to-edge rather than being constrained within the body margins.', 'apple-news' ),
 			),
+			'html_support' => array(
+				'label' => __( 'Enable HTML support?', 'apple-news' ),
+				'type' => array( 'yes', 'no' ),
+				'description' => sprintf(
+					'%s <a href="%s" target="_blank">%s</a> %s',
+					__( 'Experimental. If set to yes, certain text fields will use', 'apple-news' ),
+					__( 'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/HTMLMarkupforAppleNewsFormat.html', 'apple-news' ),
+					__( 'Apple News HTML format', 'apple-news' ),
+					__( 'instead of Markdown, allowing for proper display of certain HTML tags in content.', 'apple-news' )
+				)
+			),
 		);
 
 		// Add the groups
@@ -57,6 +68,10 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			'images' => array(
 				'label'       => __( 'Image Settings', 'apple-news' ),
 				'settings'    => array( 'use_remote_images', 'full_bleed_images' ),
+			),
+			'format' => array(
+				'label'       => __( 'Format Settings', 'apple-news' ),
+				'settings'    => array( 'html_support' ),
 			),
 		);
 

--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -457,7 +457,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				),
 			),
 			'monospaced' => array(
-				'label' => __( 'Monospaced', 'apple-news' ),
+				'label' => __( 'Monospaced (<pre>, <code>, <samp>)', 'apple-news' ),
 				'settings' => array(
 					'monospaced_font',
 					'monospaced_size',

--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -288,6 +288,28 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'label' => __( 'Pull quote transformation', 'apple-news' ),
 				'type' => array( 'none', 'uppercase' ),
 			),
+			'monospaced_font' => array(
+				'label' => '',
+				'type' => 'font',
+			),
+			'monospaced_size' => array(
+				'label' => __( 'Monospaced font size', 'apple-news' ),
+				'type' => 'integer',
+			),
+			'monospaced_color' => array(
+				'label' => __( 'Monospaced font color', 'apple-news' ),
+				'type' => 'color',
+			),
+			'monospaced_line_height' => array(
+				'label' => __( 'Monospaced line height', 'apple-news' ),
+				'type' => 'float',
+				'sanitize' => 'floatval',
+			),
+			'monospaced_tracking' => array(
+				'label' => __( 'Monospaced tracking', 'apple-news' ),
+				'type' => 'integer',
+				'description' => __( '(Percentage of font size)', 'apple-news' ),
+			),
 			'gallery_type' => array(
 				'label' => __( 'Gallery type', 'apple-news' ),
 				'type' => array( 'gallery', 'mosaic' ),
@@ -434,6 +456,16 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 					'pullquote_transform'
 				),
 			),
+			'monospaced' => array(
+				'label' => __( 'Monospaced', 'apple-news' ),
+				'settings' => array(
+					'monospaced_font',
+					'monospaced_size',
+					'monospaced_line_height',
+					'monospaced_tracking',
+					'monospaced_color',
+				),
+			),
 			'gallery' => array(
 				'label' => __( 'Gallery', 'apple-news' ),
 				'description' => __( 'Can either be a standard gallery, or mosaic.', 'apple-news' ),
@@ -532,6 +564,12 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				<p>In eu la	cus porttitor, pellentesque diam et, tristique elit. Mauris justo odio, efficitur sit amet aliquet id, aliquam placerat turpis.</p>
 				<div class="apple-news-pull-quote">Lorem ipsum dolor sit amet.</div>
 				<p>Sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Pellentesque ipsum mi, sagittis eget sodales et, volutpat at felis.</p>
+                <pre>
+.code-sample {
+    font-family: monospace;
+    white-space: pre;
+}
+                </pre>
 				</div>
 			</div>
 		</div>

--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -44,7 +44,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'type' => 'integer',
 			),
 			'body_font' => array(
-				'label' => '',
+				'label' => __( 'Body font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'body_size' => array(
@@ -82,7 +82,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'type' => array( 'yes', 'no' ),
 			),
 			'dropcap_font' => array(
-				'label' => '',
+				'label' => __( 'Dropcap font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'dropcap_color' => array(
@@ -90,7 +90,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'type' => 'color',
 			),
 			'byline_font' => array(
-				'label' => '',
+				'label' => __( 'Byline font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'byline_size' => array(
@@ -119,27 +119,27 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'required' => false,
 			),
 			'header1_font' => array(
-				'label' => '',
+				'label' => __( 'Header 1 font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'header2_font' => array(
-				'label' => '',
+				'label' => __( 'Header 2 font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'header3_font' => array(
-				'label' => '',
+				'label' => __( 'Header 3 font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'header4_font' => array(
-				'label' => '',
+				'label' => __( 'Header 4 font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'header5_font' => array(
-				'label' => '',
+				'label' => __( 'Header 5 font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'header6_font' => array(
-				'label' => '',
+				'label' => __( 'Header 6 font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'header1_line_height' => array(
@@ -251,7 +251,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'type' => 'integer',
 			),
 			'pullquote_font' => array(
-				'label' => '',
+				'label' => __( 'Pullquote font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'pullquote_size' => array(
@@ -289,7 +289,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'type' => array( 'none', 'uppercase' ),
 			),
 			'monospaced_font' => array(
-				'label' => '',
+				'label' => __( 'Monospaced font face', 'apple-news' ),
 				'type' => 'font',
 			),
 			'monospaced_size' => array(

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -199,6 +199,14 @@
 		appleNewsSetCSS( '.apple-news-settings-preview div.apple-news-pull-quote', 'pullquote_border_width', 'border-bottom-width', 'px', null );
 		appleNewsSetCSS( '.apple-news-settings-preview div.apple-news-pull-quote', 'pullquote_line_height', 'line-height', 'px', .75 );
 
+		// Monospaced
+		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_font', 'font-family', null, null );
+		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_size', 'font-size', 'px', null );
+		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_tracking', 'letter-spacing', 'px', $( '#monospaced_size' ).val() / 100 );
+		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_color', 'color', null, null );
+		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_line_height', 'line-height', 'px', null );
+		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_line_height', 'margin-bottom', 'px', null );
+
 		// Component order
 		var componentOrder = $( '#meta-component-order-sort' ).sortable( 'toArray' );
 		if ( '' !== componentKey ) {

--- a/includes/apple-exporter/builders/class-text-styles.php
+++ b/includes/apple-exporter/builders/class-text-styles.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Builders\Text_Styles class
+ *
+ * Contains a class which is used to set top-level text styles.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 1.2.1
+ */
+
+namespace Apple_Exporter\Builders;
+
+use Apple_Exporter\Exporter_Content;
+use Apple_Exporter\Exporter_Content_Settings;
+
+/**
+ * A class which is used to set top-level text styles.
+ *
+ * @since 1.2.1
+ */
+class Text_Styles extends Builder {
+
+	/**
+	 * All styles.
+	 *
+	 * @access private
+	 * @var array
+	 */
+	private $_styles = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Exporter_Content $content The content for this export.
+	 * @param Exporter_Content_Settings $settings The settings for this export.
+	 *
+	 * @access public
+	 */
+	public function __construct( $content, $settings ) {
+		parent::__construct( $content, $settings );
+
+		// Determine whether to add the styles for HTML content.
+		if ( 'yes' === $this->get_setting( 'html_support' ) ) {
+			$this->_add_html_styles();
+		}
+	}
+
+	/**
+	 * Returns all styles defined so far.
+	 *
+	 * @access public
+	 * @return array The styles defined thus far.
+	 */
+	public function build() {
+
+		/**
+		 * Allows for filtering of global text styles.
+		 *
+		 * @since 1.2.1
+		 *
+		 * @param array $styles The styles to be filtered.
+		 */
+		return apply_filters( 'apple_news_text_styles', $this->_styles );
+	}
+
+	/**
+	 * Register a style into the exporter.
+	 *
+	 * @param string $name The name of the style to register.
+	 * @param array $values The values to register to the style.
+	 *
+	 * @access public
+	 */
+	public function register_style( $name, $values ) {
+
+		// Only register once, since styles have unique names.
+		if ( array_key_exists( $name, $this->_styles ) ) {
+			return;
+		}
+
+		// Register the style.
+		$this->_styles[ $name ] = $values;
+	}
+
+	/**
+	 * Adds HTML styles to the list.
+	 *
+	 * @access private
+	 */
+	private function _add_html_styles() {
+
+		// Add style for <code> tags.
+		$this->register_style( 'default-tag-code', array(
+			'fontName' => $this->get_setting( 'monospaced_font' ),
+			'fontSize' => intval( $this->get_setting( 'monospaced_size' ) ),
+			'tracking' => intval( $this->get_setting( 'monospaced_tracking' ) ) / 100,
+			'lineHeight' => intval( $this->get_setting( 'monospaced_line_height' ) ),
+			'textColor' => $this->get_setting( 'monospaced_color' ),
+		) );
+
+		// Add style for <pre> tags.
+		$this->register_style( 'default-tag-pre', array(
+			'textAlignment' => 'left',
+			'fontName' => $this->get_setting( 'monospaced_font' ),
+			'fontSize' => intval( $this->get_setting( 'monospaced_size' ) ),
+			'tracking' => intval( $this->get_setting( 'monospaced_tracking' ) ) / 100,
+			'lineHeight' => intval( $this->get_setting( 'monospaced_line_height' ) ),
+			'textColor' => $this->get_setting( 'monospaced_color' ),
+			'paragraphSpacingBefore' => 18,
+			'paragraphSpacingAfter' => 18,
+		) );
+
+		// Add style for <samp> tags.
+		$this->register_style( 'default-tag-samp', array(
+			'fontName' => $this->get_setting( 'monospaced_font' ),
+			'fontSize' => intval( $this->get_setting( 'monospaced_size' ) ),
+			'tracking' => intval( $this->get_setting( 'monospaced_tracking' ) ) / 100,
+			'lineHeight' => intval( $this->get_setting( 'monospaced_line_height' ) ),
+			'textColor' => $this->get_setting( 'monospaced_color' ),
+		) );
+	}
+}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -77,12 +77,13 @@ class Exporter {
 		if ( $builders ) {
 			$this->builders = $builders;
 		} else {
-			$this->register_builder( 'layout'             	, new Builders\Layout( $this->content, $this->settings ) );
-			$this->register_builder( 'components'						, new Builders\Components( $this->content, $this->settings ) );
-			$this->register_builder( 'componentTextStyles'	, new Builders\Component_Text_Styles( $this->content, $this->settings ) );
-			$this->register_builder( 'componentLayouts'   	, new Builders\Component_Layouts( $this->content, $this->settings ) );
-			$this->register_builder( 'metadata'           	, new Builders\Metadata( $this->content, $this->settings ) );
-			$this->register_builder( 'advertisingSettings'	, new Builders\Advertising_Settings( $this->content, $this->settings ) );
+			$this->register_builder( 'layout', new Builders\Layout( $this->content, $this->settings ) );
+			$this->register_builder( 'components', new Builders\Components( $this->content, $this->settings ) );
+			$this->register_builder( 'componentTextStyles', new Builders\Component_Text_Styles( $this->content, $this->settings ) );
+			$this->register_builder( 'textStyles', new Builders\Text_Styles( $this->content, $this->settings ) );
+			$this->register_builder( 'componentLayouts', new Builders\Component_Layouts( $this->content, $this->settings ) );
+			$this->register_builder( 'metadata', new Builders\Metadata( $this->content, $this->settings ) );
+			$this->register_builder( 'advertisingSettings', new Builders\Advertising_Settings( $this->content, $this->settings ) );
 		}
 
 		Component_Factory::initialize( $this->workspace, $this->settings, $this->get_builder( 'componentTextStyles' ), $this->get_builder( 'componentLayouts' ) );

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\HTML class
+ *
+ * Contains a class which is used to filter raw HTML into Apple News HTML format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 1.2.1
+ */
+
+namespace Apple_Exporter;
+
+/**
+ * A class that filters raw HTML into Apple News HTML format.
+ *
+ * @since 1.2.1
+ */
+class HTML {
+
+	/**
+	 * An array of allowed HTML tags for Apple News formatted HTML.
+	 *
+	 * @access private
+	 * @var array
+	 */
+	private $_allowed_html = array(
+		'a' => array(
+			'href' => true,
+		),
+		'aside' => array(),
+		'b' => array(),
+		'blockquote' => array(),
+		'br' => array(),
+		'code' => array(),
+		'del' => array(),
+		'em' => array(),
+		'footer' => array(),
+		'i' => array(),
+		'li' => array(),
+		'ol' => array(),
+		'p' => array(),
+		'pre' => array(),
+		's' => array(),
+		'samp' => array(),
+		'strong' => array(),
+		'sub' => array(),
+		'sup' => array(),
+		'ul' => array(),
+	);
+
+	/**
+	 * Formats a raw HTML string as Apple News format HTML.
+	 *
+	 * @param string $html The HTML to format.
+	 *
+	 * @access public
+	 * @return string The formatted HTML.
+	 */
+	public function format( $html ) {
+		return wp_kses( $html, $this->_allowed_html );
+	}
+}

--- a/includes/apple-exporter/class-markdown.php
+++ b/includes/apple-exporter/class-markdown.php
@@ -75,7 +75,7 @@ class Markdown {
 			case 'em':
 				return $this->_parse_node_emphasis( $node );
 			case 'br':
-				return '  ' . "\n";
+				return "\n";
 			case 'p':
 				return $this->_parse_node_paragraph( $node );
 			case 'a':
@@ -122,13 +122,9 @@ class Markdown {
 	 * @return string The processed node, converted to a string.
 	 */
 	private function _parse_node_heading( $node ) {
-
-		// Get the heading level.
-		preg_match( '/h(\d)/', $node->nodeName, $matches );
-
 		return sprintf(
 			'%s %s' . "\n",
-			str_repeat( '#', $matches[1] ),
+			str_repeat( '#', intval( substr( $node->nodeName, 1, 1 ) ) ),
 			$this->parse_nodes( $node->childNodes )
 		);
 	}

--- a/includes/apple-exporter/class-markdown.php
+++ b/includes/apple-exporter/class-markdown.php
@@ -1,5 +1,17 @@
 <?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Markdown class
+ *
+ * Contains a class which is used to parse raw HTML into Apple News Markdown format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
 namespace Apple_Exporter;
+
+use DOMElement;
+use DOMNodeList;
 
 /**
  * This class transforms HTML into Article Format Markdown, which is a subset
@@ -13,67 +25,35 @@ namespace Apple_Exporter;
 class Markdown {
 
 	/**
-	 * List mode for the markdown.
+	 * List index for OL and UL components being transformed to Markdown.
 	 *
-	 * @var string
 	 * @access private
-	 */
-	private $list_mode;
-
-	/**
-	 * List index for the markdown.
-	 *
 	 * @var int
-	 * @access private
 	 */
-	private $list_index;
+	private $_list_index = 1;
 
 	/**
-	 * Constructor.
-	 */
-	function __construct() {
-		$this->list_mode = 'ul';
-		$this->list_index = 1;
-	}
-
-	/**
-	 * Transforms HTML into Article Format Markdown.
+	 * List mode for lists being transformed to Markdown.
 	 *
-	 * @param string $html
-	 * @return string
+	 * @access private
+	 * @var string
+	 */
+	private $_list_mode = 'ul';
+
+	/**
+	 * Parse an array of nodes into the specified format.
+	 *
+	 * @param DOMNodeList $nodes A list of DOMElement nodes to be processed.
+	 *
 	 * @access public
-	 */
-	public function parse( $html ) {
-		if ( empty( $html ) ) {
-			return '';
-		}
-
-		// PHP's DomDocument doesn't like HTML5 so we must ignore errors, we'll
-		// manually handle all tags anyways.
-		$dom = new \DOMDocument();
-		libxml_use_internal_errors( true );
-		// A trick to load string as UTF-8
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html );
-		libxml_clear_errors( true );
-
-		// Find the first-level nodes of the body tag.
-		$nodes = $dom->getElementsByTagName( 'body' )->item( 0 )->childNodes;
-
-		// Parse them and return result
-		return apply_filters( 'apple_news_parse_markdown', $this->parse_nodes( $nodes ), $nodes );
-	}
-
-	/**
-	 * Parse an array of nodes for markdown.
-	 *
-	 * @param array $nodes
 	 * @return string
-	 * @access private
 	 */
-	private function parse_nodes( $nodes ) {
+	public function parse_nodes( $nodes ) {
+
+		// Loop over each DOMElement and pass off for parsing.
 		$result = '';
 		foreach ( $nodes as $node ) {
-			$result .= $this->parse_node( $node );
+			$result .= $this->_parse_node( $node );
 		}
 
 		return $result;
@@ -82,170 +62,190 @@ class Markdown {
 	/**
 	 * Parse an individual node for markdown.
 	 *
-	 * @param DomNode $node
-	 * @return string
+	 * @param DOMElement $node The node to process.
+	 *
 	 * @access private
+	 * @return string The processed content, converted to a Markdown string.
 	 */
-	private function parse_node( $node ) {
+	private function _parse_node( $node ) {
 		switch ( $node->nodeName ) {
-		case 'strong':
-			return $this->parse_strong_node( $node );
-		case  'i':
-		case 'em':
-			return $this->parse_emphasis_node( $node );
-		case 'br':
-			return $this->parse_linebreak_node( $node );
-		case 'p':
-			return $this->parse_paragraph_node( $node );
-		case 'a':
-			return $this->parse_hyperlink_node( $node );
-		case 'ul':
-			return $this->parse_unordered_list_node( $node );
-		case 'ol':
-			return $this->parse_ordered_list_node( $node );
-		case 'li':
-			return $this->parse_list_item_node( $node );
-		case 'h1':
-		case 'h2':
-		case 'h3':
-		case 'h4':
-		case 'h5':
-		case 'h6':
-			return $this->parse_heading_node( $node );
-		case '#comment':
-			return '';
-		case '#text':
-		default:
-			return $this->parse_text_node( $node );
+			case 'strong':
+				return $this->_parse_node_strong( $node );
+			case  'i':
+			case 'em':
+				return $this->_parse_node_emphasis( $node );
+			case 'br':
+				return '  ' . "\n";
+			case 'p':
+				return $this->_parse_node_paragraph( $node );
+			case 'a':
+				return $this->_parse_node_hyperlink( $node );
+			case 'ul':
+				return $this->_parse_node_unordered_list( $node );
+			case 'ol':
+				return $this->_parse_node_ordered_list( $node );
+			case 'li':
+				return $this->_parse_node_list_item( $node );
+			case 'h1':
+			case 'h2':
+			case 'h3':
+			case 'h4':
+			case 'h5':
+			case 'h6':
+				return $this->_parse_node_heading( $node );
+			case '#comment':
+				return '';
+			case '#text':
+			default:
+				return $this->_parse_node_text( $node );
 		}
 	}
 
 	/**
-	 * Convert a text node to markdown.
+	 * Convert an <em> node to markdown.
 	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_text_node( $node ) {
-		return str_replace( '!', '\\!', $node->nodeValue );
-	}
-
-	/**
-	 * Convert a linebreak node to markdown.
+	 * @param DOMElement $node The node to process.
 	 *
-	 * @param DomNode $node
-	 * @return string
 	 * @access private
+	 * @return string The processed node, converted to a string.
 	 */
-	private function parse_linebreak_node( $node ) {
-		return "  \n";
-	}
-
-	/**
-	 * Convert a strong node to markdown.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_strong_node( $node ) {
-		return '**' . $this->parse_nodes( $node->childNodes ) . '**';
-	}
-
-	/**
-	 * Convert a emphasis node to markdown.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_emphasis_node( $node ) {
+	private function _parse_node_emphasis( $node ) {
 		return '_' . $this->parse_nodes( $node->childNodes ) . '_';
-	}
-
-	/**
-	 * Convert a paragraph node to markdown.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_paragraph_node( $node ) {
-		return $this->parse_nodes( $node->childNodes ) . "\n\n";
-	}
-
-	/**
-	 * Hyperlinks are not yet supported in Article Format markdown. Ignore for
-	 * now.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_hyperlink_node( $node ) {
-		$url = esc_url_raw( apply_filters( 'apple_news_markdown_hyperlink', $node->getAttribute( 'href' ) ) );
-		return '[' . $this->parse_nodes( $node->childNodes ) . '](' . $url . ')';
-	}
-
-	/**
-	 * Convert an unordered list node to markdown.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_unordered_list_node( $node ) {
-		$this->list_mode = 'ul';
-		return $this->parse_nodes( $node->childNodes ) . "\n\n";
-	}
-
-	/**
-	 * Convert an ordered list node to markdown.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_ordered_list_node( $node ) {
-		$this->list_mode = 'ol';
-		$this->list_index = 1;
-		return $this->parse_nodes( $node->childNodes ) . "\n\n";
-	}
-
-	/**
-	 * Convert a list item node to markdown.
-	 *
-	 * @param DomNode $node
-	 * @return string
-	 * @access private
-	 */
-	private function parse_list_item_node( $node ) {
-		if ( 'ol' == $this->list_mode ) {
-			return $this->list_index . '. ' . $this->parse_nodes( $node->childNodes );
-			$this->list_index += 1;
-		}
-
-		return "- " . $this->parse_nodes( $node->childNodes );
 	}
 
 	/**
 	 * Convert a heading node to markdown.
 	 *
-	 * @param DomNode $node
-	 * @return string
+	 * @param DOMElement $node The node to process.
+	 *
 	 * @access private
+	 * @return string The processed node, converted to a string.
 	 */
-	private function parse_heading_node( $node ) {
-		preg_match( '#h(\d)#', $node->nodeName, $matches );
-		$level = $matches[1];
-		$output = '';
-		for( $i = 0; $i < $level; $i++ ) {
-			$output .= '#';
-		}
-		$output .= ' ' . $this->parse_nodes( $node->childNodes ) . "\n";
+	private function _parse_node_heading( $node ) {
 
-		return $output;
+		// Get the heading level.
+		preg_match( '/h(\d)/', $node->nodeName, $matches );
+
+		return sprintf(
+			'%s %s' . "\n",
+			str_repeat( '#', $matches[1] ),
+			$this->parse_nodes( $node->childNodes )
+		);
 	}
 
+	/**
+	 * Convert an <a> node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_hyperlink( $node ) {
+
+		// Set the URL from the HREF parameter on the tag.
+		$url = $node->getAttribute( 'href' );
+
+		/**
+		 * Allows for filtering of the formatted content before return.
+		 *
+		 * @since 0.2.0
+		 *
+		 * @param string $url The URL to be filtered.
+		 */
+		$url = apply_filters( 'apple_news_markdown_hyperlink', $url );
+
+		return sprintf(
+			'[%s](%s)',
+			$this->parse_nodes( $node->childNodes ),
+			esc_url_raw( $url )
+		);
+	}
+
+	/**
+	 * Convert an <li> node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_list_item( $node ) {
+
+		// Fork for ordered list items.
+		if ( 'ol' === $this->_list_mode ) {
+			return sprintf(
+				'%d. %s',
+				$this->_list_index ++,
+			    $this->parse_nodes( $node->childNodes )
+			);
+		}
+
+		return '- ' . $this->parse_nodes( $node->childNodes );
+	}
+
+	/**
+	 * Convert an <ol> node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_ordered_list( $node ) {
+		$this->_list_mode = 'ol';
+		$this->_list_index = 1;
+
+		return $this->parse_nodes( $node->childNodes ) . "\n\n";
+	}
+
+	/**
+	 * Convert a <p> node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_paragraph( $node ) {
+		return $this->parse_nodes( $node->childNodes ) . "\n\n";
+	}
+
+	/**
+	 * Convert a <strong> node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_strong( $node ) {
+		return '**' . $this->parse_nodes( $node->childNodes ) . '**';
+	}
+
+	/**
+	 * Convert a text node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_text( $node ) {
+		return str_replace( '!', '\\!', $node->nodeValue );
+	}
+
+	/**
+	 * Convert a <ul> node to markdown.
+	 *
+	 * @param DOMElement $node The node to process.
+	 *
+	 * @access private
+	 * @return string The processed node, converted to a string.
+	 */
+	private function _parse_node_unordered_list( $node ) {
+		$this->_list_mode = 'ul';
+
+		return $this->parse_nodes( $node->childNodes ) . "\n\n";
+	}
 }

--- a/includes/apple-exporter/class-parser.php
+++ b/includes/apple-exporter/class-parser.php
@@ -27,10 +27,10 @@ class Parser {
 	/**
 	 * The format to use. Valid values are 'html' and 'markdown'.
 	 *
-	 * @access private
+	 * @access public
 	 * @var string
 	 */
-	private $_format;
+	public $format;
 
 	/**
 	 * Initializes the object with the format setting.
@@ -40,7 +40,7 @@ class Parser {
 	 * @access public
 	 */
 	public function __construct( $format = 'markdown' ) {
-		$this->_format = ( $format === 'html' ) ? 'html' : 'markdown';
+		$this->format = ( $format === 'html' ) ? 'html' : 'markdown';
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Parser {
 		}
 
 		// Fork for format.
-		if ( 'html' === $this->_format ) {
+		if ( 'html' === $this->format ) {
 			return $this->_parse_html( $html );
 		} else {
 			return $this->_parse_markdown( $html );

--- a/includes/apple-exporter/class-parser.php
+++ b/includes/apple-exporter/class-parser.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Parser class
+ *
+ * Contains a class which is used to parse raw HTML into an Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 1.2.1
+ */
+
+namespace Apple_Exporter;
+
+use DOMDocument;
+use DOMNodeList;
+
+require_once __DIR__ . '/class-html.php';
+require_once __DIR__ . '/class-markdown.php';
+
+/**
+ * A class that parses raw HTML into either Apple News HTML or Markdown format.
+ *
+ * @since 1.2.1
+ */
+class Parser {
+
+	/**
+	 * The format to use. Valid values are 'html' and 'markdown'.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $_format;
+
+	/**
+	 * Initializes the object with the format setting.
+	 *
+	 * @param string $format The format to use. Defaults to markdown.
+	 *
+	 * @access public
+	 */
+	public function __construct( $format = 'markdown' ) {
+		$this->_format = ( $format === 'html' ) ? 'html' : 'markdown';
+	}
+
+	/**
+	 * Transforms raw HTML into Apple News format.
+	 *
+	 * @param string $html The raw HTML to parse.
+	 *
+	 * @access public
+	 * @return string The filtered content in the format specified.
+	 */
+	public function parse( $html ) {
+
+		// Don't parse empty input.
+		if ( empty( $html ) ) {
+			return '';
+		}
+
+		// Fork for format.
+		if ( 'html' === $this->_format ) {
+			return $this->_parse_html( $html );
+		} else {
+			return $this->_parse_markdown( $html );
+		}
+	}
+
+	/**
+	 * A function to format the given HTML as Apple News HTML.
+	 *
+	 * @param string $html The raw HTML to parse.
+	 *
+	 * @access private
+	 * @return string The content, converted to an Apple News HTML string.
+	 */
+	private function _parse_html( $html ) {
+
+		// Apply formatting.
+		$parser = new HTML();
+		$content = $parser->format( $html );
+
+		/**
+		 * Allows for filtering of the formatted content before return.
+		 *
+		 * @since 1.2.1
+		 *
+		 * @param string $content The content to filter.
+		 * @param string $html The original HTML, before filtering was applied.
+		 */
+		return apply_filters( 'apple_news_parse_html', $content, $html );
+	}
+
+	/**
+	 * A function to convert the given HTML into Apple News Markdown.
+	 *
+	 * @param string $html The raw HTML to parse.
+	 *
+	 * @access private
+	 * @return string The content, converted to an Apple News Markdown string.
+	 */
+	private function _parse_markdown( $html ) {
+
+		// PHP's DOMDocument doesn't like HTML5, so we must ignore errors.
+		libxml_use_internal_errors( true );
+
+		// Load the content, forcing the use of UTF-8.
+		$dom = new DOMDocument();
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html );
+
+		// Reset error state.
+		libxml_clear_errors();
+		libxml_use_internal_errors( false );
+
+		// Find the first-level nodes of the body tag.
+		$nodes = $dom->getElementsByTagName( 'body' )->item( 0 )->childNodes;
+
+		// Perform parsing.
+		$parser = new Markdown();
+		$content = $parser->parse_nodes( $nodes );
+
+		/**
+		 * Allows for filtering of the formatted content before return.
+		 *
+		 * @since 1.2.1
+		 *
+		 * @param string $content The content to filter.
+		 * @param DOMNodeList $nodes The list of DOMElement nodes used initially.
+		 */
+		return apply_filters( 'apple_news_parse_markdown', $content, $nodes );
+	}
+}

--- a/includes/apple-exporter/class-parser.php
+++ b/includes/apple-exporter/class-parser.php
@@ -40,7 +40,7 @@ class Parser {
 	 * @access public
 	 */
 	public function __construct( $format = 'markdown' ) {
-		$this->format = ( $format === 'html' ) ? 'html' : 'markdown';
+		$this->format = ( 'html' === $format  ) ? 'html' : 'markdown';
 	}
 
 	/**

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -106,6 +106,12 @@ class Settings {
 		'pullquote_line_height' => 48,
 		'pullquote_tracking' => 0,
 
+		'monospaced_font' => 'Menlo-Regular',
+		'monospaced_size' => 16,
+		'monospaced_color' => '#4f4f4f',
+		'monospaced_line_height' => 20,
+		'monospaced_tracking' => 0,
+
 		'component_alerts' => 'none',
 		'json_alerts' => 'warn',
 

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -111,6 +111,7 @@ class Settings {
 
 		'use_remote_images' => 'no',
 		'full_bleed_images' => 'no',
+		'html_support' => 'no',
 
 		// This can either be gallery or mosaic.
 		'gallery_type' => 'gallery',

--- a/includes/apple-exporter/class-workspace.php
+++ b/includes/apple-exporter/class-workspace.php
@@ -92,7 +92,7 @@ class Workspace {
 		// JSON should be decoded before being stored.
 		// Otherwise, stripslashes_deep could potentially remove valid characters
 		// such as newlines (\n).s
-		$decoded_json = json_decode( sanitize_text_field( $json ) );
+		$decoded_json = json_decode( $json );
 		if ( null === $decoded_json ) {
 			// This is invalid JSON.
 			// Store as an empty string.

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -106,7 +106,7 @@ class Body extends Component {
 	protected function build( $text ) {
 		$this->json = array(
 			'role'   => 'body',
-			'text'   => $this->markdown->parse( $text ),
+			'text'   => $this->parser->parse( $text ),
 			'format' => 'markdown',
 		);
 

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -36,8 +36,8 @@ class Body extends Component {
 	 * @access public
 	 */
 	public static function node_matches( $node ) {
-		// We are only interested in p, ul and ol
-		if ( ! in_array( $node->nodeName, array( 'p', 'ul', 'ol' ) ) ) {
+		// We are only interested in p, pre, ul and ol
+		if ( ! in_array( $node->nodeName, array( 'p', 'pre', 'ul', 'ol' ) ) ) {
 			return null;
 		}
 

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -107,7 +107,7 @@ class Body extends Component {
 		$this->json = array(
 			'role'   => 'body',
 			'text'   => $this->parser->parse( $text ),
-			'format' => 'markdown',
+			'format' => $this->parser->format,
 		);
 
 		if ( 'yes' == $this->get_setting( 'initial_dropcap' ) ) {
@@ -119,6 +119,16 @@ class Body extends Component {
 		}
 
 		$this->set_default_layout();
+	}
+
+	/**
+	 * Whether HTML format is enabled for this component type.
+	 *
+	 * @access protected
+	 * @return bool Whether HTML format is enabled for this component type.
+	 */
+	protected function html_enabled() {
+		return true;
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -3,6 +3,8 @@ namespace Apple_Exporter\Components;
 
 require_once __DIR__ . '/../class-markdown.php';
 
+use Apple_Exporter\Parser;
+
 /**
  * Base component class. All components must inherit from this class and
  * implement its abstract method "build".
@@ -112,6 +114,16 @@ abstract class Component {
 	protected $layouts;
 
 	/**
+	 * The parser to use for this component.
+	 *
+	 * @since 1.2.1
+	 *
+	 * @access protected
+	 * @var Parser
+	 */
+	protected $parser;
+
+	/**
 	 * UID for this component.
 	 *
 	 * @since 0.4.0
@@ -128,16 +140,41 @@ abstract class Component {
 	 * @param Settings $settings
 	 * @param Component_Text_Styles $styles
 	 * @param Component_Layouts $layouts
-	 * @param Markdown $markdown
+	 * @param Parser $parser
 	 */
-	function __construct( $text, $workspace, $settings, $styles, $layouts, $markdown = null ) {
+	function __construct( $text, $workspace, $settings, $styles, $layouts, $parser = null ) {
 		$this->workspace = $workspace;
 		$this->settings  = $settings;
 		$this->styles    = $styles;
 		$this->layouts   = $layouts;
-		$this->markdown  = $markdown ?: new \Apple_Exporter\Markdown();
 		$this->text      = $text;
 		$this->json      = null;
+
+		// Negotiate parser.
+		if ( empty( $parser ) ) {
+
+			// Load format from settings.
+			$format = ( 'yes' === $this->settings->html_support )
+				? 'html'
+				: 'markdown';
+
+			// Force markdown for certain component types.
+			if ( ! function_exists( 'get_called_class' )
+				|| ! in_array(
+					get_called_class(),
+					array(
+						'Body',
+						'Intro',
+					)
+				)
+			) {
+				$format = 'markdown';
+			}
+
+			// Init new parser with the appropriate format.
+			$parser = new Parser( $format );
+		}
+		$this->parser = $parser;
 
 		// Once the text is set, build proper JSON. Store as an array.
 		$this->build( $this->text );

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -158,16 +158,8 @@ abstract class Component {
 				? 'html'
 				: 'markdown';
 
-			// Force markdown for certain component types.
-			if ( ! function_exists( 'get_called_class' )
-				|| ! in_array(
-					get_called_class(),
-					array(
-						'Body',
-						'Intro',
-					)
-				)
-			) {
+			// Only allow HTML if the component supports it.
+			if ( ! $this->html_enabled() ) {
 				$format = 'markdown';
 			}
 
@@ -363,6 +355,18 @@ abstract class Component {
 	 */
 	protected function get_setting( $name ) {
 		return $this->settings->get( $name );
+	}
+
+	/**
+	 * Whether HTML format is enabled for this component type.
+	 *
+	 * This function is intended to be overridden in child classes.
+	 *
+	 * @access protected
+	 * @return bool Whether HTML format is enabled for this component type.
+	 */
+	protected function html_enabled() {
+		return false;
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -78,7 +78,7 @@ class Heading extends Component {
 		$this->json = array(
 			'role'   => 'heading' . $level,
 			'text'   => trim( $this->parser->parse( $text ) ),
-			'format' => 'markdown',
+			'format' => $this->parser->format,
 		);
 
 		$this->set_style( $level );

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -77,7 +77,7 @@ class Heading extends Component {
 
 		$this->json = array(
 			'role'   => 'heading' . $level,
-			'text'   => trim( $this->markdown->parse( $text ) ),
+			'text'   => trim( $this->parser->parse( $text ) ),
 			'format' => 'markdown',
 		);
 

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -54,7 +54,7 @@ class Quote extends Component {
 			'components' => array( array(
 				'role'   => 'quote',
 				'text'   => $this->parser->parse( $text ),
-				'format' => 'markdown',
+				'format' => $this->parser->format,
 				'layout' => 'quote-layout',
 				'textStyle' => 'default-pullquote',
 			) ),

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -53,7 +53,7 @@ class Quote extends Component {
 			),
 			'components' => array( array(
 				'role'   => 'quote',
-				'text'   => $this->markdown->parse( $text ),
+				'text'   => $this->parser->parse( $text ),
 				'format' => 'markdown',
 				'layout' => 'quote-layout',
 				'textStyle' => 'default-pullquote',

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -66,6 +66,43 @@ class Body_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Tests HTML formatting.
+	 *
+	 * @access public
+	 */
+	public function testHTML() {
+
+		// Setup.
+		$this->settings->html_support = 'yes';
+		$html = <<<HTML
+<p>Lorem ipsum. <a href="https://wordpress.org">Dolor sit amet</a>.</p>
+<pre>
+	Preformatted text.
+</pre>
+<p>Testing a <code>code sample</code>.</p>
+HTML;
+		$component = new Body(
+			$html,
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test.
+		$this->assertEquals(
+			array(
+				'text' => $html,
+				'role' => 'body',
+				'format' => 'html',
+				'textStyle' => 'dropcapBodyStyle',
+				'layout' => 'body-layout',
+			),
+			$component->to_array()
+		);
+	}
+
+	/**
 	 * Tests body settings.
 	 *
 	 * @access public


### PR DESCRIPTION
* Adds HTML support option in the Settings area.
* Adds HTML support to Body elements if enabled in Settings.
* Adds a new Parser class to handle the split between Markdown and HTML.
* Refactors the Markdown class to conform to WordPress and PHP best practices.
* Expands definition of Body elements to include `<pre>` tags.
* Adds settings for monospaced font display.
* Adds global styles for monospaced fonts if HTML is enabled.
* Adds tests for HTML in Body elements.

Fixes #222.
Fixes #232.