### PR TITLE
AN-24 Adding support for gallery captions

### DIFF
--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -1,7 +1,22 @@
 <?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Components\Gallery class
+ *
+ * Contains a class which is used to transform galleries into Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
+
 namespace Apple_Exporter\Components;
 
+use \DOMDocument;
+use \DOMElement;
+
 /**
+ * A class to translate the output of [gallery] shortcodes into Apple News format.
+ *
  * An image gallery is just a container with 'gallery' class and some images
  * inside. The container should be a div, but can be anything as long as it has
  * a 'gallery' class.
@@ -13,43 +28,83 @@ class Gallery extends Component {
 	/**
 	 * Look for node matches for this component.
 	 *
-	 * @param DomNode $node
-	 * @return mixed
-	 * @static
+	 * @param DOMElement $node The node to examine.
+	 *
 	 * @access public
+	 * @return DOMElement|null The DOMElement on match, false on no match.
 	 */
 	public static function node_matches( $node ) {
-		if ( self::node_has_class( $node, 'gallery' ) ) {
-			return $node;
-		}
-
-		return null;
+		return ( self::node_has_class( $node, 'gallery' ) ) ? $node : null;
 	}
 
 	/**
 	 * Build the component.
 	 *
-	 * @param string $text
+	 * @param string $text The HTML to parse.
+	 *
 	 * @access protected
 	 */
 	protected function build( $text ) {
-		preg_match_all( '/src="([^"]+)"/', $text, $matches );
-		$urls  = $matches[1];
-		$items = array();
 
-		foreach ( $urls as $url ) {
-			// Collect into to items array
-			$items[] = array(
-				'URL' => $this->maybe_bundle_source( $url ),
-			);
+		// Convert the text into a NodeList.
+		libxml_use_internal_errors( true );
+		$dom = new DOMDocument();
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $text );
+		libxml_clear_errors();
+		libxml_use_internal_errors( false );
+		$nodes = $dom->getElementsByTagName( 'body' )->item( 0 )->childNodes;
+
+		// Determine if we have items.
+		if ( empty( $nodes[0]->childNodes ) ) {
+			return;
 		}
 
+		// Loop through items and construct slides.
+		$items = array();
+		foreach ( $nodes[0]->childNodes as $item ) {
+
+			// Convert item into HTML for regex matching.
+			$itemHTML = $item->ownerDocument->saveXML( $item );
+
+			// Try to get URL.
+			if ( ! preg_match( '/src="([^"]+)"/', $itemHTML, $matches ) ) {
+				continue;
+			}
+
+			// Start building the item.
+			$content = array(
+				'URL' => $this->maybe_bundle_source( $matches[1] ),
+			);
+
+			// Try to add the caption.
+			$caption = $item->getElementsByTagName( 'figcaption' );
+			if ( $caption ) {
+				$content['caption'] = array(
+					'text' => sanitize_text_field(
+						trim( $caption->item(0)->nodeValue )
+					),
+				);
+			}
+
+			// Try to add the alt text as the accessibility caption.
+			if ( preg_match( '/alt="([^"]+)"/', $itemHTML, $matches ) ) {
+				$content['accessibilityCaption'] = sanitize_text_field(
+					$matches[1]
+				);
+			}
+
+			// Add the compiled slide content to the list of items.
+			$items[] = $content;
+		}
+
+		// Build the JSON.
 		$this->json = array(
-			'role'   => $this->get_setting( 'gallery_type' ),
-			'items'  => $items,
+			'role' => $this->get_setting( 'gallery_type' ),
+			'items' => $items,
 		);
 
-		$this->set_layout();
+		// Set the layout.
+		$this->_set_layout();
 	}
 
 	/**
@@ -57,12 +112,16 @@ class Gallery extends Component {
 	 *
 	 * @access private
 	 */
-	private function set_layout() {
+	private function _set_layout() {
 		$this->json['layout'] = 'gallery-layout';
-		$this->register_full_width_layout( 'gallery-layout', array(
-			'margin' => array( 'top' => 25, 'bottom' => 25 )
-		) );
+		$this->register_full_width_layout(
+			'gallery-layout',
+			array(
+				'margin' => array(
+					'bottom' => 25,
+					'top' => 25,
+				)
+			)
+		);
 	}
-
 }
-

