### PR TITLE
AN-45 Cover art refinements

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -29,65 +29,17 @@ class Admin_Apple_News extends Apple_News {
 	 * @var array Information about images, with names as keys and data as values.
 	 */
 	public static $image_sizes = array(
-		'apple_news_ca_landscape_ipad_pro' => array(
+		'apple_news_ca_landscape' => array(
 			'height' => 1374,
 			'width' => 1832,
 		),
-		'apple_news_ca_landscape_ipad' => array(
-			'height' => 1032,
-			'width' => 1376,
-		),
-		'apple_news_ca_landscape_iphone_55' => array(
-			'height' => 783,
-			'width' => 1044,
-		),
-		'apple_news_ca_landscape_iphone_47' => array(
-			'height' => 474,
-			'width' => 632,
-		),
-		'apple_news_ca_landscape_iphone_40' => array(
-			'height' => 402,
-			'width' => 536,
-		),
-		'apple_news_ca_portrait_ipad_pro' => array(
+		'apple_news_ca_portrait' => array(
 			'height' => 1496,
 			'width' => 1122,
 		),
-		'apple_news_ca_portrait_ipad' => array(
-			'height' => 1120,
-			'width' => 840,
-		),
-		'apple_news_ca_portrait_iphone_55' => array(
-			'height' => 916,
-			'width' => 687,
-		),
-		'apple_news_ca_portrait_iphone_47' => array(
-			'height' => 552,
-			'width' => 414,
-		),
-		'apple_news_ca_portrait_iphone_40' => array(
-			'height' => 472,
-			'width' => 354,
-		),
-		'apple_news_ca_square_ipad_pro' => array(
+		'apple_news_ca_square' => array(
 			'height' => 1472,
 			'width' => 1472,
-		),
-		'apple_news_ca_square_ipad' => array(
-			'height' => 1104,
-			'width' => 1104,
-		),
-		'apple_news_ca_square_iphone_55' => array(
-			'height' => 912,
-			'width' => 912,
-		),
-		'apple_news_ca_square_iphone_47' => array(
-			'height' => 550,
-			'width' => 550,
-		),
-		'apple_news_ca_square_iphone_40' => array(
-			'height' => 470,
-			'width' => 470,
 		),
 	);
 

--- a/admin/partials/cover_art.php
+++ b/admin/partials/cover_art.php
@@ -8,7 +8,7 @@ $orientations = array(
 <p class="description">
 	<?php printf(
 		wp_kses(
-			__( 'You can set one or more <a href="%s">cover art</a> images below.', 'apple-news' ),
+			__( 'You can set one or more <a href="%s">cover art</a> images below. Only one image is required in order to enable cover art functionality.', 'apple-news' ),
 			array( 'a' => array( 'href' => array() ) )
 		),
 		'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html'

--- a/admin/partials/cover_art.php
+++ b/admin/partials/cover_art.php
@@ -21,8 +21,8 @@ $orientations = array(
         <p class="description">
 			<?php printf(
 				esc_html__( 'Minimum dimensions: %1$dx%2$d', 'apple-news' ),
-				absint( Admin_Apple_News::$image_sizes[ 'apple_news_ca_' . $key . '_ipad_pro' ]['width'] ),
-				absint( Admin_Apple_News::$image_sizes[ 'apple_news_ca_' . $key . '_ipad_pro' ]['height'] )
+				absint( Admin_Apple_News::$image_sizes[ 'apple_news_ca_' . $key ]['width'] ),
+				absint( Admin_Apple_News::$image_sizes[ 'apple_news_ca_' . $key ]['height'] )
 			); ?>
         </p>
         <div class="apple-news-coverart-image">

--- a/admin/partials/cover_art.php
+++ b/admin/partials/cover_art.php
@@ -8,7 +8,7 @@ $orientations = array(
 <p class="description">
 	<?php printf(
 		wp_kses(
-			__( 'You can set one or more <a href="%s">cover art</a> images below. Only one image is required in order to enable cover art functionality.', 'apple-news' ),
+			__( 'You can set one or more <a href="%s">cover art</a> images below. Only one image is required in order to enable cover art functionality. The image you provide will be cropped and/or resized to the minimum dimensions listed, and smaller versions will be created by Apple News as necessary.', 'apple-news' ),
 			array( 'a' => array( 'href' => array() ) )
 		),
 		'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html'

--- a/assets/js/cover-art.js
+++ b/assets/js/cover-art.js
@@ -51,16 +51,16 @@
 				// Get target minimum sizes based on orientation.
 				switch ( $imgIdInput.attr( 'name' ) ) {
 					case 'apple_news_coverart_landscape':
-						minX = apple_news_cover_art.image_sizes.apple_news_ca_landscape_ipad_pro.width;
-						minY = apple_news_cover_art.image_sizes.apple_news_ca_landscape_ipad_pro.height;
+						minX = apple_news_cover_art.image_sizes.apple_news_ca_landscape.width;
+						minY = apple_news_cover_art.image_sizes.apple_news_ca_landscape.height;
 						break;
 					case 'apple_news_coverart_portrait':
-						minX = apple_news_cover_art.image_sizes.apple_news_ca_portrait_ipad_pro.width;
-						minY = apple_news_cover_art.image_sizes.apple_news_ca_portrait_ipad_pro.height;
+						minX = apple_news_cover_art.image_sizes.apple_news_ca_portrait.width;
+						minY = apple_news_cover_art.image_sizes.apple_news_ca_portrait.height;
 						break;
 					case 'apple_news_coverart_square':
-						minX = apple_news_cover_art.image_sizes.apple_news_ca_square_ipad_pro.width;
-						minY = apple_news_cover_art.image_sizes.apple_news_ca_square_ipad_pro.height;
+						minX = apple_news_cover_art.image_sizes.apple_news_ca_square.width;
+						minY = apple_news_cover_art.image_sizes.apple_news_ca_square.height;
 						break;
 					default:
 						return;

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -102,37 +102,25 @@ class Metadata_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals(
 			'Portrait alt',
-			$result['coverArt'][5]['accessibilityCaption']
+			$result['coverArt'][1]['accessibilityCaption']
 		);
 		$this->assertEquals(
 			'image',
-			$result['coverArt'][5]['type']
+			$result['coverArt'][1]['type']
 		);
 		$this->assertEquals(
 			'Square alt',
-			$result['coverArt'][10]['accessibilityCaption']
+			$result['coverArt'][2]['accessibilityCaption']
 		);
 		$this->assertEquals(
 			'image',
-			$result['coverArt'][10]['type']
+			$result['coverArt'][2]['type']
 		);
 
 		// Ensure dimensions were set properly for each orientation.
 		$this->assertNotFalse( strpos( $result['coverArt'][0]['URL'], '1832x1374.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][1]['URL'], '1376x1032.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][2]['URL'], '1044x783.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][3]['URL'], '632x474.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][4]['URL'], '536x402.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][5]['URL'], '1122x1496.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][6]['URL'], '840x1120.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][7]['URL'], '687x916.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][8]['URL'], '414x552.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][9]['URL'], '354x472.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][10]['URL'], '1472x1472.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][11]['URL'], '1104x1104.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][12]['URL'], '912x912.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][13]['URL'], '550x550.jpg' ) );
-		$this->assertNotFalse( strpos( $result['coverArt'][14]['URL'], '470x470.jpg' ) );
+		$this->assertNotFalse( strpos( $result['coverArt'][1]['URL'], '1122x1496.jpg' ) );
+		$this->assertNotFalse( strpos( $result['coverArt'][2]['URL'], '1472x1472.jpg' ) );
 	}
 
 	/**


### PR DESCRIPTION
* Added detail to the language describing how to use the cover art feature.
* Removed additional image crop sizes. Only the largest image size will be provided to Apple News, and additional crops will be handled by the Apple News service.