### PR TITLE
AN-17 Refinement of successful push message

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -5,7 +5,8 @@ namespace Apple_Actions\Index;
 require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-export.php';
 
-use Apple_Actions\API_Action as API_Action;
+use Admin_Apple_Notice;
+use Apple_Actions\API_Action;
 
 class Push extends API_Action {
 
@@ -228,6 +229,26 @@ class Push extends API_Action {
 			} else {
 				throw new \Apple_Actions\Action_Exception( __( 'There has been an error with the API: ', 'apple-news' ) .  $e->getMessage() );
 			}
+		}
+
+		// Print success message.
+		$post = get_post( $this->id );
+		if ( $remote_id ) {
+			Admin_Apple_Notice::success(
+				sprintf(
+					__( 'Article %s has been successfully updated on Apple News!', 'apple-news' ),
+					$post->post_title
+				),
+				$user_id
+			);
+		} else {
+			Admin_Apple_Notice::success(
+				sprintf(
+					__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
+					$post->post_title
+				),
+				$user_id
+			);
 		}
 
 		$this->clean_workspace();

--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -81,11 +81,6 @@ class Admin_Apple_Async extends Apple_News {
 		$action = new Apple_Actions\Index\Push( $this->settings, $post_id );
 		try {
 			$action->perform( true, $user_id );
-
-			Admin_Apple_Notice::success( sprintf(
-				__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
-				$post->post_title
-			), $user_id );
 		} catch ( Apple_Actions\Action_Exception $e ) {
 			Admin_Apple_Notice::error( $e->getMessage(), $user_id );
 		}

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -271,6 +271,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 		$notices = get_user_meta( $user_id, 'apple_news_notice', true );
 		$this->assertNotEmpty( $notices );
 
+		array_pop( $notices );
 		$component_notice = end( $notices );
 		$this->assertEquals( 'The following components are unsupported by Apple News and were removed: iframe', $component_notice['message'] );
 
@@ -349,6 +350,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 		$notices = get_user_meta( $user_id, 'apple_news_notice', true );
 		$this->assertNotEmpty( $notices );
 
+		array_pop( $notices );
 		$component_notice = end( $notices );
 		$this->assertEquals( 'The following JSON errors were detected: Invalid unicode character sequences were found that could cause display issues on Apple News: ÂÂîî', $component_notice['message'] );
 


### PR DESCRIPTION
* Moved successful publish message to Push class.
* Split verbiage of success message based on whether the article was updated or published for the first time.

Fixes #278.