### PR TITLE
AN-59 Split pullquote and blockquote styling

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -311,6 +311,44 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'label' => __( 'Pull quote transformation', 'apple-news' ),
 				'type' => array( 'none', 'uppercase' ),
 			),
+			'blockquote_font' => array(
+				'label' => __( 'Blockquote font face', 'apple-news' ),
+				'type' => 'font',
+			),
+			'blockquote_size' => array(
+				'label' => __( 'Blockquote font size', 'apple-news' ),
+				'type' => 'integer',
+			),
+			'blockquote_color' => array(
+				'label' => __( 'Blockquote color', 'apple-news' ),
+				'type' => 'color',
+			),
+			'blockquote_border_color' => array(
+				'label' => __( 'Blockquote border color', 'apple-news' ),
+				'type' => 'color',
+			),
+			'blockquote_border_style' => array(
+				'label' => __( 'Blockquote border style', 'apple-news' ),
+				'type' => array( 'solid', 'dashed', 'dotted' ),
+			),
+			'blockquote_border_width' => array(
+				'label' => __( 'Blockquote border width', 'apple-news' ),
+				'type' => 'integer',
+			),
+			'blockquote_line_height' => array(
+				'label' => __( 'Blockquote line height', 'apple-news' ),
+				'type' => 'float',
+				'sanitize' => 'floatval',
+			),
+			'blockquote_tracking' => array(
+				'label' => __( 'Blockquote tracking', 'apple-news' ),
+				'type' => 'integer',
+				'description' => __( '(Percentage of font size)', 'apple-news' ),
+			),
+			'blockquote_background_color' => array(
+				'label' => __( 'Blockquote background color', 'apple-news' ),
+				'type' => 'color',
+			),
 			'monospaced_font' => array(
 				'label' => __( 'Monospaced font face', 'apple-news' ),
 				'type' => 'font',
@@ -489,6 +527,20 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 					'pullquote_transform'
 				),
 			),
