### PR TITLE
AN-57 Taxonomy/section mappings

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -166,6 +166,7 @@ class Push extends API_Action {
 			);
 
 			// Get sections
+			// TODO: Fork here to pull from taxonomy if requested and override not set.
 			$sections = get_post_meta( $this->id, 'apple_news_sections', true );
 			if ( is_array( $sections ) ) {
 				$meta['data']['links'] = array( 'sections' => $sections );

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -170,7 +170,7 @@ class Push extends API_Action {
 			$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
 			$override = get_post_meta( $this->id, 'apple_news_section_override', true );
 			if ( ! empty( $mappings ) && empty( $override ) ) {
-				$sections = Admin_Apple_Sections::get_sections_for_post( $this->id, 'url' );
+				$sections = Admin_Apple_Sections::get_sections_for_post( $this->id );
 			} else {
 				$sections = get_post_meta( $this->id, 'apple_news_sections', true );
 			}

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -5,8 +5,9 @@ namespace Apple_Actions\Index;
 require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-export.php';
 
-use Admin_Apple_Notice;
-use Apple_Actions\API_Action;
+use \Admin_Apple_Notice;
+use \Admin_Apple_Sections;
+use \Apple_Actions\API_Action;
 
 class Push extends API_Action {
 
@@ -165,9 +166,14 @@ class Push extends API_Action {
 				'data' => array(),
 			);
 
-			// Get sections
-			// TODO: Fork here to pull from taxonomy if requested and override not set.
-			$sections = get_post_meta( $this->id, 'apple_news_sections', true );
+			// Get sections.
+			$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
+			$override = get_post_meta( $this->id, 'apple_news_section_override', true );
+			if ( ! empty( $mappings ) && empty( $override ) ) {
+				$sections = Admin_Apple_Sections::get_sections_for_post( $this->id, 'url' );
+			} else {
+				$sections = get_post_meta( $this->id, 'apple_news_sections', true );
+			}
 			if ( is_array( $sections ) ) {
 				$meta['data']['links'] = array( 'sections' => $sections );
 			}

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -168,7 +168,7 @@ class Push extends API_Action {
 
 			// Get sections.
 			$sections = Admin_Apple_Sections::get_sections_for_post( $this->id );
-			if ( is_array( $sections ) ) {
+			if ( ! empty( $sections ) ) {
 				$meta['data']['links'] = array( 'sections' => $sections );
 			}
 

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -167,13 +167,7 @@ class Push extends API_Action {
 			);
 
 			// Get sections.
-			$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
-			$override = get_post_meta( $this->id, 'apple_news_section_override', true );
-			if ( ! empty( $mappings ) && empty( $override ) ) {
-				$sections = Admin_Apple_Sections::get_sections_for_post( $this->id );
-			} else {
-				$sections = get_post_meta( $this->id, 'apple_news_sections', true );
-			}
+			$sections = Admin_Apple_Sections::get_sections_for_post( $this->id );
 			if ( is_array( $sections ) ) {
 				$meta['data']['links'] = array( 'sections' => $sections );
 			}

--- a/admin/apple-actions/index/class-section.php
+++ b/admin/apple-actions/index/class-section.php
@@ -4,7 +4,8 @@ namespace Apple_Actions\Index;
 
 require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
 
-use Apple_Actions\API_Action as API_Action;
+use Apple_Actions\API_Action;
+use Apple_Exporter\Settings;
 
 class Section extends API_Action {
 

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -280,6 +280,8 @@ class Admin_Apple_Index_Page extends Apple_News {
 			__FILE__ ) .  '../assets/css/export-table.css' );
 		wp_enqueue_script( $this->plugin_slug . '_export_table_js', plugin_dir_url(
 			__FILE__ ) .  '../assets/js/export-table.js', array( 'jquery', 'jquery-ui-datepicker' ), self::$version, true );
+		wp_enqueue_script( $this->plugin_slug . '_single_push_js', plugin_dir_url(
+			__FILE__ ) .  '../assets/js/single-push.js', array( 'jquery' ), self::$version, true );
 
 		// Localize strings
 		wp_localize_script( $this->plugin_slug . '_export_table_js', 'apple_news_export_table', array(

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -109,15 +109,17 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	public static function save_post_meta( $post_id ) {
 
 		// Determine whether to save sections.
-		if ( empty( $_POST['apple_news_sections_by_taxonomy'] )
-			&& isset( $_POST['apple_news_sections'] )
-			&& is_array( $_POST['apple_news_sections'] )
-		) {
-			update_post_meta(
-				$post_id,
-				'apple_news_sections',
-				array_map( 'sanitize_text_field', $_POST['apple_news_sections'] )
-			);
+		if ( empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
+			$sections = array();
+			if ( ! empty( $_POST['apple_news_sections'] )
+				&& is_array( $_POST['apple_news_sections'] )
+			) {
+				$sections = array_map(
+					'sanitize_text_field',
+					$_POST['apple_news_sections']
+				);
+			}
+			update_post_meta( $post_id, 'apple_news_sections', $sections );
 		} else {
 			delete_post_meta( $post_id, 'apple_news_sections' );
 		}

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -289,7 +289,12 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			return '';
 		}
 
+		// TODO: Get meta field for section overrides IF setting exists for taxonomy-section mappings
+
+		// TODO: Echo checkbox for section overrides IF setting exists for taxonomy-section mappings
+
 		// Get current sections and determine if the article was previously published
+        // TODO: Fork here to build sections from taxonomy if specified and override not specified.
 		$apple_news_sections = get_post_meta( $post_id, 'apple_news_sections', true );
 
 		// Iterate over the list of sections.

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -110,7 +110,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Determine whether to save sections.
 		if ( empty( $_POST['apple_news_sections_by_taxonomy'] )
-			&& ! empty( $_POST['apple_news_sections'] )
+			&& isset( $_POST['apple_news_sections'] )
 			&& is_array( $_POST['apple_news_sections'] )
 		) {
 			update_post_meta(
@@ -301,7 +301,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		}
 
 		// Iterate over the list of sections and print each.
-		$apple_news_sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
+		$apple_news_sections = get_post_meta( $post_id, 'apple_news_sections', true );
 		foreach ( $sections as $section ) {
 			?>
 			<div class="section">

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -123,8 +123,8 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 				$sections = $_POST['apple_news_sections'];
 			}
 		} else {
-            $sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
-        }
+			$sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
+		}
 		update_post_meta( $post_id, 'apple_news_sections', array_map( 'sanitize_text_field', $sections ) );
 
 		if ( ! empty( $_POST['apple_news_is_preview'] ) && 1 === intval( $_POST['apple_news_is_preview'] ) ) {
@@ -200,25 +200,25 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		?>
 		<div id="apple-news-publish">
 		<?php wp_nonce_field( $this->publish_action, 'apple_news_nonce' ); ?>
-        <?php self::build_sections_override( $post->ID ); ?>
-        <div class="apple-news-sections">
-            <?php
-                $section = new Apple_Actions\Index\Section( $this->settings );
-                try {
-                    $sections = $section->get_sections();
-                } catch ( Apple_Actions\Action_Exception $e ) {
-                    Admin_Apple_Notice::error( $e->getMessage() );
-                }
+		<?php self::build_sections_override( $post->ID ); ?>
+		<div class="apple-news-sections">
+			<?php
+				$section = new Apple_Actions\Index\Section( $this->settings );
+				try {
+					$sections = $section->get_sections();
+				} catch ( Apple_Actions\Action_Exception $e ) {
+					Admin_Apple_Notice::error( $e->getMessage() );
+				}
 
-                if ( ! empty( $sections ) ) :
-                    ?>
-                    <h3><?php esc_html_e( 'Sections', 'apple-news' ) ?></h3>
-                    <?php
-                    self::build_sections_field( $sections, $post->ID );
-                endif;
-            ?>
-    		<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. Uncheck them all for a standalone article.' , 'apple-news' ) ?></p>
-        </div>
+				if ( ! empty( $sections ) ) :
+					?>
+					<h3><?php esc_html_e( 'Sections', 'apple-news' ) ?></h3>
+					<?php
+					self::build_sections_field( $sections, $post->ID );
+				endif;
+			?>
+			<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. Uncheck them all for a standalone article.' , 'apple-news' ) ?></p>
+		</div>
 		<h3><?php esc_html_e( 'Preview?', 'apple-news' ) ?></h3>
 		<input id="apple-news-is-preview" name="apple_news_is_preview" type="checkbox" value="1" <?php checked( $is_preview ) ?>>
 		<p class="description"><?php esc_html_e( 'Check this to publish the article as a draft.' , 'apple-news' ) ?></p>
@@ -307,44 +307,44 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Iterate over the list of sections and print each.
 		$apple_news_sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
-        foreach ( $sections as $section ) {
-		    ?>
-            <div class="section">
-                <input id="apple-news-section-<?php echo esc_attr( $section->id ) ?>" name="apple_news_sections[]" type="checkbox" value="<?php echo esc_attr( $section->links->self ) ?>" <?php checked( self::section_is_checked( $apple_news_sections, $section->links->self, $section->isDefault ) ) ?>>
-                <label for="apple-news-section-<?php echo esc_attr( $section->id ) ?>"><?php echo esc_html( $section->name ) ?></label>
-            </div>
-            <?php
-        }
+		foreach ( $sections as $section ) {
+			?>
+			<div class="section">
+				<input id="apple-news-section-<?php echo esc_attr( $section->id ) ?>" name="apple_news_sections[]" type="checkbox" value="<?php echo esc_attr( $section->links->self ) ?>" <?php checked( self::section_is_checked( $apple_news_sections, $section->links->self, $section->isDefault ) ) ?>>
+				<label for="apple-news-section-<?php echo esc_attr( $section->id ) ?>"><?php echo esc_html( $section->name ) ?></label>
+			</div>
+			<?php
+		}
 	}
 
 	/**
-     * Builds the sections override checkbox, if necessary.
-     *
+	 * Builds the sections override checkbox, if necessary.
+	 *
 	 * @param int $post_id The ID of the post to build the checkbox field for.
-     *
-     * @access public
+	 *
+	 * @access public
 	 */
 	public static function build_sections_override( $post_id ) {
 
-        // Determine if there are section/taxonomy mappings set.
-        $mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
-        if ( empty( $mappings ) ) {
-	        return;
-        }
+		// Determine if there are section/taxonomy mappings set.
+		$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
+		if ( empty( $mappings ) ) {
+			return;
+		}
 
-        // Add checkbox to allow override of automatic section assignment.
-        $mapping_taxonomy = Admin_Apple_Sections::get_mapping_taxonomy();
-        $override = get_post_meta( $post_id, 'apple_news_section_override', true );
-        ?>
-        <div class="section-override">
-            <label for="apple-news-sections-by-taxonomy">
-                <input id="apple-news-sections-by-taxonomy" name="apple_news_sections_by_taxonomy" type="checkbox" <?php checked( empty( $override ) ); ?> />
-                <?php esc_html_e( 'Assign sections by', 'apple-news' ); ?>
-                <?php echo esc_html( strtolower( $mapping_taxonomy->labels->singular_name ) ); ?>
-            </label>
-        </div>
-        <?php
-    }
+		// Add checkbox to allow override of automatic section assignment.
+		$mapping_taxonomy = Admin_Apple_Sections::get_mapping_taxonomy();
+		$override = get_post_meta( $post_id, 'apple_news_section_override', true );
+		?>
+		<div class="section-override">
+			<label for="apple-news-sections-by-taxonomy">
+			<input id="apple-news-sections-by-taxonomy" name="apple_news_sections_by_taxonomy" type="checkbox" <?php checked( empty( $override ) ); ?> />
+				<?php esc_html_e( 'Assign sections by', 'apple-news' ); ?>
+				<?php echo esc_html( strtolower( $mapping_taxonomy->labels->singular_name ) ); ?>
+			</label>
+		</div>
+		<?php
+	}
 
 	/**
 	 * Determine if a section is checked

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -119,7 +119,9 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		// Determine how to save sections.
 		$sections = array();
 		if ( empty( $mappings ) || empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
-			if ( ! empty( $_POST['apple_news_sections'] ) ) {
+			if ( ! empty( $_POST['apple_news_sections'] )
+                && is_array( $_POST['apple_news_sections'] )
+            ) {
 				$sections = $_POST['apple_news_sections'];
 			}
 		} else {

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -108,26 +108,19 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 */
 	public static function save_post_meta( $post_id ) {
 
-		// Save section override setting.
-		$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
-		if ( ! empty( $mappings ) && empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
-			update_post_meta( $post_id, 'apple_news_section_override', true );
+		// Determine whether to save sections.
+		if ( empty( $_POST['apple_news_sections_by_taxonomy'] )
+			&& ! empty( $_POST['apple_news_sections'] )
+			&& is_array( $_POST['apple_news_sections'] )
+		) {
+			update_post_meta(
+				$post_id,
+				'apple_news_sections',
+				array_map( 'sanitize_text_field', $_POST['apple_news_sections'] )
+			);
 		} else {
-			delete_post_meta( $post_id, 'apple_news_section_override' );
+			delete_post_meta( $post_id, 'apple_news_sections' );
 		}
-
-		// Determine how to save sections.
-		$sections = array();
-		if ( empty( $mappings ) || empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
-			if ( ! empty( $_POST['apple_news_sections'] )
-                && is_array( $_POST['apple_news_sections'] )
-            ) {
-				$sections = $_POST['apple_news_sections'];
-			}
-		} else {
-			$sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
-		}
-		update_post_meta( $post_id, 'apple_news_sections', array_map( 'sanitize_text_field', $sections ) );
 
 		if ( ! empty( $_POST['apple_news_is_preview'] ) && 1 === intval( $_POST['apple_news_is_preview'] ) ) {
 			$is_preview = true;
@@ -336,11 +329,11 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Add checkbox to allow override of automatic section assignment.
 		$mapping_taxonomy = Admin_Apple_Sections::get_mapping_taxonomy();
-		$override = get_post_meta( $post_id, 'apple_news_section_override', true );
+		$sections = get_post_meta( $post_id, 'apple_news_sections', true );
 		?>
 		<div class="section-override">
 			<label for="apple-news-sections-by-taxonomy">
-			<input id="apple-news-sections-by-taxonomy" name="apple_news_sections_by_taxonomy" type="checkbox" <?php checked( empty( $override ) ); ?> />
+			<input id="apple-news-sections-by-taxonomy" name="apple_news_sections_by_taxonomy" type="checkbox" <?php checked( ! is_array( $sections ) ); ?> />
 				<?php esc_html_e( 'Assign sections by', 'apple-news' ); ?>
 				<?php echo esc_html( strtolower( $mapping_taxonomy->labels->singular_name ) ); ?>
 			</label>

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -116,7 +116,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 				$sections = $_POST['apple_news_sections'];
 			}
 		} else {
-            $sections = Admin_Apple_Sections::get_sections_for_post( $post_id, 'url' );
+            $sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
         }
 		update_post_meta( $post_id, 'apple_news_sections', array_map( 'sanitize_text_field', $sections ) );
 
@@ -307,7 +307,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		// Get current sections and determine if the article was previously published.
 		$override = get_post_meta( $post_id, 'apple_news_section_override', true );
         if ( ! empty( $mappings ) && empty( $override ) ) {
-            $apple_news_sections = Admin_Apple_Sections::get_sections_for_post( $post_id, 'url' );
+            $apple_news_sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
         } else {
 	        $apple_news_sections = get_post_meta( $post_id, 'apple_news_sections', true );
         }

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -108,9 +108,16 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 */
 	public static function save_post_meta( $post_id ) {
 
-	    // Determine how to save sections.
-		$sections = array();
+		// Save section override setting.
 		$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
+		if ( ! empty( $mappings ) && empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
+			update_post_meta( $post_id, 'apple_news_section_override', true );
+		} else {
+			delete_post_meta( $post_id, 'apple_news_section_override' );
+		}
+
+		// Determine how to save sections.
+		$sections = array();
 		if ( empty( $mappings ) || empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
 			if ( ! empty( $_POST['apple_news_sections'] ) ) {
 				$sections = $_POST['apple_news_sections'];
@@ -119,13 +126,6 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
             $sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
         }
 		update_post_meta( $post_id, 'apple_news_sections', array_map( 'sanitize_text_field', $sections ) );
-
-		// Save section override setting.
-		if ( ! empty( $mappings ) && empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
-		    update_post_meta( $post_id, 'apple_news_section_override', true );
-		} else {
-			delete_post_meta( $post_id, 'apple_news_section_override' );
-        }
 
 		if ( ! empty( $_POST['apple_news_is_preview'] ) && 1 === intval( $_POST['apple_news_is_preview'] ) ) {
 			$is_preview = true;
@@ -299,20 +299,14 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @static
 	 */
 	public static function build_sections_field( $sections, $post_id ) {
-		// Make sure we have sections
+
+		// Make sure we have sections.
 		if ( empty( $sections ) ) {
 			return '';
 		}
 
-		// Get current sections and determine if the article was previously published.
-		$override = get_post_meta( $post_id, 'apple_news_section_override', true );
-        if ( ! empty( $mappings ) && empty( $override ) ) {
-            $apple_news_sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
-        } else {
-	        $apple_news_sections = get_post_meta( $post_id, 'apple_news_sections', true );
-        }
-
-		// Iterate over the list of sections.
+		// Iterate over the list of sections and print each.
+		$apple_news_sections = Admin_Apple_Sections::get_sections_for_post( $post_id );
         foreach ( $sections as $section ) {
 		    ?>
             <div class="section">

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -13,6 +13,7 @@ require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-bulk-export-page.p
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-notice.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-meta-boxes.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-async.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-sections.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-themes.php';
 
 /**
@@ -57,6 +58,9 @@ class Admin_Apple_News extends Apple_News {
 
 		// Set up asynchronous publishing features
 		new Admin_Apple_Async( self::$settings );
+
+		// Add section support
+		new Admin_Apple_Sections( self::$settings );
 
 		// Add theme support
 		new Admin_Apple_Themes( self::$settings );

--- a/admin/class-admin-apple-preview.php
+++ b/admin/class-admin-apple-preview.php
@@ -154,8 +154,8 @@ class Admin_Apple_Preview extends Apple_News {
 			<p>Sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Pellentesque ipsum mi, sagittis eget sodales et, volutpat at felis.</p>
 			<pre>
 .code-sample {
-font-family: monospace;
-white-space: pre;
+  font-family: monospace;
+  white-space: pre;
 }
 			</pre>
 			</div>

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -70,12 +70,22 @@ class Admin_Apple_Sections extends Apple_News {
 	/**
 	 * Given a post ID, returns an array of section URLs based on applied taxonomy.
 	 *
+	 * Supports overrides for manual section selection and fallback to postmeta
+	 * when no mappings are set.
+	 *
 	 * @param int $post_id The ID of the post to query.
 	 *
 	 * @access public
 	 * @return array An array of section URLs for the post.
 	 */
 	public static function get_sections_for_post( $post_id ) {
+
+		// Determine if sections should be loaded from postmeta.
+		$mappings = get_option( self::TAXONOMY_MAPPING_KEY );
+		$override = get_post_meta( $post_id, 'apple_news_section_override', true );
+		if ( empty( $mappings ) || ! empty( $override ) ) {
+			return get_post_meta( $post_id, 'apple_news_sections', true );
+		}
 
 		// Try to get sections.
 		$admin_settings = new Admin_Apple_Settings;
@@ -91,12 +101,6 @@ class Admin_Apple_Sections extends Apple_News {
 			if ( ! empty( $section->id ) && ! empty( $section->links->self ) ) {
 				$sections[ $section->id ] = $section->links->self;
 			}
-		}
-
-		// Try to get section mappings.
-		$mappings = get_option( self::TAXONOMY_MAPPING_KEY );
-		if ( empty( $mappings ) ) {
-			wp_die( __( 'Unable to get section mappings.', 'apple-news' ) );
 		}
 
 		// Try to get configured taxonomy.

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Publish to Apple News Admin Screens: Admin_Apple_Sections class
+ *
+ * Contains a class which is used to manage the Sections admin settings page.
+ *
+ * @package Apple_News
+ * @since 1.2.2
+ */
+
+/**
+ * This class is in charge of handling the management of Apple News sections.
+ *
+ * @since 1.2.2
+ */
+class Admin_Apple_Sections extends Apple_News {
+
+	/**
+	 * Section management page name.
+	 *
+	 * @var string
+	 * @access private
+	 */
+	private $page_name;
+
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+		$this->page_name = $this->plugin_domain . '-sections';
+		add_action( 'admin_menu', array( $this, 'setup_section_page' ), 99 );
+	}
+
+	/**
+	 * Options page setup.
+	 *
+	 * @access public
+	 */
+	public function setup_section_page() {
+		add_submenu_page(
+			'apple_news_index',
+			__( 'Apple News Sections', 'apple-news' ),
+			__( 'Sections', 'apple-news' ),
+			apply_filters( 'apple_news_settings_capability', 'manage_options' ),
+			$this->page_name,
+			array( $this, 'page_sections_render' )
+		);
+	}
+
+	/**
+	 * Options page render.
+	 *
+	 * @access public
+	 */
+	public function page_sections_render() {
+		if ( ! current_user_can( apply_filters( 'apple_news_settings_capability', 'manage_options' ) ) ) {
+			wp_die( __( 'You do not have permissions to access this page.', 'apple-news' ) );
+		}
+
+		include plugin_dir_path( __FILE__ ) . 'partials/page_sections.php';
+	}
+
+	/**
+	 * Register assets for the options page.
+	 *
+	 * @param string $hook
+	 * @access public
+	 */
+	public function register_assets( $hook ) {
+		if ( 'apple-news_page_apple-news-sections' != $hook ) {
+			return;
+		}
+
+		wp_enqueue_style( 'apple-news-sections-css', plugin_dir_url( __FILE__ ) .
+			'../assets/css/sections.css', array() );
+
+		wp_enqueue_script( 'apple-news-sections-js', plugin_dir_url( __FILE__ ) .
+			'../assets/js/sections.js', array( 'jquery' )
+		);
+
+		wp_localize_script( 'apple-news-sections-js', 'appleNewsSections', array(
+			'key1' => __( 'Message 1', 'apple-news' ),
+		) );
+	}
+}

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -19,6 +19,11 @@ use \Apple_Exporter\Settings;
 class Admin_Apple_Sections extends Apple_News {
 
 	/**
+	 * The option name for section/taxonomy mappings.
+	 */
+	const TAXONOMY_MAPPING_KEY = 'apple_news_installed_themes';
+
+	/**
 	 * Section management page name.
 	 *
 	 * @var string
@@ -243,6 +248,37 @@ class Admin_Apple_Sections extends Apple_News {
 	 * @access private
 	 */
 	private function set_section_taxonomy_mappings() {
-		// TODO: Parse apart $_POST['taxonomy-mapping-X'] where X is section ID; array of term names
+
+		// Ensure we got POST data.
+		if ( empty( $_POST ) || ! is_array( $_POST ) ) {
+			return;
+		}
+
+		// Loop through POST data and extract taxonomy mappings.
+		$mappings = [];
+		$taxonomy = self::get_mapping_taxonomy();
+		foreach ( $_POST as $key => $values ) {
+
+			// Ensure the key is in the right format.
+			if ( 0 !== strpos( $key, 'taxonomy-mapping-' ) ) {
+				continue;
+			}
+
+			// Extract the section ID.
+			$section_id = substr( $key, strlen( 'taxonomy-mapping-' ) );
+
+			// Loop over terms and convert to term IDs for save.
+			foreach ( $values as $value ) {
+
+				// Try to get term.
+				$term = get_term_by( 'name', $value, $taxonomy->name );
+				if ( ! empty( $term ) && ! is_wp_error( $term ) ) {
+					$mappings[ $section_id ][] = $term->term_id;
+				}
+			}
+		}
+
+		// Save the new mappings.
+		update_option( self::TAXONOMY_MAPPING_KEY, $mappings );
 	}
 }

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -21,7 +21,7 @@ class Admin_Apple_Sections extends Apple_News {
 	/**
 	 * The option name for section/taxonomy mappings.
 	 */
-	const TAXONOMY_MAPPING_KEY = 'apple_news_installed_themes';
+	const TAXONOMY_MAPPING_KEY = 'apple_news_section_taxonomy_mappings';
 
 	/**
 	 * Section management page name.

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -167,7 +167,7 @@ class Admin_Apple_Sections extends Apple_News {
 		}
 
 		// Check the nonce.
-		check_admin_referer( 'apple_news_sections', 'apple_news_sections' );
+		check_admin_referer( 'apple_news_sections' );
 
 		// Call the callback for the action for further processing.
 		call_user_func( $this->valid_actions[ $action ] );

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -80,18 +80,16 @@ class Admin_Apple_Sections extends Apple_News {
 	 */
 	public static function get_sections_for_post( $post_id ) {
 
-		// Determine if sections should be loaded from postmeta.
-		$post_meta = get_post_meta( $post_id );
-		if ( isset( $post_meta['apple_news_sections'] ) ) {
-			$meta_value = get_post_meta( $post_id, 'apple_news_sections', true );
-
-			return ( is_array( $meta_value ) ) ? $meta_value : array();
-		}
-
 		// Determine if there are taxonomy mappings configured.
 		$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
 		if ( empty( $mappings ) ) {
-			return array();
+			return self::get_sections_from_meta( $post_id );
+		}
+
+		// Load section overrides from postmeta if the meta key is set.
+		$post_meta = get_post_meta( $post_id );
+		if ( isset( $post_meta['apple_news_sections'] ) ) {
+			return self::get_sections_from_meta( $post_id );
 		}
 
 		// Try to get sections.
@@ -332,6 +330,20 @@ class Admin_Apple_Sections extends Apple_News {
 			plugin_dir_url( __FILE__ ) . '../assets/js/sections.js',
 			array( 'jquery', 'jquery-ui-autocomplete' )
 		);
+	}
+
+	/**
+	 * Retrieves an array of sections from postmeta for a given post ID.
+	 *
+	 * @param int $post_id The post ID to look up.
+	 *
+	 * @access private
+	 * @return array An array of sections for the specified post.
+	 */
+	private static function get_sections_from_meta( $post_id ) {
+		$meta_value = get_post_meta( $post_id, 'apple_news_sections', true );
+
+		return ( is_array( $meta_value ) ) ? $meta_value : array();
 	}
 
 	/**

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -154,12 +154,7 @@ class Admin_Apple_Sections extends Apple_News {
 		$section_api = new Section( $this->settings );
 		$sections_raw = $section_api->get_sections();
 		if ( empty( $sections_raw ) || ! is_array( $sections_raw ) ) {
-			// TODO: REMOVE AFTER TESTING
-			$section = new stdClass;
-			$section->id = 'test-section-id';
-			$section->name = 'Main';
-			$sections = [ $section ];
-			//wp_die( __( 'Unable to fetch a list of sections.', 'apple-news' ) );
+			wp_die( __( 'Unable to fetch a list of sections.', 'apple-news' ) );
 		}
 
 		// Convert sections returned from the API into a key/value pair of id/name.

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -154,7 +154,12 @@ class Admin_Apple_Sections extends Apple_News {
 		$section_api = new Section( $this->settings );
 		$sections_raw = $section_api->get_sections();
 		if ( empty( $sections_raw ) || ! is_array( $sections_raw ) ) {
-			wp_die( __( 'Unable to fetch a list of sections.', 'apple-news' ) );
+			// TODO: REMOVE AFTER TESTING
+			$section = new stdClass;
+			$section->id = 'test-section-id';
+			$section->name = 'Main';
+			$sections = [ $section ];
+			//wp_die( __( 'Unable to fetch a list of sections.', 'apple-news' ) );
 		}
 
 		// Convert sections returned from the API into a key/value pair of id/name.

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -80,16 +80,16 @@ class Admin_Apple_Sections extends Apple_News {
 	 */
 	public static function get_sections_for_post( $post_id ) {
 
+		// Try to load sections from postmeta.
+		$meta_value = get_post_meta( $post_id, 'apple_news_sections', true );
+		if ( is_array( $meta_value ) ) {
+			return $meta_value;
+		}
+
 		// Determine if there are taxonomy mappings configured.
 		$mappings = get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
 		if ( empty( $mappings ) ) {
-			return self::get_sections_from_meta( $post_id );
-		}
-
-		// Load section overrides from postmeta if the meta key is set.
-		$post_meta = get_post_meta( $post_id );
-		if ( isset( $post_meta['apple_news_sections'] ) ) {
-			return self::get_sections_from_meta( $post_id );
+			return array();
 		}
 
 		// Try to get sections.
@@ -330,20 +330,6 @@ class Admin_Apple_Sections extends Apple_News {
 			plugin_dir_url( __FILE__ ) . '../assets/js/sections.js',
 			array( 'jquery', 'jquery-ui-autocomplete' )
 		);
-	}
-
-	/**
-	 * Retrieves an array of sections from postmeta for a given post ID.
-	 *
-	 * @param int $post_id The post ID to look up.
-	 *
-	 * @access private
-	 * @return array An array of sections for the specified post.
-	 */
-	private static function get_sections_from_meta( $post_id ) {
-		$meta_value = get_post_meta( $post_id, 'apple_news_sections', true );
-
-		return ( is_array( $meta_value ) ) ? $meta_value : array();
 	}
 
 	/**

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -84,7 +84,9 @@ class Admin_Apple_Sections extends Apple_News {
 		$mappings = get_option( self::TAXONOMY_MAPPING_KEY );
 		$override = get_post_meta( $post_id, 'apple_news_section_override', true );
 		if ( empty( $mappings ) || ! empty( $override ) ) {
-			return get_post_meta( $post_id, 'apple_news_sections', true );
+			$sections = get_post_meta( $post_id, 'apple_news_sections', true );
+
+			return ( is_array( $sections ) ) ? $sections : array();
 		}
 
 		// Try to get sections.

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -367,9 +367,11 @@ class Admin_Apple_Sections extends Apple_News {
 			// Loop over terms and convert to term IDs for save.
 			$values = array_map( 'sanitize_text_field', $_POST[ $key ] );
 			foreach ( $values as $value ) {
-
-				// Try to get term.
-				$term = get_term_by( 'name', $value, $taxonomy->name );
+				if ( function_exists( 'wpcom_vip_get_term_by' ) ) {
+					$term = wpcom_vip_get_term_by( 'name', $value, $taxonomy->name );
+				} else {
+					$term = get_term_by( 'name', $value, $taxonomy->name );
+				}
 				if ( ! empty( $term ) && ! is_wp_error( $term ) ) {
 					$mappings[ $section_id ][] = $term->term_id;
 					$mappings[ $section_id ] = array_unique( $mappings[ $section_id ] );

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -68,6 +68,21 @@ class Admin_Apple_Sections extends Apple_News {
 	}
 
 	/**
+	 * Given a post ID, returns an array of sections based on applied taxonomy.
+	 *
+	 * @param int $post_id The ID of the post to query.
+	 * @param string $field The section field to return. Can be 'id' or 'url'.
+	 *
+	 * @access public
+	 * @return array An array of section identifiers for the post.
+	 */
+	public static function get_sections_for_post( $post_id, $field = 'id' ) {
+
+		// TODO: WIRE THIS UP
+		return array();
+	}
+
+	/**
 	 * Constructor.
 	 */
 	function __construct() {

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -8,6 +8,9 @@
  * @since 1.2.2
  */
 
+use \Apple_Actions\Index\Section;
+use \Apple_Exporter\Settings;
+
 /**
  * This class is in charge of handling the management of Apple News sections.
  *
@@ -24,11 +27,45 @@ class Admin_Apple_Sections extends Apple_News {
 	private $page_name;
 
 	/**
+	 * Contains settings loaded from WordPress and merged with defaults.
+	 *
+	 * @var Settings
+	 * @access private
+	 */
+	private $settings;
+
+	/**
 	 * Constructor.
 	 */
 	function __construct() {
+
+		// Initialize class variables.
 		$this->page_name = $this->plugin_domain . '-sections';
+		$admin_settings = new Admin_Apple_Settings;
+		$this->settings = $admin_settings->fetch_settings();
+
+		// Set up action hooks.
 		add_action( 'admin_menu', array( $this, 'setup_section_page' ), 99 );
+	}
+
+	/**
+	 * Returns a taxonomy object representing the taxonomy to be mapped to sections.
+	 *
+	 * @access public
+	 * @return WP_Taxonomy|false A WP_Taxonomy object on success; false on failure.
+	 */
+	public static function get_mapping_taxonomy() {
+
+		/**
+		 * Allows for modification of the taxonomy used for section mapping.
+		 *
+		 * @since 1.2.2
+		 *
+		 * @param string $taxonomy The taxonomy slug to be filtered.
+		 */
+		$taxonomy = apply_filters( 'apple_news_section_taxonomy', 'category' );
+
+		return get_taxonomy( $taxonomy );
 	}
 
 	/**
@@ -53,10 +90,34 @@ class Admin_Apple_Sections extends Apple_News {
 	 * @access public
 	 */
 	public function page_sections_render() {
+
+		// Don't allow access to this page if the user does not have permission.
 		if ( ! current_user_can( apply_filters( 'apple_news_settings_capability', 'manage_options' ) ) ) {
 			wp_die( __( 'You do not have permissions to access this page.', 'apple-news' ) );
 		}
 
+		// Negotiate the taxonomy name.
+		$taxonomy = self::get_mapping_taxonomy();
+		if ( empty( $taxonomy->label ) ) {
+			wp_die( __( 'You specified an invalid mapping taxonomy.', 'apple-news' ) );
+		}
+
+		// Try to get a list of sections.
+		$section_api = new Section( $this->settings );
+		$sections_raw = $section_api->get_sections();
+		if ( empty( $sections_raw ) || ! is_array( $sections_raw ) ) {
+			wp_die( __( 'Unable to fetch a list of sections.', 'apple-news' ) );
+		}
+
+		// Convert sections returned from the API into a key/value pair of id/name.
+		$sections = [];
+		foreach ( $sections_raw as $section ) {
+			if ( ! empty( $section->id ) && ! empty( $section->name ) ) {
+				$sections[ $section->id ] = $section->name;
+			}
+		}
+
+		// Load the partial with the form.
 		include plugin_dir_path( __FILE__ ) . 'partials/page_sections.php';
 	}
 

--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -16,6 +16,14 @@ use Apple_Exporter\Settings as Settings;
 class Admin_Apple_Settings extends Apple_News {
 
 	/**
+	 * Keeps track of whether functionality has been initialized or not.
+	 *
+	 * @access private
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
 	 * Associative array of fields and types. If not present, defaults to string.
 	 * Possible types are: integer, color, boolean, string and options.
 	 * If options, use an array instead of a string.
@@ -68,9 +76,12 @@ class Admin_Apple_Settings extends Apple_News {
 		$this->sections = array();
 		$this->page_name = $this->plugin_domain . '-options';
 
-		add_action( 'admin_init', array( $this, 'register_sections' ), 5 );
-		add_action( 'admin_menu', array( $this, 'setup_options_page' ), 99 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'register_assets' ) );
+		if ( ! self::$initialized ) {
+			add_action( 'admin_init', array( $this, 'register_sections' ), 5 );
+			add_action( 'admin_menu', array( $this, 'setup_options_page' ), 99 );
+			add_action( 'admin_enqueue_scripts', array( $this, 'register_assets' ) );
+			self::$initialized = true;
+		}
 	}
 
 	/**

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -26,7 +26,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @var string
 	 * @const
 	 */
-	const theme_index_key = 'apple_news_installed_themes';
+	const THEME_INDEX_KEY = 'apple_news_installed_themes';
 
 	/**
 	 * Key for the active theme.
@@ -34,7 +34,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @var string
 	 * @const
 	 */
-	const theme_active_key = 'apple_news_active_theme';
+	const THEME_ACTIVE_KEY = 'apple_news_active_theme';
 
 	/**
 	 * Prefix for individual theme keys.
@@ -42,7 +42,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @var string
 	 * @const
 	 */
-	const theme_key_prefix = 'apple_news_theme_';
+	const THEME_KEY_PREFIX = 'apple_news_theme_';
 
 	/**
 	 * Valid actions handled by this class and their callback functions.
@@ -193,7 +193,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @return array
 	 */
 	public function list_themes() {
-		return get_option( self::theme_index_key, array() );
+		return get_option( self::THEME_INDEX_KEY, array() );
 	}
 
 	/**
@@ -203,7 +203,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @return string
 	 */
 	public function get_active_theme() {
-		return get_option( self::theme_active_key );
+		return get_option( self::THEME_ACTIVE_KEY );
 	}
 
 	/**
@@ -244,7 +244,7 @@ class Admin_Apple_Themes extends Apple_News {
 		$index = array_unique( $index );
 
 		// Save the theme index
-		update_option( self::theme_index_key, $index, false );
+		update_option( self::THEME_INDEX_KEY, $index, false );
 
 		// Indicate success
 		\Admin_Apple_Notice::success( sprintf(
@@ -338,7 +338,7 @@ class Admin_Apple_Themes extends Apple_News {
 		$settings->save_settings( $new_settings );
 
 		// Set the theme active
-		update_option( self::theme_active_key, $name, false );
+		update_option( self::THEME_ACTIVE_KEY, $name, false );
 
 		// Indicate success
 		\Admin_Apple_Notice::success( sprintf(
@@ -382,7 +382,7 @@ class Admin_Apple_Themes extends Apple_News {
 
 		// Remove from the index and delete settings
 		unset( $themes[ $index ] );
-		update_option( self::theme_index_key, $themes, false );
+		update_option( self::THEME_INDEX_KEY, $themes, false );
 		delete_option( $key );
 
 		// Indicate success
@@ -676,7 +676,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access public
 	 */
 	public function theme_key_from_name( $name ) {
-		return self::theme_key_prefix . sanitize_key( $name );
+		return self::THEME_KEY_PREFIX . sanitize_key( $name );
 	}
 
 	/**

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -1,9 +1,10 @@
 <div class="wrap apple-news-sections">
 	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
 	<h2><?php esc_html_e( 'Section', 'apple-news' ) ?>/<?php echo esc_html( $taxonomy->labels->singular_name ); ?> <?php esc_html_e( 'Mappings', 'apple-news' ) ?></h2>
-	<p><?php esc_html_e( 'To enable automatic section assignment, choose the', 'apple-news' ); ?>
-		<?php echo esc_html( strtolower( $taxonomy->label ) ); ?>
-		<?php esc_html_e( 'that you would like to be associated with each section.', 'apple-news' ); ?>
+	<p><?php echo esc_html( sprintf(
+			__( 'To enable automatic section assignment, choose the %s that you would like to be associated with each section.', 'apple-news' ),
+			strtolower( $taxonomy->label )
+		) ); ?>
 	</p>
 	<form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
 		<?php wp_nonce_field( 'apple_news_sections' ); ?>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -1,53 +1,53 @@
 <div class="wrap apple-news-sections">
 	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
-    <h2><?php esc_html_e( 'Section', 'apple-news' ) ?>/<?php echo esc_html( $taxonomy->labels->singular_name ); ?> <?php esc_html_e( 'Mappings', 'apple-news' ) ?></h2>
-    <p><?php esc_html_e( 'To enable automatic section assignment, choose the', 'apple-news' ); ?>
-        <?php echo esc_html( strtolower( $taxonomy->label ) ); ?>
-        <?php esc_html_e( 'that you would like to be associated with each section.', 'apple-news' ); ?>
-    </p>
-    <form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
-	    <?php wp_nonce_field( 'apple_news_sections' ); ?>
-        <input name="action" type="hidden" value="apple_news_set_section_taxonomy_mappings" />
-        <div id="apple-news-section-taxonomy-mapping-template">
-            <label class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
-            <input type="text" class="apple-news-section-taxonomy-autocomplete" />
-            <button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
-        </div>
-        <table class="wp-list-table widefat fixed striped">
-            <thead>
-            <tr>
-                <th scope="col" id="apple_news_section_name" class="manage-column column-apple-news-section-name column-primary"><?php esc_html_e( 'Section', 'apple-news' ); ?></th>
-                <th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php echo esc_html( $taxonomy->label ); ?></th>
-            </tr>
-            </thead>
-            <tbody id="apple-news-sections-list">
-            <?php $count = 0; ?>
-            <?php foreach ( $sections as $section_id => $section_name ): ?>
-                <tr id="apple-news-section-<?php echo esc_attr( $section_id ); ?>">
-                    <td><?php echo esc_html( $section_name ); ?></td>
-                    <td>
-                        <ul class="apple-news-section-taxonomy-mapping-list">
-                        <?php if ( ! empty( $mappings[ $section_id ] ) ): ?>
-                            <?php foreach ( $mappings[ $section_id ] as $term ): ?>
-                                <?php $id = 'apple-news-section-mapping-' . ++ $count; ?>
-                                <li>
-                                    <label for="<?php echo esc_attr( $id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
-                                    <input name="taxonomy-mapping-<?php echo esc_attr( $section_id ); ?>[]" id="<?php echo esc_attr( $id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
-                                    <button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
-                                </li>
-                            <?php endforeach; ?>
-                        <?php endif; ?>
-                        </ul>
-                        <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add', 'apple-news' ); ?> <?php echo esc_html( $taxonomy->labels->singular_name ); ?></button>
-                    </td>
-                </tr>
-            <?php endforeach; ?>
-            </tbody>
-        </table>
-	    <?php submit_button(
-		    __( 'Save Changes', 'apple-news' ),
-		    'primary',
-		    'apple_news_set_section_taxonomy_mappings'
-	    ); ?>
-    </form>
+	<h2><?php esc_html_e( 'Section', 'apple-news' ) ?>/<?php echo esc_html( $taxonomy->labels->singular_name ); ?> <?php esc_html_e( 'Mappings', 'apple-news' ) ?></h2>
+	<p><?php esc_html_e( 'To enable automatic section assignment, choose the', 'apple-news' ); ?>
+		<?php echo esc_html( strtolower( $taxonomy->label ) ); ?>
+		<?php esc_html_e( 'that you would like to be associated with each section.', 'apple-news' ); ?>
+	</p>
+	<form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
+		<?php wp_nonce_field( 'apple_news_sections' ); ?>
+		<input name="action" type="hidden" value="apple_news_set_section_taxonomy_mappings" />
+		<div id="apple-news-section-taxonomy-mapping-template">
+			<label class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+			<input type="text" class="apple-news-section-taxonomy-autocomplete" />
+			<button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
+		</div>
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+			<tr>
+				<th scope="col" id="apple_news_section_name" class="manage-column column-apple-news-section-name column-primary"><?php esc_html_e( 'Section', 'apple-news' ); ?></th>
+				<th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php echo esc_html( $taxonomy->label ); ?></th>
+			</tr>
+			</thead>
+			<tbody id="apple-news-sections-list">
+			<?php $count = 0; ?>
+			<?php foreach ( $sections as $section_id => $section_name ): ?>
+				<tr id="apple-news-section-<?php echo esc_attr( $section_id ); ?>">
+					<td><?php echo esc_html( $section_name ); ?></td>
+					<td>
+						<ul class="apple-news-section-taxonomy-mapping-list">
+						<?php if ( ! empty( $mappings[ $section_id ] ) ): ?>
+							<?php foreach ( $mappings[ $section_id ] as $term ): ?>
+								<?php $id = 'apple-news-section-mapping-' . ++ $count; ?>
+								<li>
+									<label for="<?php echo esc_attr( $id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+									<input name="taxonomy-mapping-<?php echo esc_attr( $section_id ); ?>[]" id="<?php echo esc_attr( $id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
+									<button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
+								</li>
+							<?php endforeach; ?>
+						<?php endif; ?>
+						</ul>
+						<button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add', 'apple-news' ); ?> <?php echo esc_html( $taxonomy->labels->singular_name ); ?></button>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+			</tbody>
+		</table>
+		<?php submit_button(
+			__( 'Save Changes', 'apple-news' ),
+			'primary',
+			'apple_news_set_section_taxonomy_mappings'
+		); ?>
+	</form>
 </div>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -2,6 +2,10 @@
 	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
     <form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
 	    <?php wp_nonce_field( 'apple_news_sections', 'apple_news_sections' ); ?>
+        <div id="apple-news-section-taxonomy-mapping-template">
+            <label class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+            <input type="text" class="apple-news-section-taxonomy-autocomplete" />
+        </div>
         <table class="wp-list-table widefat fixed striped">
             <thead>
             <tr>
@@ -9,7 +13,7 @@
                 <th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php esc_html( $taxonomy->label ); ?></th>
             </tr>
             </thead>
-            <tbody id="sections-list">
+            <tbody id="apple-news-sections-list">
             <?php foreach ( $sections as $section_id => $section_name ): ?>
                 <tr id="apple-news-section-<?php echo esc_attr( $section_id ); ?>">
                     <td><?php echo esc_html( $section_name ); ?></td>
@@ -17,8 +21,6 @@
                         <ul class="apple-news-section-taxonomy-mapping-list">
 	                        <?php // TODO: Wire up autocomplete fields here. ?>
                             <li>
-                                <label for="apple-news-section-taxonomy-mapping-1" class="screen-reader-text"><?php echo esc_html( $section_name ); ?> Mapping 1</label>
-                                <input id="apple-news-section-taxonomy-mapping-1" type="text" class="apple-news-section-taxonomy-autocomplete" />
                             </li>
                         </ul>
                         <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add Mapping', 'apple-news' ); ?></button>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -11,10 +11,16 @@
             </thead>
             <tbody id="sections-list">
             <?php foreach ( $sections as $section_id => $section_name ): ?>
-                <tr>
+                <tr id="apple-news-section-<?php echo esc_attr( $section_id ); ?>">
                     <td><?php echo esc_html( $section_name ); ?></td>
                     <td>
-                        <?php // TODO: Wire up autocomplete fields here. ?>
+                        <ul class="apple-news-section-taxonomy-mapping-list">
+	                        <?php // TODO: Wire up autocomplete fields here. ?>
+                            <li>
+                                <label for="apple-news-section-taxonomy-mapping-1" class="screen-reader-text"><?php echo esc_html( $section_name ); ?> Mapping 1</label>
+                                <input id="apple-news-section-taxonomy-mapping-1" type="text" class="apple-news-section-taxonomy-autocomplete" />
+                            </li>
+                        </ul>
                         <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add Mapping', 'apple-news' ); ?></button>
                     </td>
                 </tr>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -1,5 +1,10 @@
 <div class="wrap apple-news-sections">
 	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
+    <h2><?php esc_html_e( 'Section', 'apple-news' ) ?>/<?php echo esc_html( $taxonomy->labels->singular_name ); ?> <?php esc_html_e( 'Mappings', 'apple-news' ) ?></h2>
+    <p><?php esc_html_e( 'To enable automatic section assignment, choose the', 'apple-news' ); ?>
+        <?php echo esc_html( strtolower( $taxonomy->label ) ); ?>
+        <?php esc_html_e( 'that you would like to be associated with each section.', 'apple-news' ); ?>
+    </p>
     <form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
 	    <?php wp_nonce_field( 'apple_news_sections', 'apple_news_sections' ); ?>
         <input name="action" type="hidden" value="apple_news_set_section_taxonomy_mappings" />
@@ -12,18 +17,28 @@
             <thead>
             <tr>
                 <th scope="col" id="apple_news_section_name" class="manage-column column-apple-news-section-name column-primary"><?php esc_html_e( 'Section', 'apple-news' ); ?></th>
-                <th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php esc_html( $taxonomy->label ); ?></th>
+                <th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php echo esc_html( $taxonomy->label ); ?></th>
             </tr>
             </thead>
             <tbody id="apple-news-sections-list">
+            <?php $count = 0; ?>
             <?php foreach ( $sections as $section_id => $section_name ): ?>
                 <tr id="apple-news-section-<?php echo esc_attr( $section_id ); ?>">
                     <td><?php echo esc_html( $section_name ); ?></td>
                     <td>
                         <ul class="apple-news-section-taxonomy-mapping-list">
-	                        <?php // TODO: Wire up autocomplete fields here. ?>
+                        <?php if ( ! empty( $mappings[ $section_id ] ) ): ?>
+                            <?php foreach ( $mappings[ $section_id ] as $term ): ?>
+                                <?php $id = 'apple-news-section-mapping-' . ++ $count; ?>
+                                <li>
+                                    <label for="<?php echo esc_attr( $id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+                                    <input name="taxonomy-mapping-<?php echo esc_attr( $section_id ); ?>[]" id="<?php echo esc_attr( $id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
+                                    <button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
+                                </li>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
                         </ul>
-                        <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add Mapping', 'apple-news' ); ?></button>
+                        <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add', 'apple-news' ); ?> <?php echo esc_html( $taxonomy->labels->singular_name ); ?></button>
                     </td>
                 </tr>
             <?php endforeach; ?>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -2,6 +2,7 @@
 	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
     <form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
 	    <?php wp_nonce_field( 'apple_news_sections', 'apple_news_sections' ); ?>
+        <input name="action" type="hidden" value="apple_news_set_section_taxonomy_mappings" />
         <div id="apple-news-section-taxonomy-mapping-template">
             <label class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
             <input type="text" class="apple-news-section-taxonomy-autocomplete" />

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -21,8 +21,6 @@
                     <td>
                         <ul class="apple-news-section-taxonomy-mapping-list">
 	                        <?php // TODO: Wire up autocomplete fields here. ?>
-                            <li>
-                            </li>
                         </ul>
                         <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add Mapping', 'apple-news' ); ?></button>
                     </td>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -6,7 +6,7 @@
         <?php esc_html_e( 'that you would like to be associated with each section.', 'apple-news' ); ?>
     </p>
     <form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
-	    <?php wp_nonce_field( 'apple_news_sections', 'apple_news_sections' ); ?>
+	    <?php wp_nonce_field( 'apple_news_sections' ); ?>
         <input name="action" type="hidden" value="apple_news_set_section_taxonomy_mappings" />
         <div id="apple-news-section-taxonomy-mapping-template">
             <label class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -1,0 +1,3 @@
+<div class="wrap apple-news-sections">
+	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
+</div>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -1,3 +1,30 @@
 <div class="wrap apple-news-sections">
 	<h1 id="apple_news_sections_title"><?php esc_html_e( 'Manage Sections', 'apple-news' ) ?></h1>
+    <form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
+	    <?php wp_nonce_field( 'apple_news_sections', 'apple_news_sections' ); ?>
+        <table class="wp-list-table widefat fixed striped">
+            <thead>
+            <tr>
+                <th scope="col" id="apple_news_section_name" class="manage-column column-apple-news-section-name column-primary"><?php esc_html_e( 'Section', 'apple-news' ); ?></th>
+                <th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php esc_html( $taxonomy->label ); ?></th>
+            </tr>
+            </thead>
+            <tbody id="sections-list">
+            <?php foreach ( $sections as $section_id => $section_name ): ?>
+                <tr>
+                    <td><?php echo esc_html( $section_name ); ?></td>
+                    <td>
+                        <?php // TODO: Wire up autocomplete fields here. ?>
+                        <button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add Mapping', 'apple-news' ); ?></button>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+	    <?php submit_button(
+		    __( 'Save Changes', 'apple-news' ),
+		    'primary',
+		    'apple_news_set_section_taxonomy_mappings'
+	    ); ?>
+    </form>
 </div>

--- a/admin/partials/page_sections.php
+++ b/admin/partials/page_sections.php
@@ -5,6 +5,7 @@
         <div id="apple-news-section-taxonomy-mapping-template">
             <label class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
             <input type="text" class="apple-news-section-taxonomy-autocomplete" />
+            <button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
         </div>
         <table class="wp-list-table widefat fixed striped">
             <thead>

--- a/admin/partials/page_single_push.php
+++ b/admin/partials/page_single_push.php
@@ -16,8 +16,11 @@
 			<tr>
 				<th scope="row"><?php esc_html_e( 'Sections', 'apple-news' ) ?></th>
 				<td>
-					<?php \Admin_Apple_Meta_Boxes::build_sections_field( $sections, $post->ID ); ?>
-					<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. Uncheck them all for a standalone article.' , 'apple-news' ) ?></p>
+					<?php \Admin_Apple_Meta_Boxes::build_sections_override( $post->ID ); ?>
+					<div class="apple-news-sections">
+						<?php \Admin_Apple_Meta_Boxes::build_sections_field( $sections, $post->ID ); ?>
+						<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. Uncheck them all for a standalone article.' , 'apple-news' ) ?></p>
+					</div>
 				</td>
 			</tr>
 			<?php endif; ?>

--- a/assets/css/sections.css
+++ b/assets/css/sections.css
@@ -1,0 +1,4 @@
+#apple-news-section-taxonomy-mapping-template {
+    display: none;
+    visibility: hidden;
+}

--- a/assets/css/sections.css
+++ b/assets/css/sections.css
@@ -2,3 +2,34 @@
     display: none;
     visibility: hidden;
 }
+
+.apple-news-section-taxonomy-remove {
+    background: none;
+    border: none;
+    cursor: pointer;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    text-indent: 0;
+    width: 24px;
+}
+
+.apple-news-section-taxonomy-remove:hover .apple-news-section-taxonomy-remove-icon:before {
+    color: #c00;
+}
+
+.apple-news-section-taxonomy-remove-icon:before {
+    background: none;
+    border-radius: 50%;
+    color: #0073aa;
+    content: "\f153";
+    display: block;
+    font: 400 16px/20px dashicons;
+    height: 20px;
+    line-height: 1.28;
+    margin-left: 2px;
+    speak: none;
+    text-align: center;
+    width: 20px;
+}

--- a/assets/css/sections.css
+++ b/assets/css/sections.css
@@ -1,35 +1,35 @@
 #apple-news-section-taxonomy-mapping-template {
-    display: none;
-    visibility: hidden;
+	display: none;
+	visibility: hidden;
 }
 
 .apple-news-section-taxonomy-remove {
-    background: none;
-    border: none;
-    cursor: pointer;
-    height: 24px;
-    margin: 0;
-    padding: 0;
-    position: absolute;
-    text-indent: 0;
-    width: 24px;
+	background: none;
+	border: none;
+	cursor: pointer;
+	height: 24px;
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	text-indent: 0;
+	width: 24px;
 }
 
 .apple-news-section-taxonomy-remove:hover .apple-news-section-taxonomy-remove-icon:before {
-    color: #c00;
+	color: #c00;
 }
 
 .apple-news-section-taxonomy-remove-icon:before {
-    background: none;
-    border-radius: 50%;
-    color: #0073aa;
-    content: "\f153";
-    display: block;
-    font: 400 16px/20px dashicons;
-    height: 20px;
-    line-height: 1.28;
-    margin-left: 2px;
-    speak: none;
-    text-align: center;
-    width: 20px;
+	background: none;
+	border-radius: 50%;
+	color: #0073aa;
+	content: "\f153";
+	display: block;
+	font: 400 16px/20px dashicons;
+	height: 20px;
+	line-height: 1.28;
+	margin-left: 2px;
+	speak: none;
+	text-align: center;
+	width: 20px;
 }

--- a/assets/js/meta-boxes.js
+++ b/assets/js/meta-boxes.js
@@ -1,9 +1,22 @@
 (function ( $, window, undefined ) {
 	'use strict';
 
+	var $assign_by_taxonomy = $( '#apple-news-sections-by-taxonomy' );
+
 	$( '#apple-news-publish-submit' ).click(function ( e ) {
 		$( '#apple-news-publish-action' ).val( apple_news_meta_boxes.publish_action );
 		$( '#post' ).submit();
 	});
+
+	// Listen for changes to the "assign by taxonomy" checkbox.
+	if ( $assign_by_taxonomy.length ) {
+		$assign_by_taxonomy.on( 'change', function () {
+			if ( $( this ).is( ':checked' ) ) {
+				$( '.apple-news-sections' ).hide();
+			} else {
+				$( '.apple-news-sections' ).show();
+			}
+		} ).change();
+	}
 
 })( jQuery, window );

--- a/assets/js/sections.js
+++ b/assets/js/sections.js
@@ -1,0 +1,31 @@
+(
+	function ( $ ) {
+		$( document ).ready( function () {
+
+			// An object to contain configuration and functionality for the Sections settings page.
+			var apple_news_sections = {
+
+				/**
+				 * A function that enables autocomplete on taxonomy mapping fields.
+				 */
+				enable_autocomplete: function () {
+					$( '.apple-news-section-taxonomy-autocomplete' ).autocomplete( {
+						delay: 500,
+						minLength: 3,
+						source: ajaxurl + '?action=apple_news_section_taxonomy_autocomplete'
+					} );
+				},
+
+				/**
+				 * A function that initializes functionality on the Settings admin screen.
+				 */
+				init: function () {
+					this.enable_autocomplete();
+				}
+			};
+
+			// Initialize functionality.
+			apple_news_sections.init();
+		} );
+	}( jQuery )
+);

--- a/assets/js/sections.js
+++ b/assets/js/sections.js
@@ -28,12 +28,13 @@
 						// Copy the HTML from the template.
 						$item.html( $template.html() );
 
-						// Set a unique ID on the input field that we just created.
+						// Create a unique ID on the input and map it to the label.
 						$input = $item.find( 'input' );
 						$input.uniqueId();
-
-						// Wire up the label using the unique ID.
 						$item.find( 'label' ).attr( 'for', $input.attr( 'id' ) );
+
+						// Set the correct name on the field.
+						$input.attr( 'name', 'taxonomy-mapping-' + $( this ).attr( 'data-section-id' ) + '[]' );
 
 						// Add the item to the list.
 						$( this ).siblings( '.apple-news-section-taxonomy-mapping-list' ).append( $item );

--- a/assets/js/sections.js
+++ b/assets/js/sections.js
@@ -9,10 +9,37 @@
 				 * A function that enables autocomplete on taxonomy mapping fields.
 				 */
 				enable_autocomplete: function () {
-					$( '.apple-news-section-taxonomy-autocomplete' ).autocomplete( {
+					$( '#apple-news-sections-list' ).find( '.apple-news-section-taxonomy-autocomplete' ).autocomplete( {
 						delay: 500,
 						minLength: 3,
 						source: ajaxurl + '?action=apple_news_section_taxonomy_autocomplete'
+					} );
+				},
+
+				/**
+				 * A function to set up listeners for additions to mappings.
+				 */
+				listen_for_additions: function () {
+					$( '.apple-news-add-section-taxonomy-mapping' ).on( 'click', function () {
+						var $template = $( '#apple-news-section-taxonomy-mapping-template' ),
+							$item = $( '<li>' ),
+							$input;
+
+						// Copy the HTML from the template.
+						$item.html( $template.html() );
+
+						// Set a unique ID on the input field that we just created.
+						$input = $item.find( 'input' );
+						$input.uniqueId();
+
+						// Wire up the label using the unique ID.
+						$item.find( 'label' ).attr( 'for', $input.attr( 'id' ) );
+
+						// Add the item to the list.
+						$( this ).siblings( '.apple-news-section-taxonomy-mapping-list' ).append( $item );
+
+						// Activate autocomplete.
+						apple_news_sections.enable_autocomplete();
 					} );
 				},
 
@@ -21,6 +48,7 @@
 				 */
 				init: function () {
 					this.enable_autocomplete();
+					this.listen_for_additions();
 				}
 			};
 

--- a/assets/js/sections.js
+++ b/assets/js/sections.js
@@ -44,11 +44,19 @@
 				},
 
 				/**
+				 * A function to set up listeners for mapping deletions.
+				 */
+				listen_for_deletions: function () {
+
+				},
+
+				/**
 				 * A function that initializes functionality on the Settings admin screen.
 				 */
 				init: function () {
 					this.enable_autocomplete();
 					this.listen_for_additions();
+					this.listen_for_deletions();
 				}
 			};
 

--- a/assets/js/sections.js
+++ b/assets/js/sections.js
@@ -47,7 +47,9 @@
 				 * A function to set up listeners for mapping deletions.
 				 */
 				listen_for_deletions: function () {
-
+					$( '#apple-news-sections-list' ).on( 'click', '.apple-news-section-taxonomy-remove', function () {
+						$( this ).parent().remove();
+					} );
 				},
 
 				/**

--- a/assets/js/single-push.js
+++ b/assets/js/single-push.js
@@ -1,0 +1,17 @@
+(function ( $, window, undefined ) {
+	'use strict';
+
+	var $assign_by_taxonomy = $( '#apple-news-sections-by-taxonomy' );
+
+	// Listen for changes to the "assign by taxonomy" checkbox.
+	if ( $assign_by_taxonomy.length ) {
+		$assign_by_taxonomy.on( 'change', function () {
+			if ( $( this ).is( ':checked' ) ) {
+				$( '.apple-news-sections' ).hide();
+			} else {
+				$( '.apple-news-sections' ).show();
+			}
+		} ).change();
+	}
+
+})( jQuery, window );

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -108,6 +108,7 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 			),
 			'taxonomy-mapping-abcdef01-2345-6789-abcd-ef012356789b' => array(
 				'Category 2',
+				'Category 3',
 			),
 		);
 		$_REQUEST = array(
@@ -126,7 +127,8 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 					$category1->term_id
 				),
 				'abcdef01-2345-6789-abcd-ef012356789b' => array(
-					$category2->term_id
+					$category2->term_id,
+					$category3->term_id,
 				),
 			),
 			get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY )

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Publish to Apple News Tests: Admin_Apple_Sections_Test class
+ *
+ * Contains a class to test the Admin_Apple_Sections class.
+ *
+ * @since 1.2.2
+ */
+
+use \Apple_Exporter\Settings;
+
+/**
+ * A class to test the Admin_Apple_Sections class.
+ *
+ * @since 1.2.2
+ */
+class Admin_Apple_Sections_Test extends WP_UnitTestCase {
+
+	/**
+	 * Actions to be run before each test in this class.
+	 *
+	 * @access public
+	 */
+	public function setUp() {
+		parent::setup();
+		$this->settings = new Settings();
+		set_transient(
+			'apple_news_sections',
+			array(
+				(object) array(
+					'createdAt' => '2017-01-01T00:00:00Z',
+					'id' => 'abcdef01-2345-6789-abcd-ef012356789a',
+					'isDefault' => true,
+					'links' => (object) array(
+						'channel' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
+						'self' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
+					),
+					'modifiedAt' => '2017-01-01T00:00:00Z',
+					'name' => 'Main',
+					'shareUrl' => 'https://apple.news/AbCdEfGhIj-KlMnOpQrStUv',
+					'type' => 'section',
+				),
+				(object) array(
+					'createdAt' => '2017-01-01T00:00:00Z',
+					'id' => 'abcdef01-2345-6789-abcd-ef012356789b',
+					'isDefault' => false,
+					'links' => (object) array(
+						'channel' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
+						'self' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
+					),
+					'modifiedAt' => '2017-01-01T00:00:00Z',
+					'name' => 'Secondary Section',
+					'shareUrl' => 'https://apple.news/AbCdEfGhIj-KlMnOpQrStUw',
+					'type' => 'section',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Ensures that the apple_news_section_taxonomy filter is working properly.
+	 *
+	 * @access public
+	 */
+	public function testMappingTaxonomyFilter() {
+
+		// Test default behavior.
+		$taxonomy = Admin_Apple_Sections::get_mapping_taxonomy();
+		$this->assertEquals( 'category', $taxonomy->name );
+
+		// Switch to post tag.
+		add_filter( 'apple_news_section_taxonomy', function () {
+			return 'post_tag';
+		} );
+
+		// Test filtered value.
+		$taxonomy = Admin_Apple_Sections::get_mapping_taxonomy();
+		$this->assertEquals( 'post_tag', $taxonomy->name );
+	}
+
+	// TODO: Test filter for mapping taxonomy.
+	// TODO: Test save category mappings
+	// TODO: Test create post with categories in category mappings and ensure sections are properly set
+	// TODO: Test override functionality for manual settings selection
+}

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -67,6 +67,46 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that automatic section/category mappings function properly.
+	 *
+	 * @access public
+	 */
+	public function testAutomaticCategoryMapping() {
+
+		// Set up mappings.
+		$_POST = array(
+			'action' => 'apple_news_set_section_taxonomy_mappings',
+			'page' => 'apple_news_sections',
+			'taxonomy-mapping-abcdef01-2345-6789-abcd-ef012356789a' => array(
+				'Category 1',
+			),
+			'taxonomy-mapping-abcdef01-2345-6789-abcd-ef012356789b' => array(
+				'Category 2',
+				'Category 3',
+			),
+		);
+		$_REQUEST = array(
+			'_wp_http_referer' => '/wp-admin/admin.php?page=apple-news-sections',
+			'_wpnonce' => wp_create_nonce( 'apple_news_sections' ),
+		);
+		$sections = new Admin_Apple_Sections();
+		$sections->action_router();
+
+		// Create a post with Category 2 to trigger second section membership.
+		$category2 = get_term_by( 'name', 'Category 2', 'category' );
+		$post_id = $this->factory->post->create();
+		wp_set_post_categories( $post_id, $category2->term_id );
+
+		// Validate automatic section assignment.
+		$this->assertEquals(
+			array(
+				'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
+			),
+			Admin_Apple_Sections::get_sections_for_post( $post_id )
+		);
+	}
+
+	/**
 	 * Ensures that the apple_news_section_taxonomy filter is working properly.
 	 *
 	 * @access public

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -23,7 +23,16 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setup();
+
+		// Cache default settings for future use.
 		$this->settings = new Settings();
+
+		// Create some dummy categories to use in mapping testing.
+		wp_insert_term( 'Category 1', 'category' );
+		wp_insert_term( 'Category 2', 'category' );
+		wp_insert_term( 'Category 3', 'category' );
+
+		// Pre-cache a transient for sections using dummy data to bypass API call.
 		set_transient(
 			'apple_news_sections',
 			array(
@@ -78,8 +87,52 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'post_tag', $taxonomy->name );
 	}
 
-	// TODO: Test filter for mapping taxonomy.
-	// TODO: Test save category mappings
+	/**
+	 * Ensures that the category mapping form saves properly.
+	 *
+	 * @access public
+	 */
+	public function testSaveCategoryMapping() {
+
+		// Get info about our categories.
+		$category1 = get_term_by( 'name', 'Category 1', 'category' );
+		$category2 = get_term_by( 'name', 'Category 2', 'category' );
+		$category3 = get_term_by( 'name', 'Category 3', 'category' );
+
+		// Set up post data.
+		$_POST = array(
+			'action' => 'apple_news_set_section_taxonomy_mappings',
+			'page' => 'apple_news_sections',
+			'taxonomy-mapping-abcdef01-2345-6789-abcd-ef012356789a' => array(
+				'Category 1',
+			),
+			'taxonomy-mapping-abcdef01-2345-6789-abcd-ef012356789b' => array(
+				'Category 2',
+			),
+		);
+		$_REQUEST = array(
+			'_wp_http_referer' => '/wp-admin/admin.php?page=apple-news-sections',
+			'_wpnonce' => wp_create_nonce( 'apple_news_sections' ),
+		);
+
+		// Run the request.
+		$sections = new Admin_Apple_Sections();
+		$sections->action_router();
+
+		// Validate the response.
+		$this->assertEquals(
+			array(
+				'abcdef01-2345-6789-abcd-ef012356789a' => array(
+					$category1->term_id
+				),
+				'abcdef01-2345-6789-abcd-ef012356789b' => array(
+					$category2->term_id
+				),
+			),
+			get_option( Admin_Apple_Sections::TAXONOMY_MAPPING_KEY )
+		);
+	}
+
 	// TODO: Test create post with categories in category mappings and ensure sections are properly set
 	// TODO: Test override functionality for manual settings selection
 }

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -141,8 +141,7 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		wp_set_post_categories( $post_id, $category2->term_id );
 
-		// Set the override bit for the post and manually set the first section.
-		update_post_meta( $post_id, 'apple_news_section_override', true );
+		// Manually set the first section to override automatic mapping.
 		update_post_meta(
 			$post_id,
 			'apple_news_sections',

--- a/tests/admin/test-class-admin-apple-themes.php
+++ b/tests/admin/test-class-admin-apple-themes.php
@@ -71,14 +71,14 @@ class Admin_Apple_Themes_Test extends WP_UnitTestCase {
 		$this->createDefaultTheme();
 
 		// Ensure the default theme was created
-		$this->assertEquals( __( 'Default', 'apple-news' ), get_option( $themes::theme_active_key ) );
+		$this->assertEquals( __( 'Default', 'apple-news' ), get_option( $themes::THEME_ACTIVE_KEY ) );
 		$this->assertEquals(
 			$this->getFormattingSettings( $this->settings->all() ),
 			get_option( $themes->theme_key_from_name( __( 'Default', 'apple-news' ) ) )
 		);
 		$this->assertEquals(
 			array( __( 'Default', 'apple-news' ) ),
-			get_option( $themes::theme_index_key )
+			get_option( $themes::THEME_INDEX_KEY )
 		);
 	}
 
@@ -109,7 +109,7 @@ class Admin_Apple_Themes_Test extends WP_UnitTestCase {
 		$themes->action_router();
 
 		// Check that the theme got set
-		$this->assertEquals( $name, get_option( $themes::theme_active_key ) );
+		$this->assertEquals( $name, get_option( $themes::THEME_ACTIVE_KEY ) );
 
 		$current_settings = $settings_obj->fetch_settings();
 		$this->assertEquals( 50, $current_settings['layout_margin'] );
@@ -128,7 +128,7 @@ class Admin_Apple_Themes_Test extends WP_UnitTestCase {
 		// Ensure both themes exist
 		$this->assertEquals(
 			array( __( 'Default', 'apple-news' ), $name ),
-			get_option( $themes::theme_index_key )
+			get_option( $themes::THEME_INDEX_KEY )
 		);
 		$this->assertNotEmpty( get_option( $themes->theme_key_from_name( __( 'Default', 'apple-news' ) ) ) );
 		$this->assertNotEmpty( get_option( $themes->theme_key_from_name( $name ) ) );
@@ -146,7 +146,7 @@ class Admin_Apple_Themes_Test extends WP_UnitTestCase {
 		// Ensure both themes exist
 		$this->assertEquals(
 			array( __( 'Default', 'apple-news' ) ),
-			get_option( $themes::theme_index_key )
+			get_option( $themes::THEME_INDEX_KEY )
 		);
 		$this->assertEmpty( get_option( $themes->theme_key_from_name( $name ) ) );
 	}


### PR DESCRIPTION
* Adds a new settings screen called Sections.
* Allows for mapping taxonomy terms to sections for automatic section assignment.
* Adds an override checkbox if mappings are enabled to allow for overriding section assignments on a per-post basis.
* Adds unit test coverage for the new functionality.

Fixes #167.