### PR TITLE
AN-43 Adding support for still URLs in video elements

### DIFF
--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -69,7 +69,7 @@ class Metadata extends Builder {
 			for ( $i = 0; $i < count( $matches[2] ); $i ++ ) {
 
 				// Try to match an MP4 source URL.
-				if ( preg_match( '/src="([^\?"]+\.mp4)/', $matches[2][ $i ], $src ) ) {
+				if ( preg_match( '/src="([^\?"]+\.mp4[^"]*)"/', $matches[2][ $i ], $src ) ) {
 					$meta['thumbnailURL'] = $this->maybe_bundle_source(
 						$matches[1][ $i ]
 					);

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -28,14 +28,9 @@ class Metadata extends Builder {
 
 		// If the content has a cover, use it as thumb.
 		if ( $this->content_cover() ) {
-			if ( 'yes' === $this->get_setting( 'use_remote_images' ) ) {
-				$thumb_url = $this->content_cover();
-			} else {
-				$filename = \Apple_News::get_filename( $this->content_cover() );
-				$thumb_url = 'bundle://' . $filename;
-			}
-
-			$meta['thumbnailURL'] = $thumb_url;
+			$meta['thumbnailURL'] = $this->maybe_bundle_source(
+				$this->content_cover()
+			);
 		}
 
 		// Add date fields.
@@ -75,7 +70,9 @@ class Metadata extends Builder {
 
 				// Try to match an MP4 source URL.
 				if ( preg_match( '/src="([^\?"]+\.mp4)/', $matches[2][ $i ], $src ) ) {
-					$meta['thumbnailURL'] = $matches[1][ $i ];
+					$meta['thumbnailURL'] = $this->maybe_bundle_source(
+						$matches[1][ $i ]
+					);
 					$meta['videoURL'] = $src[1];
 
 					break;
@@ -135,21 +132,7 @@ class Metadata extends Builder {
 
 			// Bundle source, if necessary.
 			$url = wp_get_attachment_image_url( $id, $name );
-			if ( 'yes' !== $this->get_setting( 'use_remote_images' ) ) {
-				$filename = \Apple_News::get_filename( $url );
-				$bundle_url = apply_filters(
-					'apple_news_bundle_source',
-					$url,
-					$filename,
-					$this->content_id()
-				);
-				add_post_meta(
-					$this->content_id(),
-					Workspace::BUNDLE_META_KEY,
-					esc_url_raw( $bundle_url )
-				);
-				$url = 'bundle://' . $filename;
-			}
+			$url = $this->maybe_bundle_source( $url );
 
 			// Add this crop to the coverArt array.
 			$meta['coverArt'][] = array(

--- a/includes/apple-exporter/components/class-video.php
+++ b/includes/apple-exporter/components/class-video.php
@@ -1,8 +1,20 @@
 <?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Components\Video class
+ *
+ * Contains a class which is used to transform video elements into Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
+
 namespace Apple_Exporter\Components;
 
+use \DOMElement;
+
 /**
- * An HTML video tag representation.
+ * A class which is used to transform video elements into Apple News format.
  *
  * @since 0.2.0
  */
@@ -11,14 +23,15 @@ class Video extends Component {
 	/**
 	 * Look for node matches for this component.
 	 *
-	 * @param DomNode $node
-	 * @return mixed
-	 * @static
+	 * @param DOMElement $node The node to examine.
+	 *
 	 * @access public
+	 * @return DOMElement|null The DOMElement on match, false on no match.
 	 */
 	public static function node_matches( $node ) {
-		// Is this an video node?
-		if ( 'video' == $node->nodeName && self::remote_file_exists( $node ) ) {
+
+		// Ensure that this is a video tag and that the source exists.
+		if ( 'video' === $node->nodeName && self::remote_file_exists( $node ) ) {
 			return $node;
 		}
 
@@ -28,22 +41,26 @@ class Video extends Component {
 	/**
 	 * Build the component.
 	 *
-	 * @param string $text
+	 * @param string $html The HTML to parse into text for processing.
+	 *
 	 * @access protected
 	 */
-	protected function build( $text ) {
-		// Remove initial and trailing tags: <video><p>...</p></video>
-		if ( ! preg_match( '/src="([^"]+)"/', $text, $match ) ) {
-			return null;
+	protected function build( $html ) {
+
+		// Ensure there is a video source to use.
+		if ( ! preg_match( '/src="([^"]+)"/', $html, $matches ) ) {
+			return;
 		}
 
-		$url = $match[1];
-
+		// Build initial JSON.
 		$this->json = array(
 			'role' => 'video',
-			'URL'  => $url,
+			'URL' => $matches[1],
 		);
+
+		// Add poster frame, if defined.
+		if ( preg_match( '/poster="([^"]+)"/', $html, $poster ) ) {
+			$this->json['stillURL'] = $this->maybe_bundle_source( $poster[1] );
+		}
 	}
-
 }
-

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -349,7 +349,7 @@ HTML;
 			$result['thumbnailURL']
 		);
 		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/example-video.mp4',
+			'https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1',
 			$result['videoURL']
 		);
 	}

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -332,6 +332,7 @@ class Metadata_Test extends WP_UnitTestCase {
 	public function testVideo() {
 
 		// Setup.
+		$this->settings->set( 'use_remote_images', 'yes' );
 		$html = <<<HTML
 <video class="wp-video-shortcode" id="video-71-1" width="525" height="295" poster="https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg" preload="metadata" controls="controls">
 	<source type="video/mp4" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1" />

--- a/tests/apple-exporter/components/test-class-video.php
+++ b/tests/apple-exporter/components/test-class-video.php
@@ -1,37 +1,127 @@
 <?php
+/**
+ * Publish to Apple News Tests: Quote_Test class
+ *
+ * Contains a class which is used to test Apple_Exporter\Components\Quote.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
 require_once __DIR__ . '/class-component-testcase.php';
 
-use Apple_Exporter\Components\Video as Video;
+use Apple_Exporter\Components\Video;
+use Apple_Exporter\Workspace;
 
+/**
+ * A class which is used to test the Apple_Exporter\Components\Video class.
+ */
 class Video_Test extends Component_TestCase {
 
-	public function testGeneratedJSON() {
-		$workspace = $this->prophet->prophesize( '\Exporter\Workspace' );
+	/**
+	 * Contains test HTML content to feed into the Video object for testing.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $_content = <<<HTML
+<video class="wp-video-shortcode" id="video-71-1" width="525" height="295" poster="https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg" preload="metadata" controls="controls">
+	<source type="video/mp4" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1" />
+	<a href="https://example.com/wp-content/uploads/2017/02/example-video.mp4">https://example.com/wp-content/uploads/2017/02/example-video.mp4</a>
+</video>
+HTML;
 
-		// Pass the mock workspace as a dependency
-		$component = new Video( '<video><source src="http://someurl.com/video-file.mp4?some_query=string"></video>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+	/**
+	 * A filter function to modify the video URL in the generated JSON.
+	 *
+	 * @param array $json The JSON array to modify.
+	 *
+	 * @access public
+	 * @return array The modified JSON.
+	 */
+	public function filter_apple_news_video_json( $json ) {
+		$json['URL'] = 'http://filter.me';
 
-		$json = $component->to_array();
-		$this->assertEquals( 'video', $json['role'] );
-		$this->assertEquals( 'http://someurl.com/video-file.mp4?some_query=string', $json['URL'] );
+		return $json;
 	}
 
+	/**
+	 * Test the `apple_news_quote_json` filter.
+	 *
+	 * @access public
+	 */
 	public function testFilter() {
-		$workspace = $this->prophet->prophesize( '\Exporter\Workspace' );
 
-		// Pass the mock workspace as a dependency
-		$component = new Video( '<video><source src="http://someurl.com/video-file.mp4?some_query=string"></video>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		// Setup.
+		$component = $this->_get_component();
+		add_filter(
+			'apple_news_video_json',
+			array( $this, 'filter_apple_news_video_json' )
+		);
 
-		add_filter( 'apple_news_video_json', function( $json ) {
-			$json['URL'] = 'http://filter.me';
-			return $json;
-		} );
+		// Test.
+		$result = $component->to_array();
+		$this->assertEquals(
+			'http://filter.me',
+			$result['URL']
+		);
 
-		$json = $component->to_array();
-		$this->assertEquals( 'http://filter.me', $json['URL'] );
+		// Teardown.
+		remove_filter(
+			'apple_news_video_json',
+			array( $this, 'filter_apple_news_video_json' )
+		);
 	}
 
+	/**
+	 * Tests the transformation process from a video element to a Video component.
+	 *
+	 * @access public
+	 */
+	public function testGeneratedJSON() {
+
+		// Setup.
+		$this->settings->set( 'use_remote_images', 'yes' );
+		$component = $this->_get_component();
+
+		// Test.
+		$result = $component->to_array();
+		$this->assertEquals(
+			'https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg',
+			$result['stillURL']
+		);
+		$this->assertEquals(
+			'video',
+			$result['role']
+		);
+		$this->assertEquals(
+			'https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1',
+			$result['URL']
+		);
+	}
+
+	/**
+	 * A function to get a basic component for testing using defined content.
+	 *
+	 * @access private
+	 * @return Video A Video object containing the specified content.
+	 */
+	private function _get_component( $content = '' ) {
+
+		// Negotiate content.
+		if ( empty( $content ) ) {
+			$content = $this->_content;
+		}
+
+		// Build the component.
+		$component = new Video(
+			$content,
+			new Workspace( 1 ),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		return $component;
+	}
 }


### PR DESCRIPTION
* Added support for the `stillURL` property on `video` elements.
* Refactored the `Video_Test` class to conform to WordPress standards and PHP best practices.
* Bugfix for mismatched video URLs in metadata and `video` elements when a query string is present.
* Added central `maybe_bundle_source` function to `Builder` class for more streamlined handling of image bundling in metadata.