+			'blockquote' => array(
+				'label' => __( 'Blockquote', 'apple-news' ),
+				'settings' => array(
+					'blockquote_font',
+					'blockquote_size',
+					'blockquote_line_height',
+					'blockquote_tracking',
+					'blockquote_color',
+					'blockquote_border_color',
+					'blockquote_border_style',
+					'blockquote_border_width',
+					'blockquote_background_color',
+				),
+			),
 			'monospaced' => array(
 				'label' => __( 'Monospaced (<pre>, <code>, <samp>)', 'apple-news' ),
 				'settings' => array(
@@ -599,8 +651,9 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				<p>Maecenas tortor dui, pellentesque ac ullamcorper quis, malesuada sit amet turpis. Nunc in tellus et justo dapibus sollicitudin.</p>
 				<h2>Quisque efficitur</h2>
 				<p>Quisque efficitur sit amet ex et venenatis. Morbi nisi nisi, ornare id iaculis eget, pulvinar ac dolor.</p>
+                <blockquote>Blockquote lorem ipsum dolor sit amet, efficitur sit amet aliquet id, aliquam placerat turpis.</blockquote>
 				<p>In eu la	cus porttitor, pellentesque diam et, tristique elit. Mauris justo odio, efficitur sit amet aliquet id, aliquam placerat turpis.</p>
-				<div class="apple-news-pull-quote">Lorem ipsum dolor sit amet.</div>
+				<div class="apple-news-pull-quote">Pull quote lorem ipsum dolor sit amet.</div>
 				<p>Sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Pellentesque ipsum mi, sagittis eget sodales et, volutpat at felis.</p>
                 <pre>
 .code-sample {

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -153,7 +153,7 @@ ul#meta-component-order-sort li:hover {
 
 .apple-news-settings-preview blockquote {
 	margin: 0 0 1.5em;
-	padding: 1em;
+	padding: 12px 10px;
 }
 
 .apple-news-byline.title-cover-byline,

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -151,6 +151,11 @@ ul#meta-component-order-sort li:hover {
 	margin-bottom: 30px;
 }
 
+.apple-news-settings-preview blockquote {
+	margin: 0 0 1.5em;
+	padding: 1em;
+}
+
 .apple-news-byline.title-cover-byline,
 .apple-news-byline.byline-title-cover,
 .apple-news-byline.byline-cover-title,

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -207,6 +207,17 @@
 		appleNewsSetCSS( '.apple-news-settings-preview div.apple-news-pull-quote', 'pullquote_border_width', 'border-bottom-width', 'px', null );
 		appleNewsSetCSS( '.apple-news-settings-preview div.apple-news-pull-quote', 'pullquote_line_height', 'line-height', 'px', .75 );
 
+		// Blockquote
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_font', 'font-family', null, null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_size', 'font-size', 'px', null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_tracking', 'letter-spacing', 'px', $( '#blockquote_size' ).val() / 100 );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_color', 'color', null, null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_border_color', 'border-left-color', null, null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_border_style', 'border-left-style', null, null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_border_width', 'border-left-width', 'px', null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_line_height', 'line-height', 'px', null );
+		appleNewsSetCSS( '.apple-news-settings-preview blockquote', 'blockquote_background_color', 'background-color', null, null );
+
 		// Monospaced
 		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_font', 'font-family', null, null );
 		appleNewsSetCSS( '.apple-news-settings-preview pre', 'monospaced_size', 'font-size', 'px', null );

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -110,7 +110,7 @@ class Components extends Builder {
 		// Build a new component and set the anchor position to AUTO.
 		$component = $this->_get_component_from_shortname(
 			'blockquote',
-			'<blockquote>' . $pullquote . '</blockquote>'
+			'<blockquote class="pullquote">' . $pullquote . '</blockquote>'
 		);
 		$component->set_anchor_position( Component::ANCHOR_AUTO );
 

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -110,7 +110,7 @@ class Components extends Builder {
 		// Build a new component and set the anchor position to AUTO.
 		$component = $this->_get_component_from_shortname(
 			'blockquote',
-			'<blockquote class="pullquote">' . $pullquote . '</blockquote>'
+			'<blockquote class="apple-news-pullquote">' . $pullquote . '</blockquote>'
 		);
 		$component->set_anchor_position( Component::ANCHOR_AUTO );
 

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -114,6 +114,16 @@ class Settings {
 		'pullquote_line_height' => 48,
 		'pullquote_tracking' => 0,
 
+		'blockquote_font' => 'AvenirNext-Regular',
+		'blockquote_size' => 18,
+		'blockquote_color' => '#4f4f4f',
+		'blockquote_border_color' => '#4f4f4f',
+		'blockquote_border_style' => 'solid',
+		'blockquote_border_width' => '3',
+		'blockquote_line_height' => 24,
+		'blockquote_tracking' => 0,
+		'blockquote_background_color' => '#e1e1e1',
+
 		'monospaced_font' => 'Menlo-Regular',
 		'monospaced_size' => 16,
 		'monospaced_color' => '#4f4f4f',

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -46,13 +46,11 @@ class Quote extends Component {
 		$text = $matches[1];
 
 		// Split for pullquote vs. blockquote.
-		if ( 0 === strpos( $html, '<blockquote class="pullquote">' ) ) {
+		if ( 0 === strpos( $html, '<blockquote class="apple-news-pullquote">' ) ) {
 			$this->_build_pullquote( $text );
 		} else {
 			$this->_build_blockquote( $text );
 		}
-
-
 	}
 
 	/**
@@ -68,16 +66,24 @@ class Quote extends Component {
 		$this->json = array(
 			'role' => 'container',
 			'layout' => array(
-				'columnStart' => 3,
-				'columnSpan' => 4
+				'columnStart' => $this->get_setting( 'body_offset' ),
+				'columnSpan' => $this->get_setting( 'body_column_span' ),
+				'margin' => array(
+					'bottom' => $this->get_setting( 'layout_gutter' ),
+					'top' => $this->get_setting( 'layout_gutter' ),
+				),
 			),
 			'style' => array(
+				'backgroundColor' => $this->get_setting( 'blockquote_background_color' ),
 				'border' => array (
-					'left' => array (
+					'all' => array (
 						'width' => $this->get_setting( 'blockquote_border_width' ),
 						'style' => $this->get_setting( 'blockquote_border_style' ),
 						'color' => $this->get_setting( 'blockquote_border_color' ),
 					),
+					'bottom' => false,
+					'right' => false,
+					'top' => false,
 				),
 			),
 			'components' => array(
@@ -85,16 +91,15 @@ class Quote extends Component {
 					'role' => 'quote',
 					'text' => $this->parser->parse( $text ),
 					'format' => $this->parser->format,
-					'layout' => 'quote-layout',
+					'layout' => 'blockquote-layout',
 					'textStyle' => 'default-blockquote',
 				)
 			),
 		);
 
 		// Set component attributes.
+		$this->_set_blockquote_layout();
 		$this->_set_blockquote_style();
-		$this->_set_layout();
-		$this->_set_blockquote_anchor();
 	}
 
 	/**
@@ -129,31 +134,34 @@ class Quote extends Component {
 					'role' => 'quote',
 					'text' => $this->parser->parse( $text ),
 					'format' => $this->parser->format,
-					'layout' => 'quote-layout',
+					'layout' => 'pullquote-layout',
 					'textStyle' => 'default-pullquote',
 				)
 			),
 		);
 
 		// Set component attributes.
-		$this->_set_pullquote_style();
-		$this->_set_layout();
 		$this->_set_pullquote_anchor();
+		$this->_set_pullquote_layout();
+		$this->_set_pullquote_style();
 	}
 
 	/**
-	 * Sets the anchor settings for a blockquote.
+	 * Set the layout for a blockquote.
 	 *
 	 * @access private
 	 */
-	private function _set_blockquote_anchor() {
-		$this->set_anchor_position( Component::ANCHOR_AUTO );
-		$this->json['anchor'] = array(
-			'targetComponentIdentifier' => 'blockquoteAnchor',
-			'originAnchorPosition' => 'top',
-			'targetAnchorPosition' => 'top',
-			'rangeStart' => 0,
-			'rangeLength' => 10,
+	private function _set_blockquote_layout() {
+		$this->register_layout(
+			'blockquote-layout',
+			array(
+				'contentInset' => array(
+					'bottom' => true,
+					'left' => true,
+					'right' => true,
+					'top' => true,
+				),
+			)
 		);
 	}
 
@@ -178,23 +186,6 @@ class Quote extends Component {
 	}
 
 	/**
-	 * Set the layout for the component.
-	 *
-	 * @access private
-	 */
-	private function _set_layout() {
-		$this->register_layout(
-			'quote-layout',
-			array(
-				'margin' => array(
-					'top' => 12,
-					'bottom' => 12,
-				),
-			)
-		);
-	}
-
-	/**
 	 * Sets the anchor settings for a pullquote.
 	 *
 	 * @access private
@@ -207,6 +198,23 @@ class Quote extends Component {
 			'targetAnchorPosition' => 'top',
 			'rangeStart' => 0,
 			'rangeLength' => 10,
+		);
+	}
+
+	/**
+	 * Set the layout for a pullquote.
+	 *
+	 * @access private
+	 */
+	private function _set_pullquote_layout() {
+		$this->register_layout(
+			'pullquote-layout',
+			array(
+				'margin' => array(
+					'top' => 12,
+					'bottom' => 12,
+				),
+			)
 		);
 	}
 

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -1,8 +1,20 @@
 <?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Components\Quote class
+ *
+ * Contains a class which is used to transform blockquotes into Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
+
 namespace Apple_Exporter\Components;
 
+use \DOMElement;
+
 /**
- * An HTML's blockquote representation.
+ * A class which is used to transform blockquotes into Apple News format.
  *
  * @since 0.2.0
  */
@@ -11,29 +23,60 @@ class Quote extends Component {
 	/**
 	 * Look for node matches for this component.
 	 *
-	 * @param DomNode $node
-	 * @return mixed
-	 * @static
+	 * @param DOMElement $node The node to examine.
+	 *
 	 * @access public
+	 * @return DOMElement|null The DOMElement on match, false on no match.
 	 */
 	public static function node_matches( $node ) {
-		if ( 'blockquote' == $node->nodeName ) {
-			return $node;
-		}
-
-		return null;
+		return ( 'blockquote' === $node->nodeName ) ? $node : null;
 	}
 
 	/**
 	 * Build the component.
 	 *
-	 * @param string $text
+	 * @param string $html The HTML to parse into text for processing.
+	 *
 	 * @access protected
 	 */
-	protected function build( $text ) {
-		preg_match( '#<blockquote.*?>(.*?)</blockquote>#si', $text, $matches );
+	protected function build( $html ) {
+
+		// Extract text from blockquote HTML.
+		preg_match( '#<blockquote.*?>(.*?)</blockquote>#si', $html, $matches );
 		$text = $matches[1];
 
+		// Split for pullquote vs. blockquote.
+		if ( 0 === strpos( $html, '<blockquote class="pullquote">' ) ) {
+			$this->_build_pullquote( $text );
+		} else {
+			$this->_build_blockquote( $text );
+		}
+
+
+	}
+
+	/**
+	 * Runs the build operation for a blockquote.
+	 *
+	 * @param string $text The text to use when building the blockquote.
+	 *
+	 * @access private
+	 */
+	private function _build_blockquote( $text ) {
+
+		// TODO: WIRE THIS UP
+	}
+
+	/**
+	 * Runs the build operation for a pullquote.
+	 *
+	 * @param string $text The text to use when building the pullquote.
+	 *
+	 * @access private
+	 */
+	private function _build_pullquote( $text ) {
+
+		// Set JSON for this element.
 		$this->json = array(
 			'role' => 'container',
 			'layout' => array(
@@ -51,50 +94,21 @@ class Quote extends Component {
 					'right' => false,
 				),
 			),
-			'components' => array( array(
-				'role'   => 'quote',
-				'text'   => $this->parser->parse( $text ),
-				'format' => $this->parser->format,
-				'layout' => 'quote-layout',
-				'textStyle' => 'default-pullquote',
-			) ),
+			'components' => array(
+				array(
+					'role' => 'quote',
+					'text' => $this->parser->parse( $text ),
+					'format' => $this->parser->format,
+					'layout' => 'quote-layout',
+					'textStyle' => 'default-pullquote',
+				)
+			),
 		);
 
-		$this->set_style();
-		$this->set_layout();
-		$this->set_anchor();
-	}
-
-	/**
-	 * Set the layout for the component.
-	 *
-	 * @access private
-	 */
-	private function set_layout() {
-		$this->register_layout( 'quote-layout', array(
-			'margin' => array(
-				'top' => 12,
-				'bottom' => 12,
-			),
-		) );
-	}
-
-	/**
-	 * Set the style for the component.
-	 *
-	 * @access private
-	 */
-	private function set_style() {
-		$this->json['textStyle'] = 'default-pullquote';
-		$this->register_style( 'default-pullquote', array(
-			'fontName' => $this->get_setting( 'pullquote_font' ),
-			'fontSize' => intval( $this->get_setting( 'pullquote_size' ) ),
-			'textColor' => $this->get_setting( 'pullquote_color' ),
-			'textTransform' => $this->get_setting( 'pullquote_transform' ),
-			'lineHeight' => intval( $this->get_setting( 'pullquote_line_height' ) ),
-			'textAlignment' => $this->find_text_alignment(),
-			'tracking' => intval( $this->get_setting( 'pullquote_tracking' ) ) / 100,
-		) );
+		// Set component attributes.
+		$this->_set_pullquote_style();
+		$this->_set_pullquote_layout();
+		$this->_set_pullquote_anchor();
 	}
 
 	/**
@@ -102,9 +116,8 @@ class Quote extends Component {
 	 *
 	 * @access private
 	 */
-	private function set_anchor() {
+	private function _set_pullquote_anchor() {
 		$this->set_anchor_position( Component::ANCHOR_AUTO );
-
 		$this->json['anchor'] = array(
 			'targetComponentIdentifier' => 'pullquoteAnchor',
 			'originAnchorPosition' => 'top',
@@ -114,5 +127,41 @@ class Quote extends Component {
 		);
 	}
 
-}
+	/**
+	 * Set the layout for the component.
+	 *
+	 * @access private
+	 */
+	private function _set_pullquote_layout() {
+		$this->register_layout(
+			'quote-layout',
+			array(
+				'margin' => array(
+					'top' => 12,
+					'bottom' => 12,
+				),
+			)
+		);
+	}
 
+	/**
+	 * Set the style for the component.
+	 *
+	 * @access private
+	 */
+	private function _set_pullquote_style() {
+		$this->json['textStyle'] = 'default-pullquote';
+		$this->register_style(
+			'default-pullquote',
+			array(
+				'fontName' => $this->get_setting( 'pullquote_font' ),
+				'fontSize' => intval( $this->get_setting( 'pullquote_size' ) ),
+				'textColor' => $this->get_setting( 'pullquote_color' ),
+				'textTransform' => $this->get_setting( 'pullquote_transform' ),
+				'lineHeight' => intval( $this->get_setting( 'pullquote_line_height' ) ),
+				'textAlignment' => $this->find_text_alignment(),
+				'tracking' => intval( $this->get_setting( 'pullquote_tracking' ) ) / 100,
+			)
+		);
+	}
+}

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -64,7 +64,37 @@ class Quote extends Component {
 	 */
 	private function _build_blockquote( $text ) {
 
-		// TODO: WIRE THIS UP
+		// Set JSON for this element.
+		$this->json = array(
+			'role' => 'container',
+			'layout' => array(
+				'columnStart' => 3,
+				'columnSpan' => 4
+			),
+			'style' => array(
+				'border' => array (
+					'left' => array (
+						'width' => $this->get_setting( 'blockquote_border_width' ),
+						'style' => $this->get_setting( 'blockquote_border_style' ),
+						'color' => $this->get_setting( 'blockquote_border_color' ),
+					),
+				),
+			),
+			'components' => array(
+				array(
+					'role' => 'quote',
+					'text' => $this->parser->parse( $text ),
+					'format' => $this->parser->format,
+					'layout' => 'quote-layout',
+					'textStyle' => 'default-blockquote',
+				)
+			),
+		);
+
+		// Set component attributes.
+		$this->_set_blockquote_style();
+		$this->_set_layout();
+		$this->_set_blockquote_anchor();
 	}
 
 	/**
@@ -107,12 +137,65 @@ class Quote extends Component {
 
 		// Set component attributes.
 		$this->_set_pullquote_style();
-		$this->_set_pullquote_layout();
+		$this->_set_layout();
 		$this->_set_pullquote_anchor();
 	}
 
 	/**
-	 * Sets the anchor settings for this component.
+	 * Sets the anchor settings for a blockquote.
+	 *
+	 * @access private
+	 */
+	private function _set_blockquote_anchor() {
+		$this->set_anchor_position( Component::ANCHOR_AUTO );
+		$this->json['anchor'] = array(
+			'targetComponentIdentifier' => 'blockquoteAnchor',
+			'originAnchorPosition' => 'top',
+			'targetAnchorPosition' => 'top',
+			'rangeStart' => 0,
+			'rangeLength' => 10,
+		);
+	}
+
+	/**
+	 * Set the style for a blockquote.
+	 *
+	 * @access private
+	 */
+	private function _set_blockquote_style() {
+		$this->json['textStyle'] = 'default-blockquote';
+		$this->register_style(
+			'default-blockquote',
+			array(
+				'fontName' => $this->get_setting( 'blockquote_font' ),
+				'fontSize' => intval( $this->get_setting( 'blockquote_size' ) ),
+				'textColor' => $this->get_setting( 'blockquote_color' ),
+				'lineHeight' => intval( $this->get_setting( 'blockquote_line_height' ) ),
+				'textAlignment' => $this->find_text_alignment(),
+				'tracking' => intval( $this->get_setting( 'blockquote_tracking' ) ) / 100,
+			)
+		);
+	}
+
+	/**
+	 * Set the layout for the component.
+	 *
+	 * @access private
+	 */
+	private function _set_layout() {
+		$this->register_layout(
+			'quote-layout',
+			array(
+				'margin' => array(
+					'top' => 12,
+					'bottom' => 12,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Sets the anchor settings for a pullquote.
 	 *
 	 * @access private
 	 */
@@ -128,24 +211,7 @@ class Quote extends Component {
 	}
 
 	/**
-	 * Set the layout for the component.
-	 *
-	 * @access private
-	 */
-	private function _set_pullquote_layout() {
-		$this->register_layout(
-			'quote-layout',
-			array(
-				'margin' => array(
-					'top' => 12,
-					'bottom' => 12,
-				),
-			)
-		);
-	}
-
-	/**
-	 * Set the style for the component.
+	 * Set the style for a pullquote.
 	 *
 	 * @access private
 	 */

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -137,15 +137,93 @@ class Apple_News {
 	 * @return array The modified settings array.
 	 */
 	public function migrate_api_settings( $wp_settings ) {
+
 		// Use the value of api_autosync_update for api_autosync_delete if not set
 		// since that was the previous value used to determine this behavior.
 		if ( empty( $wp_settings['api_autosync_delete'] )
 		     && ! empty( $wp_settings['api_autosync_update'] )
 		) {
-
 			$wp_settings['api_autosync_delete'] = $wp_settings['api_autosync_update'];
 			update_option( self::$option_name, $wp_settings, 'no' );
 		}
+
+		return $wp_settings;
+	}
+
+	/**
+	 * Migrate legacy blockquote settings to new format.
+	 *
+	 * @param array $wp_settings An array of settings loaded from WP options.
+	 *
+	 * @access public
+	 * @return array The modified settings array.
+	 */
+	public function migrate_blockquote_settings( $wp_settings ) {
+
+		// Check for the presence of blockquote-specific settings.
+		if ( $this->_all_keys_exist( $wp_settings, array(
+			'blockquote_background_color',
+			'blockquote_border_color',
+			'blockquote_border_style',
+			'blockquote_border_width',
+			'blockquote_color',
+			'blockquote_font',
+			'blockquote_line_height',
+			'blockquote_size',
+			'blockquote_tracking',
+		) ) ) {
+			return $wp_settings;
+		}
+
+		// Set the background color to 90% of the body background.
+		if ( ! isset( $wp_settings['blockquote_background_color'] )
+		     && isset( $wp_settings['body_background_color'] )
+		) {
+
+			// Get current octets.
+			if ( 7 === strlen( $wp_settings['body_background_color'] ) ) {
+				$r = hexdec( substr( $wp_settings['body_background_color'], 1, 2 ) );
+				$g = hexdec( substr( $wp_settings['body_background_color'], 3, 2 ) );
+				$b = hexdec( substr( $wp_settings['body_background_color'], 5, 2 ) );
+			} elseif ( 4 === strlen( $wp_settings['body_background_color'] ) ) {
+				$r = substr( $wp_settings['body_background_color'], 1, 1 );
+				$g = substr( $wp_settings['body_background_color'], 2, 1 );
+				$b = substr( $wp_settings['body_background_color'], 3, 1 );
+				$r = hexdec( $r . $r );
+				$g = hexdec( $g . $g );
+				$b = hexdec( $b . $b );
+			} else {
+				$r = 250;
+				$g = 250;
+				$b = 250;
+			}
+
+			// Darken by 10% and recompile back into a hex string.
+			$wp_settings['blockquote_background_color'] = sprintf(
+				'#%s%s%s',
+				dechex( $r * .9 ),
+				dechex( $g * .9 ),
+				dechex( $b * .9 )
+			);
+		}
+
+		// Clone settings, as necessary.
+		$wp_settings = $this->_clone_settings(
+			$wp_settings,
+			array(
+				'blockquote_border_color' => 'pullquote_border_color',
+				'blockquote_border_style' => 'pullquote_border_style',
+				'blockquote_border_width' => 'pullquote_border_width',
+				'blockquote_color' => 'body_color',
+				'blockquote_font' => 'body_font',
+				'blockquote_line_height' => 'body_line_height',
+				'blockquote_size' => 'body_size',
+				'blockquote_tracking' => 'body_tracking',
+			)
+		);
+
+		// Store the updated option to save the new setting names.
+		update_option( self::$option_name, $wp_settings, 'no' );
 
 		return $wp_settings;
 	}
@@ -161,31 +239,33 @@ class Apple_News {
 	public function migrate_caption_settings( $wp_settings ) {
 
 		// Check for the presence of caption-specific settings.
-		if ( isset( $wp_settings['caption_color'] )
-		     && isset( $wp_settings['caption_font'] )
-		     && isset( $wp_settings['caption_line_height'] )
-		     && isset( $wp_settings['caption_size'] )
-		     && isset( $wp_settings['caption_tracking'] )
-		) {
+		if ( $this->_all_keys_exist( $wp_settings, array(
+			'caption_color',
+			'caption_font',
+			'caption_line_height',
+			'caption_size',
+			'caption_tracking',
+		) ) ) {
 			return $wp_settings;
 		}
 
-		// Migrate settings, as necessary.
-		$settings = array( 'color', 'font', 'line_height', 'size', 'tracking' );
-		foreach ( $settings as $setting ) {
-			$body_setting = 'body_' . $setting;
-			$caption_setting = 'caption_' . $setting;
-			if ( ! isset( $wp_settings[ $caption_setting ] )
-			     && isset( $wp_settings[ $body_setting ] )
-			) {
-				$wp_settings[ $caption_setting ] = $wp_settings[ $body_setting ];
-
-				// Adjust font size down by 2 to match legacy handling.
-				if ( 'size' === $setting ) {
-					$wp_settings[ $caption_setting ] -= 2;
-				}
-			}
+		// Clone and modify font size, if necessary.
+		if ( ! isset( $wp_settings['caption_size'] )
+		     && isset( $wp_settings['body_size'] )
+		) {
+			$wp_settings['caption_size'] = $wp_settings['body_size'] - 2;
 		}
+
+		// Clone settings, as necessary.
+		$wp_settings = $this->_clone_settings(
+			$wp_settings,
+			array(
+				'caption_color' => 'body_color',
+				'caption_font' => 'body_font',
+				'caption_line_height' => 'body_line_height',
+				'caption_tracking' => 'body_tracking',
+			)
+		);
 
 		// Store the updated option to save the new setting names.
 		update_option( self::$option_name, $wp_settings, 'no' );
@@ -211,38 +291,32 @@ class Apple_News {
 			return $wp_settings;
 		}
 
-		// Check for presence of legacy font setting.
-		if ( ! empty( $wp_settings['header_font'] ) ) {
-			$wp_settings['header1_font'] = $wp_settings['header_font'];
-			$wp_settings['header2_font'] = $wp_settings['header_font'];
-			$wp_settings['header3_font'] = $wp_settings['header_font'];
-			$wp_settings['header4_font'] = $wp_settings['header_font'];
-			$wp_settings['header5_font'] = $wp_settings['header_font'];
-			$wp_settings['header6_font'] = $wp_settings['header_font'];
-			unset( $wp_settings['header_font'] );
-		}
+		// Clone settings, as necessary.
+		$wp_settings = $this->_clone_settings( $wp_settings, array(
+			'header1_color' => 'header_color',
+			'header2_color' => 'header_color',
+			'header3_color' => 'header_color',
+			'header4_color' => 'header_color',
+			'header5_color' => 'header_color',
+			'header6_color' => 'header_color',
+			'header1_font' => 'header_font',
+			'header2_font' => 'header_font',
+			'header3_font' => 'header_font',
+			'header4_font' => 'header_font',
+			'header5_font' => 'header_font',
+			'header6_font' => 'header_font',
+			'header1_line_height' => 'header_line_height',
+			'header2_line_height' => 'header_line_height',
+			'header3_line_height' => 'header_line_height',
+			'header4_line_height' => 'header_line_height',
+			'header5_line_height' => 'header_line_height',
+			'header6_line_height' => 'header_line_height',
+		) );
 
-		// Check for presence of legacy color setting.
-		if ( ! empty( $wp_settings['header_color'] ) ) {
-			$wp_settings['header1_color'] = $wp_settings['header_color'];
-			$wp_settings['header2_color'] = $wp_settings['header_color'];
-			$wp_settings['header3_color'] = $wp_settings['header_color'];
-			$wp_settings['header4_color'] = $wp_settings['header_color'];
-			$wp_settings['header5_color'] = $wp_settings['header_color'];
-			$wp_settings['header6_color'] = $wp_settings['header_color'];
-			unset( $wp_settings['header_color'] );
-		}
-
-		// Check for presence of legacy line height setting.
-		if ( ! empty( $wp_settings['header_line_height'] ) ) {
-			$wp_settings['header1_line_height'] = $wp_settings['header_line_height'];
-			$wp_settings['header2_line_height'] = $wp_settings['header_line_height'];
-			$wp_settings['header3_line_height'] = $wp_settings['header_line_height'];
-			$wp_settings['header4_line_height'] = $wp_settings['header_line_height'];
-			$wp_settings['header5_line_height'] = $wp_settings['header_line_height'];
-			$wp_settings['header6_line_height'] = $wp_settings['header_line_height'];
-			unset( $wp_settings['header_line_height'] );
-		}
+		// Remove legacy settings.
+		unset( $wp_settings['header_color'] );
+		unset( $wp_settings['header_font'] );
+		unset( $wp_settings['header_line_height'] );
 
 		// Store the updated option to remove the legacy setting names.
 		update_option( self::$option_name, $wp_settings, 'no' );
@@ -315,6 +389,49 @@ class Apple_News {
 
 		// Ensure caption settings are set properly.
 		$wp_settings = $this->migrate_caption_settings( $wp_settings );
+
+		return $wp_settings;
+	}
+
+	/**
+	 * Verifies that the list of keys provided all exist in the settings array.
+	 *
+	 * @param array $compare The array to compare against the list of keys.
+	 * @param array $keys The keys to check.
+	 *
+	 * @access private
+	 * @return bool True if all keys exist in the array, false if not.
+	 */
+	private function _all_keys_exist( $compare, $keys ) {
+		return ( count( $keys ) === count(
+			array_intersect_key( $compare, array_combine( $keys, $keys ) ) )
+		);
+	}
+
+	/**
+	 * A generic function to assist with splitting settings for new functionality.
+	 *
+	 * Accepts an array of settings and a settings map to clone settings from one
+	 * key to another.
+	 *
+	 * @param array $wp_settings An array of settings to modify.
+	 * @param array $settings_map A settings map in the format $to => $from.
+	 *   Example:
+	 *   $settings_map = array(
+	 *       'blockquote_color' => 'pullquote_color',
+	 *   );
+	 *
+	 * @access private
+	 * @return array The modified settings array.
+	 */
+	private function _clone_settings( $wp_settings, $settings_map ) {
+
+		// Loop over each setting in the map and clone if conditions are favorable.
+		foreach ( $settings_map as $to => $from ) {
+			if ( ! isset( $wp_settings[ $to ] ) && isset( $wp_settings[ $from ] ) ) {
+				$wp_settings[ $to ] = $wp_settings[ $from ];
+			}
+		}
 
 		return $wp_settings;
 	}

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -252,6 +252,7 @@ class Apple_News {
 		// Clone and modify font size, if necessary.
 		if ( ! isset( $wp_settings['caption_size'] )
 		     && isset( $wp_settings['body_size'] )
+		     && is_numeric( $wp_settings['body_size'] )
 		) {
 			$wp_settings['caption_size'] = $wp_settings['body_size'] - 2;
 		}

--- a/tests/apple-exporter/components/test-class-quote.php
+++ b/tests/apple-exporter/components/test-class-quote.php
@@ -69,13 +69,13 @@ class Quote_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testSettings() {
+	public function testSettingsPullquote() {
 
 		// Setup.
 		$content = new Exporter_Content(
 			3,
 			'Title',
-			'<blockquote><p>my quote</p></blockquote>'
+			'<blockquote class="apple-news-pullquote"><p>my quote</p></blockquote>'
 		);
 
 		// Set quote settings.
@@ -122,11 +122,11 @@ class Quote_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testTransform() {
+	public function testTransformPullquote() {
 
 		// Setup.
 		$component = new Quote(
-			'<blockquote><p>my quote</p></blockquote>',
+			'<blockquote class="apple-news-pullquote"><p>my quote</p></blockquote>',
 			null,
 			$this->settings,
 			$this->styles,
@@ -141,6 +141,6 @@ class Quote_Test extends Component_TestCase {
 		$this->assertEquals( "my quote\n\n", $result['text'] );
 		$this->assertEquals( 'markdown', $result['format'] );
 		$this->assertEquals( 'default-pullquote', $result['textStyle'] );
-		$this->assertEquals( 'quote-layout', $result['layout'] );
+		$this->assertEquals( 'pullquote-layout', $result['layout'] );
 	}
 }

--- a/tests/apple-exporter/components/test-class-quote.php
+++ b/tests/apple-exporter/components/test-class-quote.php
@@ -65,7 +65,75 @@ class Quote_Test extends Component_TestCase {
 	}
 
 	/**
-	 * Tests quote settings.
+	 * Tests blockquote settings.
+	 *
+	 * @access public
+	 */
+	public function testSettingsBlockquote() {
+
+		// Setup.
+		$content = new Exporter_Content(
+			3,
+			'Title',
+			'<blockquote><p>my quote</p></blockquote>'
+		);
+
+		// Set quote settings.
+		$this->settings->blockquote_font = 'TestFontName';
+		$this->settings->blockquote_size = 20;
+		$this->settings->blockquote_color = '#abcdef';
+		$this->settings->blockquote_line_height = 28;
+		$this->settings->blockquote_tracking = 50;
+		$this->settings->blockquote_background_color = '#fedcba';
+		$this->settings->blockquote_border_color = '#012345';
+		$this->settings->blockquote_border_style = 'dashed';
+		$this->settings->blockquote_border_width = 10;
+
+		// Run the export.
+		$exporter = new Exporter( $content, null, $this->settings );
+		$json = json_decode( $exporter->export(), true );
+
+		// Validate body settings in generated JSON.
+		$this->assertEquals(
+			'TestFontName',
+			$json['componentTextStyles']['default-blockquote']['fontName']
+		);
+		$this->assertEquals(
+			20,
+			$json['componentTextStyles']['default-blockquote']['fontSize']
+		);
+		$this->assertEquals(
+			'#abcdef',
+			$json['componentTextStyles']['default-blockquote']['textColor']
+		);
+		$this->assertEquals(
+			28,
+			$json['componentTextStyles']['default-blockquote']['lineHeight']
+		);
+		$this->assertEquals(
+			0.5,
+			$json['componentTextStyles']['default-blockquote']['tracking']
+		);
+		$this->assertEquals(
+			'#fedcba',
+			$json['components'][1]['style']['backgroundColor']
+		);
+		$this->assertEquals(
+			'#012345',
+			$json['components'][1]['style']['border']['all']['color']
+		);
+		$this->assertEquals(
+			'dashed',
+			$json['components'][1]['style']['border']['all']['style']
+		);
+		$this->assertEquals(
+			10,
+			$json['components'][1]['style']['border']['all']['width']
+		);
+	}
+
+	/**
+	 * Tests pullquote settings.
 	 *
 	 * @access public
 	 */

--- a/tests/apple-exporter/components/test-class-quote.php
+++ b/tests/apple-exporter/components/test-class-quote.php
@@ -190,6 +190,33 @@ class Quote_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
+	public function testTransformBlockquote() {
+
+		// Setup.
+		$component = new Quote(
+			'<blockquote><p>my quote</p></blockquote>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		$result_wrapper = $component->to_array();
+		$result = $result_wrapper['components'][0];
+
+		// Test.
+		$this->assertEquals( 'container', $result_wrapper['role'] );
+		$this->assertEquals( 'quote', $result['role'] );
+		$this->assertEquals( "my quote\n\n", $result['text'] );
+		$this->assertEquals( 'markdown', $result['format'] );
+		$this->assertEquals( 'default-blockquote', $result['textStyle'] );
+		$this->assertEquals( 'blockquote-layout', $result['layout'] );
+	}
+
+	/**
+	 * Tests the transformation process from a pullquote to a Quote component.
+	 *
+	 * @access public
+	 */
 	public function testTransformPullquote() {
 
 		// Setup.

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -1,53 +1,133 @@
 <?php
+/**
+ * Publish to Apple News Tests: Apple_News_Test class
+ *
+ * Contains a class which is used to test the Apple_News class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
-use \Apple_News as Apple_News;
-use \Apple_Exporter\Settings as Settings;
+use \Apple_Exporter\Settings;
 
+/**
+ * A class which is used to test the Apple_News class.
+ */
 class Apple_News_Test extends WP_UnitTestCase {
 
-	public function setup() {
+	/**
+	 * A function containing operations to be run before each test function.
+	 *
+	 * @access public
+	 */
+	public function setUp() {
 		parent::setup();
 		$this->settings = new Settings();
 	}
 
+	/**
+	 * Ensures that the get_filename function properly returns an image filename.
+	 *
+	 * @see Apple_News::get_filename()
+	 *
+	 * @access public
+	 */
 	public function testGetFilename() {
 		$url = 'http://someurl.com/image.jpg?w=150&h=150';
 		$filename = Apple_News::get_filename( $url );
-
 		$this->assertEquals( 'image.jpg', $filename );
 	}
 
-	public function testVersion() {
-		$plugin_data = apple_news_get_plugin_data();
-		$this->assertEquals( $plugin_data['Version'], Apple_News::$version );
+	/**
+	 * Ensures that the migrate_api_settings function properly migrates settings.
+	 *
+	 * @see Apple_News::migrate_api_settings()
+	 *
+	 * @access public
+	 */
+	public function testMigrateApiSettings() {
+
+		// Setup.
+		$default_settings = $this->settings->all();
+		$expected_settings = $default_settings;
+		$expected_settings['api_autosync_update'] = 'no';
+		$apple_news = new Apple_News();
+		update_option( $apple_news::$option_name, $expected_settings );
+		$apple_news->migrate_api_settings( $default_settings );
+
+		// Ensure the defaults did not overwrite the migrated legacy data.
+		$migrated_settings = get_option( $apple_news::$option_name );
+		$this->assertNotEquals( $default_settings, $migrated_settings );
+		$this->assertEquals( $expected_settings, $migrated_settings );
 	}
 
+	/**
+	 * Ensures that the migrate_settings function properly migrates legacy settings.
+	 *
+	 * @see Apple_News::migrate_settings()
+	 *
+	 * @access public
+	 */
 	public function testMigrateSettings() {
+
+		// Setup.
 		update_option( 'use_remote_images', 'yes' );
 		$default_settings = $this->settings->all();
 		$apple_news = new Apple_News();
 		$apple_news->migrate_settings( $this->settings );
 
+		// Ensure the defaults did not overwrite the migrated legacy data.
 		$migrated_settings = get_option( $apple_news::$option_name );
 		$this->assertNotEquals( $default_settings, $migrated_settings );
 
+		// Ensure the migrated settings match what we expect.
 		$default_settings['use_remote_images'] = 'yes';
 		$this->assertEquals( $default_settings, $migrated_settings );
 	}
 
-	public function testSupportInfoHTML() {
-		$this->assertEquals( '<br /><br />If you need assistance, please reach out for support on <a href="https://wordpress.org/support/plugin/publish-to-apple-news">WordPress.org</a> or <a href="https://github.com/alleyinteractive/apple-news/issues">GitHub</a>.', Apple_News::get_support_info() );
+	/**
+	 * Ensures that the get_support_info returns the correct values.
+	 *
+	 * @see Apple_News::get_support_info()
+	 *
+	 * @access public
+	 */
+	public function testSupportInfo() {
+
+		// Test HTML.
+		$this->assertEquals(
+			'<br /><br />If you need assistance, please reach out for support on <a href="https://wordpress.org/support/plugin/publish-to-apple-news">WordPress.org</a> or <a href="https://github.com/alleyinteractive/apple-news/issues">GitHub</a>.',
+			Apple_News::get_support_info()
+		);
+
+		// Test HTML with no padding.
+		$this->assertEquals(
+			'If you need assistance, please reach out for support on <a href="https://wordpress.org/support/plugin/publish-to-apple-news">WordPress.org</a> or <a href="https://github.com/alleyinteractive/apple-news/issues">GitHub</a>.',
+			Apple_News::get_support_info( 'html', false )
+		);
+
+		// Test text.
+		$this->assertEquals(
+			"\n\n" . 'If you need assistance, please reach out for support on WordPress.org or GitHub.',
+			Apple_News::get_support_info( 'text' )
+		);
+
+		// Test text with no padding.
+		$this->assertEquals(
+			'If you need assistance, please reach out for support on WordPress.org or GitHub.',
+			Apple_News::get_support_info( 'text', false )
+		);
 	}
 
-	public function testSupportInfoHTMLNoPadding() {
-		$this->assertEquals( 'If you need assistance, please reach out for support on <a href="https://wordpress.org/support/plugin/publish-to-apple-news">WordPress.org</a> or <a href="https://github.com/alleyinteractive/apple-news/issues">GitHub</a>.', Apple_News::get_support_info( 'html', false ) );
-	}
-
-	public function testSupportInfoText() {
-		$this->assertEquals( "\n\nIf you need assistance, please reach out for support on WordPress.org or GitHub.", Apple_News::get_support_info( 'text' ) );
-	}
-
-	public function testSupportInfoTextNoPadding() {
-		$this->assertEquals( "If you need assistance, please reach out for support on WordPress.org or GitHub.", Apple_News::get_support_info( 'text', false ) );
+	/**
+	 * Ensures that the version in Apple_News matches the reported plugin version.
+	 *
+	 * @see Apple_News::$version
+	 *
+	 * @access public
+	 */
+	public function testVersion() {
+		$plugin_data = apple_news_get_plugin_data();
+		$this->assertEquals( $plugin_data['Version'], Apple_News::$version );
 	}
 }

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -63,6 +63,54 @@ class Apple_News_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that the migrate_blockquote_settings function migrates settings.
+	 *
+	 * @see Apple_News::migrate_blockquote_settings()
+	 *
+	 * @access public
+	 */
+	public function testMigrateBlockquoteSettings() {
+
+		// Setup.
+		$legacy_settings = $this->settings->all();
+		$legacy_settings['body_background_color'] = '#aaaaaa';
+		$legacy_settings['pullquote_border_color'] = '#abcdef';
+		$legacy_settings['pullquote_border_style'] = 'dashed';
+		$legacy_settings['pullquote_border_width'] = 10;
+		$legacy_settings['body_color'] = '#012345';
+		$legacy_settings['body_font'] = 'TestFont';
+		$legacy_settings['body_line_height'] = 30;
+		$legacy_settings['body_size'] = 20;
+		$legacy_settings['body_tracking'] = 10;
+		unset( $legacy_settings['blockquote_background_color'] );
+		unset( $legacy_settings['blockquote_border_color'] );
+		unset( $legacy_settings['blockquote_border_style'] );
+		unset( $legacy_settings['blockquote_border_width'] );
+		unset( $legacy_settings['blockquote_color'] );
+		unset( $legacy_settings['blockquote_font'] );
+		unset( $legacy_settings['blockquote_line_height'] );
+		unset( $legacy_settings['blockquote_size'] );
+		unset( $legacy_settings['blockquote_tracking'] );
+		$apple_news = new Apple_News();
+		update_option( $apple_news::$option_name, $legacy_settings );
+		$apple_news->migrate_blockquote_settings( $legacy_settings );
+
+		// Ensure the defaults did not overwrite the migrated legacy data.
+		$expected_settings = $legacy_settings;
+		$expected_settings['blockquote_background_color'] = '#999999';
+		$expected_settings['blockquote_border_color'] = '#abcdef';
+		$expected_settings['blockquote_border_style'] = 'dashed';
+		$expected_settings['blockquote_border_width'] = 10;
+		$expected_settings['blockquote_color'] = '#012345';
+		$expected_settings['blockquote_font'] = 'TestFont';
+		$expected_settings['blockquote_line_height'] = 30;
+		$expected_settings['blockquote_size'] = 20;
+		$expected_settings['blockquote_tracking'] = 10;
+		$migrated_settings = get_option( $apple_news::$option_name );
+		$this->assertEquals( $expected_settings, $migrated_settings );
+	}
+
+	/**
 	 * Ensures that the migrate_settings function properly migrates legacy settings.
 	 *
 	 * @see Apple_News::migrate_settings()

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -111,6 +111,42 @@ class Apple_News_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that the migrate_caption_settings function migrates settings.
+	 *
+	 * @see Apple_News::migrate_caption_settings()
+	 *
+	 * @access public
+	 */
+	public function testMigrateCaptionSettings() {
+
+		// Setup.
+		$legacy_settings = $this->settings->all();
+		$legacy_settings['body_color'] = '#abcdef';
+		$legacy_settings['body_font'] = 'TestFont';
+		$legacy_settings['body_line_height'] = 40;
+		$legacy_settings['body_size'] = 30;
+		$legacy_settings['body_tracking'] = 10;
+		unset( $legacy_settings['caption_color'] );
+		unset( $legacy_settings['caption_font'] );
+		unset( $legacy_settings['caption_line_height'] );
+		unset( $legacy_settings['caption_size'] );
+		unset( $legacy_settings['caption_tracking'] );
+		$apple_news = new Apple_News();
+		update_option( $apple_news::$option_name, $legacy_settings );
+		$apple_news->migrate_caption_settings( $legacy_settings );
+
+		// Ensure the defaults did not overwrite the migrated legacy data.
+		$expected_settings = $legacy_settings;
+		$expected_settings['caption_color'] = '#abcdef';
+		$expected_settings['caption_font'] = 'TestFont';
+		$expected_settings['caption_line_height'] = 40;
+		$expected_settings['caption_size'] = 28;
+		$expected_settings['caption_tracking'] = 10;
+		$migrated_settings = get_option( $apple_news::$option_name );
+		$this->assertEquals( $expected_settings, $migrated_settings );
+	}
+
+	/**
 	 * Ensures that the migrate_settings function properly migrates legacy settings.
 	 *
 	 * @see Apple_News::migrate_settings()

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensures that the migrate_api_settings function properly migrates settings.
+	 * Ensures that the migrate_api_settings function migrates settings.
 	 *
 	 * @see Apple_News::migrate_api_settings()
 	 *
@@ -48,16 +48,17 @@ class Apple_News_Test extends WP_UnitTestCase {
 	public function testMigrateApiSettings() {
 
 		// Setup.
-		$default_settings = $this->settings->all();
-		$expected_settings = $default_settings;
-		$expected_settings['api_autosync_update'] = 'no';
+		$legacy_settings = $this->settings->all();
+		$legacy_settings['api_autosync_update'] = 'no';
+		unset( $legacy_settings['api_autosync_delete'] );
 		$apple_news = new Apple_News();
-		update_option( $apple_news::$option_name, $expected_settings );
-		$apple_news->migrate_api_settings( $default_settings );
+		update_option( $apple_news::$option_name, $legacy_settings );
+		$apple_news->migrate_api_settings( $legacy_settings );
 
 		// Ensure the defaults did not overwrite the migrated legacy data.
+		$expected_settings = $legacy_settings;
+		$expected_settings['api_autosync_delete'] = 'no';
 		$migrated_settings = get_option( $apple_news::$option_name );
-		$this->assertNotEquals( $default_settings, $migrated_settings );
 		$this->assertEquals( $expected_settings, $migrated_settings );
 	}
 

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -147,6 +147,69 @@ class Apple_News_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that the migrate_header_settings function migrates settings.
+	 *
+	 * @see Apple_News::migrate_header_settings()
+	 *
+	 * @access public
+	 */
+	public function testMigrateHeaderSettings() {
+
+		// Setup.
+		$legacy_settings = $this->settings->all();
+		$legacy_settings['header_color'] = '#abcdef';
+		$legacy_settings['header_font'] = 'TestFont';
+		$legacy_settings['header_line_height'] = 100;
+		unset( $legacy_settings['header1_color'] );
+		unset( $legacy_settings['header2_color'] );
+		unset( $legacy_settings['header3_color'] );
+		unset( $legacy_settings['header4_color'] );
+		unset( $legacy_settings['header5_color'] );
+		unset( $legacy_settings['header6_color'] );
+		unset( $legacy_settings['header1_font'] );
+		unset( $legacy_settings['header2_font'] );
+		unset( $legacy_settings['header3_font'] );
+		unset( $legacy_settings['header4_font'] );
+		unset( $legacy_settings['header5_font'] );
+		unset( $legacy_settings['header6_font'] );
+		unset( $legacy_settings['header1_line_height'] );
+		unset( $legacy_settings['header2_line_height'] );
+		unset( $legacy_settings['header3_line_height'] );
+		unset( $legacy_settings['header4_line_height'] );
+		unset( $legacy_settings['header5_line_height'] );
+		unset( $legacy_settings['header6_line_height'] );
+		$apple_news = new Apple_News();
+		update_option( $apple_news::$option_name, $legacy_settings );
+		$apple_news->migrate_header_settings( $legacy_settings );
+
+		// Ensure the defaults did not overwrite the migrated legacy data.
+		$expected_settings = $legacy_settings;
+		$expected_settings['header1_color'] = '#abcdef';
+		$expected_settings['header2_color'] = '#abcdef';
+		$expected_settings['header3_color'] = '#abcdef';
+		$expected_settings['header4_color'] = '#abcdef';
+		$expected_settings['header5_color'] = '#abcdef';
+		$expected_settings['header6_color'] = '#abcdef';
+		$expected_settings['header1_font'] = 'TestFont';
+		$expected_settings['header2_font'] = 'TestFont';
+		$expected_settings['header3_font'] = 'TestFont';
+		$expected_settings['header4_font'] = 'TestFont';
+		$expected_settings['header5_font'] = 'TestFont';
+		$expected_settings['header6_font'] = 'TestFont';
+		$expected_settings['header1_line_height'] = 100;
+		$expected_settings['header2_line_height'] = 100;
+		$expected_settings['header3_line_height'] = 100;
+		$expected_settings['header4_line_height'] = 100;
+		$expected_settings['header5_line_height'] = 100;
+		$expected_settings['header6_line_height'] = 100;
+		unset( $expected_settings['header_color'] );
+		unset( $expected_settings['header_font'] );
+		unset( $expected_settings['header_line_height'] );
+		$migrated_settings = get_option( $apple_news::$option_name );
+		$this->assertEquals( $expected_settings, $migrated_settings );
+	}
+
+	/**
 	 * Ensures that the migrate_settings function properly migrates legacy settings.
 	 *
 	 * @see Apple_News::migrate_settings()


### PR DESCRIPTION
* Created a new settings block for blockquote-specific settings.
* Changed behavior and appearance of blockquotes to differentiate them from pullquotes.
* Created a settings migration function to use existing body and pullquote settings to initialize blockquote settings.
* Added reusable functions for handling settings migration in the base Apple_News class.
* Refactored test-apple-news.php to conform to WordPress coding standards and PHP best practices.
* Added unit test coverage in test-apple-news.php to cover all settings migration functions.
* Added unit test coverage for blockquotes.

Fixes #246.