### PR TITLE
AN-17 Fix for encoding warning with Unicode separator characters

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -52,6 +52,14 @@ class Exporter {
 	private $builders;
 
 	/**
+	 * A list of Unicode separator characters for use in filtering.
+	 *
+	 * @access private
+	 * @var array
+	 */
+	private $separators;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Exporter_Content $content
@@ -63,6 +71,25 @@ class Exporter {
 		$this->workspace = $workspace ?: new Workspace( $this->content_id() );
 		$this->settings  = $settings  ?: new Settings();
 		$this->builders  = array();
+		$this->separators = array(
+			json_decode( '"\u0020"' ),
+			json_decode( '"\u00a0"' ),
+			json_decode( '"\u1680"' ),
+			json_decode( '"\u2000"' ),
+			json_decode( '"\u2001"' ),
+			json_decode( '"\u2002"' ),
+			json_decode( '"\u2003"' ),
+			json_decode( '"\u2004"' ),
+			json_decode( '"\u2005"' ),
+			json_decode( '"\u2006"' ),
+			json_decode( '"\u2007"' ),
+			json_decode( '"\u2008"' ),
+			json_decode( '"\u2009"' ),
+			json_decode( '"\u200a"' ),
+			json_decode( '"\u202f"' ),
+			json_decode( '"\u205f"' ),
+			json_decode( '"\u3000"' ),
+		);
 	}
 
 	/**
@@ -192,6 +219,8 @@ class Exporter {
 
 		$json = apply_filters( 'apple_news_generate_json', $json, $this->content_id() );
 
+		// Clean up the data array and convert to JSON format.
+		$this->prepare_for_encoding( $json );
 		$json = json_encode( $json );
 
 		// Check the JSON for unicode errors.
@@ -307,4 +336,28 @@ class Exporter {
 		return $this->content->title() ?: 'Untitled Article';
 	}
 
+	/**
+	 * Cleans up data destined for JSON conversion.
+	 *
+	 * @param mixed $data The data to clean up.
+	 *
+	 * @access private
+	 */
+	private function prepare_for_encoding( &$data ) {
+
+		// If the value is an array, loop through it and process each element.
+		if ( is_array( $data ) ) {
+			foreach ( $data as &$datum ) {
+				$this->prepare_for_encoding( $datum );
+			}
+		}
+
+		// If the value is a string, clean it up.
+		if ( is_string( $data ) ) {
+			$data = str_replace( $this->separators, ' ', $data );
+			$data = preg_replace( '/\h+/', ' ', $data );
+
+			return;
+		}
+	}
 }


### PR DESCRIPTION
* Replaces Unicode separator characters with spaces.
* Replaces two or more spaces with a single space.
* Resolves error messages and display issues related to the use of Unicode separator characters, including non-breaking spaces.

Fixes #271