### PR TITLE
AN-53 Legacy header settings fix

### DIFF
--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -88,6 +88,14 @@ class Apple_News {
 	 */
 	public function migrate_header_settings( $wp_settings ) {
 
+		// Check for presence of any legacy header setting.
+		if ( empty( $wp_settings['header_font'] )
+			&& empty( $wp_settings['header_color'] )
+			&& empty( $wp_settings['header_line_height'] )
+		) {
+			return $wp_settings;
+		}
+
 		// Check for presence of legacy font setting.
 		if ( ! empty( $wp_settings['header_font'] ) ) {
 			$wp_settings['header1_font'] = $wp_settings['header_font'];
@@ -96,6 +104,7 @@ class Apple_News {
 			$wp_settings['header4_font'] = $wp_settings['header_font'];
 			$wp_settings['header5_font'] = $wp_settings['header_font'];
 			$wp_settings['header6_font'] = $wp_settings['header_font'];
+			unset( $wp_settings['header_font'] );
 		}
 
 		// Check for presence of legacy color setting.
@@ -106,6 +115,7 @@ class Apple_News {
 			$wp_settings['header4_color'] = $wp_settings['header_color'];
 			$wp_settings['header5_color'] = $wp_settings['header_color'];
 			$wp_settings['header6_color'] = $wp_settings['header_color'];
+			unset( $wp_settings['header_color'] );
 		}
 
 		// Check for presence of legacy line height setting.
@@ -116,7 +126,11 @@ class Apple_News {
 			$wp_settings['header4_line_height'] = $wp_settings['header_line_height'];
 			$wp_settings['header5_line_height'] = $wp_settings['header_line_height'];
 			$wp_settings['header6_line_height'] = $wp_settings['header_line_height'];
+			unset( $wp_settings['header_line_height'] );
 		}
+
+		// Store the updated option to remove the legacy setting names.
+		update_option( self::$option_name, $wp_settings, 'no' );
 
 		return $wp_settings;
 	}

--- a/tests/apple-exporter/components/test-class-heading.php
+++ b/tests/apple-exporter/components/test-class-heading.php
@@ -352,6 +352,58 @@ class Heading_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Tests the function to migrate legacy header settings.
+	 *
+	 * @see Apple_News::migrate_header_settings()
+	 *
+	 * @access public
+	 */
+	public function testSettingsMigration() {
+
+		// Test with default settings.
+		$this->assertEmpty( $this->settings->header_color );
+		$this->assertEmpty( $this->settings->header_font );
+		$this->assertEmpty( $this->settings->header_line_height );
+
+		// Set legacy settings to test migration.
+		$wp_settings = array(
+			'header_color' => '#abcdef',
+			'header_font' => 'TestFont',
+			'header_line_height' => 128,
+		);
+		update_option( Apple_News::$option_name, $wp_settings );
+
+		// Run legacy settings through migrate script.
+		$admin_settings = new Admin_Apple_Settings();
+		$settings = $admin_settings->fetch_settings();
+
+		// Ensure legacy settings have been stripped.
+		$this->assertEmpty( $this->settings->header_color );
+		$this->assertEmpty( $this->settings->header_font );
+		$this->assertEmpty( $this->settings->header_line_height );
+
+		// Ensure legacy settings were applied to new values.
+		$this->assertEquals( '#abcdef', $settings->header1_color );
+		$this->assertEquals( '#abcdef', $settings->header2_color );
+		$this->assertEquals( '#abcdef', $settings->header3_color );
+		$this->assertEquals( '#abcdef', $settings->header4_color );
+		$this->assertEquals( '#abcdef', $settings->header5_color );
+		$this->assertEquals( '#abcdef', $settings->header6_color );
+		$this->assertEquals( 'TestFont', $settings->header1_font );
+		$this->assertEquals( 'TestFont', $settings->header2_font );
+		$this->assertEquals( 'TestFont', $settings->header3_font );
+		$this->assertEquals( 'TestFont', $settings->header4_font );
+		$this->assertEquals( 'TestFont', $settings->header5_font );
+		$this->assertEquals( 'TestFont', $settings->header6_font );
+		$this->assertEquals( 128, $settings->header1_line_height );
+		$this->assertEquals( 128, $settings->header2_line_height );
+		$this->assertEquals( 128, $settings->header3_line_height );
+		$this->assertEquals( 128, $settings->header4_line_height );
+		$this->assertEquals( 128, $settings->header5_line_height );
+		$this->assertEquals( 128, $settings->header6_line_height );
+	}
+
+	/**
 	 * Ensures that headings are produced from heading tags.
 	 *
 	 * @access public


### PR DESCRIPTION
* Fixes a bug in which the legacy header settings get stuck in options and are not removed.
* Adds test coverage for the legacy header settings migration function.