--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -55,13 +55,13 @@ class Gallery extends Component {
 		$nodes = $dom->getElementsByTagName( 'body' )->item( 0 )->childNodes;
 
 		// Determine if we have items.
-		if ( empty( $nodes[0]->childNodes ) ) {
+		if ( ! $nodes || ! $nodes->item( 0 )->childNodes ) {
 			return;
 		}
 
 		// Loop through items and construct slides.
 		$items = array();
-		foreach ( $nodes[0]->childNodes as $item ) {
+		foreach ( $nodes->item( 0 )->childNodes as $item ) {
 
 			// Convert item into HTML for regex matching.
 			$itemHTML = $item->ownerDocument->saveXML( $item );
@@ -78,7 +78,7 @@ class Gallery extends Component {
 
 			// Try to add the caption.
 			$caption = $item->getElementsByTagName( 'figcaption' );
-			if ( $caption ) {
+			if ( $caption && $caption->length ) {
 				$content['caption'] = array(
 					'text' => sanitize_text_field(
 						trim( $caption->item(0)->nodeValue )

--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -120,7 +120,7 @@ class Gallery extends Component {
 				'margin' => array(
 					'bottom' => 25,
 					'top' => 25,
-				)
+				),
 			)
 		);
 	}

--- a/tests/apple-exporter/components/test-class-gallery.php
+++ b/tests/apple-exporter/components/test-class-gallery.php
@@ -1,99 +1,57 @@
 <?php
+/**
+ * Publish to Apple News Tests: Gallery_Test class
+ *
+ * Contains a class which is used to test Apple_Exporter\Components\Gallery.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
 require_once __DIR__ . '/class-component-testcase.php';
 
-use Apple_Exporter\Components\Gallery as Gallery;
+use \Apple_Exporter\Components\Gallery;
 
+/**
+ * A class which is used to test the Apple_Exporter\Components\Gallery class.
+ */
 class Gallery_Test extends Component_TestCase {
 
-	public function testGeneratedJSON() {
-		$this->settings->set( 'use_remote_images', 'no' );
-
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		// get_file_contents and write_tmp_files must be caleld with the specified params
-		$workspace->bundle_source( 'filename-1.jpg', 'http://someurl.com/filename-1.jpg' )->shouldBeCalled();
-		$workspace->bundle_source( 'another-filename-2.jpg', 'http://someurl.com/another-filename-2.jpg' )->shouldBeCalled();
-
-		// Pass the mock workspace as a dependency
-		$component = new Gallery( '<div class="gallery"><img
-			src="http://someurl.com/filename-1.jpg" alt="Example" /><img
-			src="http://someurl.com/another-filename-2.jpg" alt="Example" /></div>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
-
-		// Test for valid JSON
-		$this->assertEquals(
-			array(
-				'role' => 'gallery',
-				'items' => array(
-					array(
-						'URL' => 'bundle://filename-1.jpg',
-						'accessibilityCaption' => 'Example',
-					),
-					array(
-						'URL' => 'bundle://another-filename-2.jpg',
-						'accessibilityCaption' => 'Example',
-					),
-				),
-				'layout' => 'gallery-layout',
-			),
-			$component->to_array()
-		);
-	}
-
-	public function testGeneratedJSONRemoteImages() {
-		$this->settings->set( 'use_remote_images', 'yes' );
-
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		// get_file_contents and write_tmp_files must be caleld with the specified params
-		$workspace->bundle_source( 'filename-1.jpg', 'http://someurl.com/filename-1.jpg' )->shouldNotBeCalled();
-		$workspace->bundle_source( 'another-filename-2.jpg', 'http://someurl.com/another-filename-2.jpg' )->shouldNotBeCalled();
-
-		// Pass the mock workspace as a dependency
-		$component = new Gallery( '<div class="gallery"><img
-			src="http://someurl.com/filename-1.jpg" alt="Example" /><img
-			src="http://someurl.com/another-filename-2.jpg" alt="Example" /></div>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
-
-		// Test for valid JSON
-		$this->assertEquals(
-			array(
-				'role' => 'gallery',
-				'items' => array(
-					array(
-						'URL' => 'http://someurl.com/filename-1.jpg',
-						'accessibilityCaption' => 'Example',
-					),
-					array(
-						'URL' => 'http://someurl.com/another-filename-2.jpg',
-						'accessibilityCaption' => 'Example',
-					),
-				),
-				'layout' => 'gallery-layout',
-			),
-			$component->to_array()
-		);
-	}
-
+	/**
+	 * Test the apple_news_gallery_json filter.
+	 *
+	 * @access public
+	 */
 	public function testFilter() {
+
+		// Setup.
 		$this->settings->set( 'use_remote_images', 'no' );
-
 		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		// get_file_contents and write_tmp_files must be caleld with the specified params
-		$workspace->bundle_source( 'filename-1.jpg', 'http://someurl.com/filename-1.jpg' )->shouldBeCalled();
-		$workspace->bundle_source( 'another-filename-2.jpg', 'http://someurl.com/another-filename-2.jpg' )->shouldBeCalled();
-
-		// Pass the mock workspace as a dependency
-		$component = new Gallery( '<div class="gallery"><img
+		$workspace->bundle_source(
+			'filename-1.jpg',
+			'http://someurl.com/filename-1.jpg'
+		)->shouldBeCalled();
+		$workspace->bundle_source(
+			'another-filename-2.jpg',
+			'http://someurl.com/another-filename-2.jpg'
+		)->shouldBeCalled();
+		$component = new Gallery(
+			'<div class="gallery"><img
 			src="http://someurl.com/filename-1.jpg" alt="Example" /><img
 			src="http://someurl.com/another-filename-2.jpg" alt="Example" /></div>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+			$workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
+		// Add the filter and set a custom layout.
 		add_filter( 'apple_news_gallery_json', function( $json ) {
 			$json['layout'] = 'fancy-layout';
 			return $json;
 		} );
 
-		// Test for valid JSON
+		// Ensure the filter properly modified the layout.
 		$this->assertEquals(
 			array(
 				'role' => 'gallery',
@@ -113,5 +71,99 @@ class Gallery_Test extends Component_TestCase {
 		);
 	}
 
-}
+	/**
+	 * Ensures that the component generates the proper JSON for a simple gallery.
+	 *
+	 * @access public
+	 */
+	public function testGeneratedJSON() {
 
+		// Setup.
+		$this->settings->set( 'use_remote_images', 'no' );
+		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
+		$workspace->bundle_source(
+			'filename-1.jpg',
+			'http://someurl.com/filename-1.jpg'
+		)->shouldBeCalled();
+		$workspace->bundle_source(
+			'another-filename-2.jpg',
+			'http://someurl.com/another-filename-2.jpg'
+		)->shouldBeCalled();
+		$component = new Gallery(
+			'<div class="gallery"><img
+			src="http://someurl.com/filename-1.jpg" alt="Example" /><img
+			src="http://someurl.com/another-filename-2.jpg" alt="Example" /></div>',
+			$workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test for valid JSON.
+		$this->assertEquals(
+			array(
+				'role' => 'gallery',
+				'items' => array(
+					array(
+						'URL' => 'bundle://filename-1.jpg',
+						'accessibilityCaption' => 'Example',
+					),
+					array(
+						'URL' => 'bundle://another-filename-2.jpg',
+						'accessibilityCaption' => 'Example',
+					),
+				),
+				'layout' => 'gallery-layout',
+			),
+			$component->to_array()
+		);
+	}
+
+	/**
+	 * Tests the functionality of the `use_remote_images` setting.
+	 *
+	 * @access public
+	 */
+	public function testGeneratedJSONRemoteImages() {
+
+		// Setup.
+		$this->settings->set( 'use_remote_images', 'yes' );
+		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
+		$workspace->bundle_source(
+			'filename-1.jpg',
+			'http://someurl.com/filename-1.jpg'
+		)->shouldNotBeCalled();
+		$workspace->bundle_source(
+			'another-filename-2.jpg',
+			'http://someurl.com/another-filename-2.jpg'
+		)->shouldNotBeCalled();
+		$component = new Gallery(
+			'<div class="gallery"><img
+			src="http://someurl.com/filename-1.jpg" alt="Example" /><img
+			src="http://someurl.com/another-filename-2.jpg" alt="Example" /></div>',
+			$workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Ensure that the URL parameters are using remote images.
+		$this->assertEquals(
+			array(
+				'role' => 'gallery',
+				'items' => array(
+					array(
+						'URL' => 'http://someurl.com/filename-1.jpg',
+						'accessibilityCaption' => 'Example',
+					),
+					array(
+						'URL' => 'http://someurl.com/another-filename-2.jpg',
+						'accessibilityCaption' => 'Example',
+					),
+				),
+				'layout' => 'gallery-layout',
+			),
+			$component->to_array()
+		);
+	}
+}

--- a/tests/apple-exporter/components/test-class-gallery.php
+++ b/tests/apple-exporter/components/test-class-gallery.php
@@ -18,6 +18,42 @@ use \Apple_Exporter\Components\Gallery;
 class Gallery_Test extends Component_TestCase {
 
 	/**
+	 * Test content representing the output of a complex gallery.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $_complex_html = <<<HTML
+<div id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-full">
+	<figure class="gallery-item">
+		<div class="gallery-icon landscape">
+			<img width="721" height="643" src="http://someurl.com/filename-1.jpg" class="attachment-full size-full" alt="Alt Text 1" aria-describedby="gallery-1-52" srcset="http://someurl.com/filename-1.jpg 721w, http://someurl.com/filename-1-300x268.jpg 300w" sizes="100vw"/>
+		</div>
+		<figcaption class="wp-caption-text gallery-caption" id="gallery-1-52">Caption 1</figcaption>
+	</figure>
+	<figure class="gallery-item">
+		<div class="gallery-icon portrait">
+			<img width="700" height="766" src="http://someurl.com/another-filename-2.jpg" class="attachment-full size-full" alt="Alt Text 2" aria-describedby="gallery-1-53" srcset="http://someurl.com/another-filename-2.jpg 700w, http://someurl.com/another-filename-2-274x300.jpg 274w" sizes="100vw"/>
+		</div>
+		<figcaption class="wp-caption-text gallery-caption" id="gallery-1-53">Caption 2</figcaption>
+	</figure>
+</div>
+HTML;
+
+	/**
+	 * Test content representing the output of a simple gallery.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $_simple_html = <<<HTML
+<div class="gallery">
+	<img src="http://someurl.com/filename-1.jpg" alt="Example" />
+	<img src="http://someurl.com/another-filename-2.jpg" alt="Example" />
+</div>
+HTML;
+
+	/**
 	 * A filter function to modify the layout in the generated JSON.
 	 *
 	 * @param array $json The JSON array to modify.
@@ -39,29 +75,7 @@ class Gallery_Test extends Component_TestCase {
 	public function testFilter() {
 
 		// Setup.
-		$html = <<<HTML
-<div class="gallery">
-	<img src="http://someurl.com/filename-1.jpg" alt="Example" />
-	<img src="http://someurl.com/another-filename-2.jpg" alt="Example" />
-</div>
-HTML;
-		$this->settings->set( 'use_remote_images', 'no' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
-			'filename-1.jpg',
-			'http://someurl.com/filename-1.jpg'
-		)->shouldBeCalled();
-		$workspace->bundle_source(
-			'another-filename-2.jpg',
-			'http://someurl.com/another-filename-2.jpg'
-		)->shouldBeCalled();
-		$component = new Gallery(
-			$html,
-			$workspace->reveal(),
-			$this->settings,
-			$this->styles,
-			$this->layouts
-		);
+		$component = $this->_setup_component( $this->_simple_html );
 
 		// Add the filter and set a custom layout.
 		add_filter(
@@ -103,29 +117,7 @@ HTML;
 	public function testGeneratedJSON() {
 
 		// Setup.
-		$html = <<<HTML
-<div class="gallery">
-	<img src="http://someurl.com/filename-1.jpg" alt="Example" />
-	<img src="http://someurl.com/another-filename-2.jpg" alt="Example" />
-</div>
-HTML;
-		$this->settings->set( 'use_remote_images', 'no' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
-			'filename-1.jpg',
-			'http://someurl.com/filename-1.jpg'
-		)->shouldBeCalled();
-		$workspace->bundle_source(
-			'another-filename-2.jpg',
-			'http://someurl.com/another-filename-2.jpg'
-		)->shouldBeCalled();
-		$component = new Gallery(
-			$html,
-			$workspace->reveal(),
-			$this->settings,
-			$this->styles,
-			$this->layouts
-		);
+		$component = $this->_setup_component( $this->_simple_html );
 
 		// Test for valid JSON.
 		$this->assertEquals(
@@ -155,39 +147,7 @@ HTML;
 	public function testGeneratedJSONComplex() {
 
 		// Setup.
-		$html = <<<HTML
-<div id="gallery-1" class="gallery galleryid-0 gallery-columns-3 gallery-size-full">
-	<figure class="gallery-item">
-		<div class="gallery-icon landscape">
-			<img width="721" height="643" src="http://someurl.com/filename-1.jpg" class="attachment-full size-full" alt="Alt Text 1" aria-describedby="gallery-1-52" srcset="http://someurl.com/filename-1.jpg 721w, http://someurl.com/filename-1-300x268.jpg 300w" sizes="100vw"/>
-		</div>
-		<figcaption class="wp-caption-text gallery-caption" id="gallery-1-52">Caption 1</figcaption>
-	</figure>
-	<figure class="gallery-item">
-		<div class="gallery-icon portrait">
-			<img width="700" height="766" src="http://someurl.com/another-filename-2.jpg" class="attachment-full size-full" alt="Alt Text 2" aria-describedby="gallery-1-53" srcset="http://someurl.com/another-filename-2.jpg 700w, http://someurl.com/another-filename-2-274x300.jpg 274w" sizes="100vw"/>
-		</div>
-		<figcaption class="wp-caption-text gallery-caption" id="gallery-1-53">Caption 2</figcaption>
-	</figure>
-</div>
-HTML;
-		$this->settings->set( 'use_remote_images', 'no' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
-			'filename-1.jpg',
-			'http://someurl.com/filename-1.jpg'
-		)->shouldBeCalled();
-		$workspace->bundle_source(
-			'another-filename-2.jpg',
-			'http://someurl.com/another-filename-2.jpg'
-		)->shouldBeCalled();
-		$component = new Gallery(
-			$html,
-			$workspace->reveal(),
-			$this->settings,
-			$this->styles,
-			$this->layouts
-		);
+		$component = $this->_setup_component( $this->_complex_html );
 
 		// Test for valid JSON.
 		$this->assertEquals(
@@ -223,12 +183,6 @@ HTML;
 	public function testGeneratedJSONRemoteImages() {
 
 		// Setup.
-		$html = <<<HTML
-<div class="gallery">
-	<img src="http://someurl.com/filename-1.jpg" alt="Example" />
-	<img src="http://someurl.com/another-filename-2.jpg" alt="Example" />
-</div>
-HTML;
 		$this->settings->set( 'use_remote_images', 'yes' );
 		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
 		$workspace->bundle_source(
@@ -240,7 +194,7 @@ HTML;
 			'http://someurl.com/another-filename-2.jpg'
 		)->shouldNotBeCalled();
 		$component = new Gallery(
-			$html,
+			$this->_simple_html,
 			$workspace->reveal(),
 			$this->settings,
 			$this->styles,
@@ -264,6 +218,37 @@ HTML;
 				'layout' => 'gallery-layout',
 			),
 			$component->to_array()
+		);
+	}
+
+	/**
+	 * Given HTML content, sets up a workspace and a Gallery component.
+	 *
+	 * @param string $content The HTML content to feed into the component.
+	 *
+	 * @access private
+	 * @return Gallery The Gallery component constructed from the content.
+	 */
+	private function _setup_component( $content ) {
+
+		// Set up the workspace.
+		$this->settings->set( 'use_remote_images', 'no' );
+		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
+		$workspace->bundle_source(
+			'filename-1.jpg',
+			'http://someurl.com/filename-1.jpg'
+		)->shouldBeCalled();
+		$workspace->bundle_source(
+			'another-filename-2.jpg',
+			'http://someurl.com/another-filename-2.jpg'
+		)->shouldBeCalled();
+
+		return new Gallery(
+			$content,
+			$workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
 		);
 	}
 }

--- a/tests/apple-exporter/components/test-class-gallery.php
+++ b/tests/apple-exporter/components/test-class-gallery.php
@@ -27,9 +27,11 @@ class Gallery_Test extends Component_TestCase {
 				'items' => array(
 					array(
 						'URL' => 'bundle://filename-1.jpg',
+						'accessibilityCaption' => 'Example',
 					),
 					array(
 						'URL' => 'bundle://another-filename-2.jpg',
+						'accessibilityCaption' => 'Example',
 					),
 				),
 				'layout' => 'gallery-layout',
@@ -59,9 +61,11 @@ class Gallery_Test extends Component_TestCase {
 				'items' => array(
 					array(
 						'URL' => 'http://someurl.com/filename-1.jpg',
+						'accessibilityCaption' => 'Example',
 					),
 					array(
 						'URL' => 'http://someurl.com/another-filename-2.jpg',
+						'accessibilityCaption' => 'Example',
 					),
 				),
 				'layout' => 'gallery-layout',
@@ -96,9 +100,11 @@ class Gallery_Test extends Component_TestCase {
 				'items' => array(
 					array(
 						'URL' => 'bundle://filename-1.jpg',
+						'accessibilityCaption' => 'Example',
 					),
 					array(
 						'URL' => 'bundle://another-filename-2.jpg',
+						'accessibilityCaption' => 'Example',
 					),
 				),
 				'layout' => 'fancy-layout',


### PR DESCRIPTION
* Adds support for captions on images in galleries.
* Adds support for alt text on images in galleries.
* Adds a unit test for complex galleries including both captions and alt text.
* Refactors the `Gallery` and `Gallery_Test` classes for adherence to WordPress standards and PHP best practices.

Fixes #97.