### PR TITLE
AN-63 Adding support for additional drop cap style options

### DIFF
--- a/admin/class-admin-apple-preview.php
+++ b/admin/class-admin-apple-preview.php
@@ -128,8 +128,8 @@ class Admin_Apple_Preview extends Apple_News {
 				}
 			?>
 			<div class="apple-news-component">
-			<p><span class="apple-news-dropcap">L</span>orem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sagittis, <a href="#">augue vitae iaculis euismod</a>, libero nulla pellentesque quam, non venenatis massa odio id dolor.</p>
-			<p>Praesent eget odio vel sapien scelerisque euismod. Phasellus eros sapien, rutrum ac nibh nec, tristique commodo neque.</p>
+			<p><span class="apple-news-dropcap">L</span>orem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sagittis, libero nulla pellentesque quam, non venenatis massa odio id dolor.</p>
+			<p>Praesent eget odio vel sapien scelerisque euismod. Phasellus eros sapien, <a href="#">augue vitae iaculis euismod</a>, rutrum ac nibh nec, tristique commodo neque.</p>
 			<?php printf(
 					'<div class="apple-news-image">%s</div>',
 					esc_html__( 'Image', 'apple-news' )

--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -108,6 +108,7 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 			'dropcap_number_of_lines' => array(
 				'label' => __( 'Drop cap number of lines', 'apple-news' ),
 				'type' => 'integer',
+				'description' => __( 'Must be an integer between 2 and 10. Actual number of lines occupied will vary based on device size.', 'apple-news' ),
 			),
 			'dropcap_number_of_raised_lines' => array(
 				'label' => __( 'Drop cap number of raised lines', 'apple-news' ),

--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -89,13 +89,33 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 				'label' => __( 'Use initial drop cap', 'apple-news' ),
 				'type' => array( 'yes', 'no' ),
 			),
-			'dropcap_font' => array(
-				'label' => __( 'Dropcap font face', 'apple-news' ),
-				'type' => 'font',
+			'dropcap_background_color' => array(
+				'label' => __( 'Drop cap background color', 'apple-news' ),
+				'type' => 'color',
 			),
 			'dropcap_color' => array(
 				'label' => __( 'Drop cap font color', 'apple-news' ),
 				'type' => 'color',
+			),
+			'dropcap_font' => array(
+				'label' => __( 'Dropcap font face', 'apple-news' ),
+				'type' => 'font',
+			),
+			'dropcap_number_of_characters' => array(
+				'label' => __( 'Drop cap number of characters', 'apple-news' ),
+				'type' => 'integer',
+			),
+			'dropcap_number_of_lines' => array(
+				'label' => __( 'Drop cap number of lines', 'apple-news' ),
+				'type' => 'integer',
+			),
+			'dropcap_number_of_raised_lines' => array(
+				'label' => __( 'Drop cap number of raised lines', 'apple-news' ),
+				'type' => 'integer',
+			),
+			'dropcap_padding' => array(
+				'label' => __( 'Drop cap padding', 'apple-news' ),
+				'type' => 'integer',
 			),
 			'byline_font' => array(
 				'label' => __( 'Byline font face', 'apple-news' ),
@@ -433,9 +453,14 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 			'dropcap' => array(
 				'label' => __( 'Drop Cap', 'apple-news' ),
 				'settings' => array(
-					'dropcap_font',
 					'initial_dropcap',
-					'dropcap_color'
+					'dropcap_background_color',
+					'dropcap_color',
+					'dropcap_font',
+					'dropcap_number_of_characters',
+					'dropcap_number_of_lines',
+					'dropcap_number_of_raised_lines',
+					'dropcap_padding',
 				),
 			),
 			'byline' => array(

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -830,13 +830,17 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		// use the default value to be safe.
 		$default_settings = new Settings();
 		foreach ( $this->settings as $key => $attributes ) {
-			if ( ! empty( $_POST[ $key ] ) ) {
+			if ( ! empty( $_POST[ $key ] )
+				|| ( isset( $_POST[ $key ] )
+					&& in_array( $_POST[ $key ], array( 0, '0' ), true )
+				)
+			) {
 				// Sanitize the value
 				$sanitize = ( empty( $attributes['sanitize'] ) || ! is_callable( $attributes['sanitize'] ) ) ? 'sanitize_text_field' : $attributes['sanitize'];
 				$value = call_user_func( $sanitize, $_POST[ $key ] );
 			} else {
 				// Use the default value
-				$value = $default_settings->get( $key );
+				$value = $default_settings->$key;
 			}
 
 			// Add to the array

--- a/assets/css/preview.css
+++ b/assets/css/preview.css
@@ -48,6 +48,7 @@
 
 .apple-news-dropcap {
 	float: left;
+	margin-right: 5px;
 	position: relative;
 }
 

--- a/assets/css/preview.css
+++ b/assets/css/preview.css
@@ -48,9 +48,6 @@
 
 .apple-news-dropcap {
 	float: left;
-	padding-top: 7px;
-	padding-right: 10px;
-	padding-left: 5px;
 }
 
 .wrap .apple-news-title {

--- a/assets/css/preview.css
+++ b/assets/css/preview.css
@@ -46,7 +46,7 @@
 	margin: 0px;
 }
 
-.apple-news-dropcap-enabled {
+.apple-news-dropcap {
 	float: left;
 	padding-top: 7px;
 	padding-right: 10px;

--- a/assets/css/preview.css
+++ b/assets/css/preview.css
@@ -48,6 +48,9 @@
 
 .apple-news-dropcap {
 	float: left;
+	margin-bottom: -30px;
+	margin-top: -2px;
+	position: relative;
 }
 
 .wrap .apple-news-title {

--- a/assets/css/preview.css
+++ b/assets/css/preview.css
@@ -48,8 +48,6 @@
 
 .apple-news-dropcap {
 	float: left;
-	margin-bottom: -30px;
-	margin-top: -2px;
 	position: relative;
 }
 

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -57,6 +57,7 @@
 		var bodyLineHeight = $( '#body_line_height' ).val(),
 			dropcapCharacters = parseInt( $( '#dropcap_number_of_characters' ).val() ),
 			dropcapNumberOfLines = parseInt( $( '#dropcap_number_of_lines' ).val() ),
+			dropcapNumberOfRaisedLines = parseInt( $( '#dropcap_number_of_raised_lines' ).val() ),
 			dropcapPadding = parseInt( $( '#dropcap_padding' ).val() ),
 			dropcapParagraph = $( '.apple-news-component p' ).first();
 
@@ -67,6 +68,15 @@
 		} else if ( dropcapNumberOfLines > 10 ) {
 			dropcapNumberOfLines = 10;
 			$( '#dropcap_number_of_lines' ).val( 10 )
+		}
+
+		// Adjust number of raised lines to remain within tolerance.
+		if ( dropcapNumberOfRaisedLines < 0 ) {
+			dropcapNumberOfRaisedLines = 0;
+			$( '#dropcap_number_of_raised_lines' ).val( 0 )
+		} else if ( dropcapNumberOfRaisedLines >= dropcapNumberOfLines ) {
+			dropcapNumberOfRaisedLines = dropcapNumberOfLines - 1;
+			$( '#dropcap_number_of_raised_lines' ).val( dropcapNumberOfRaisedLines )
 		}
 
 		// Remove existing dropcap.
@@ -93,12 +103,16 @@
 			dropcapSize = bodyLineHeight * targetLines * 1.2 - dropcapPadding * 2;
 			dropcapLineHeight = dropcapSize;
 
-			// TODO: Calculate raised lines
+			// Compute the adjusted number of target lines based on raised lines.
+			var adjustedLines = Math.round( -0.6 * dropcapNumberOfRaisedLines + targetLines );
+			dropcapParagraph.css( 'margin-top', ( 20 + bodyLineHeight * ( targetLines - adjustedLines ) / 2 ) + 'px' );
 
 			// Apply computed styles.
 			$( '.apple-news-preview .apple-news-dropcap' )
 				.css( 'font-size', dropcapSize + 'px' )
-				.css( 'line-height', dropcapLineHeight + 'px' )
+				.css( 'line-height', ( dropcapLineHeight * .66 ) + 'px' )
+				.css( 'margin-bottom', ( -1 * bodyLineHeight * .33 ) + 'px' )
+				.css( 'margin-top', ( -1 * bodyLineHeight * ( targetLines - adjustedLines ) * .9 + bodyLineHeight * .33 ) + 'px' )
 				.css( 'padding', dropcapPadding + 'px ' + ( dropcapPadding + 5 ) + 'px ' + dropcapPadding + 'px ' + dropcapPadding + 'px' );
 
 			// Apply direct styles.

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -54,11 +54,20 @@
 		appleNewsSetCSS( '.apple-news-image', 'body_line_height', 'margin-bottom', 'px', null );
 
 		// Dropcap
-		var bodySize = $( '#body_size' ).val(),
-			bodyLineHeight = $( '#body_line_height' ).val(),
-			dropcapCharacters = $( '#dropcap_number_of_characters' ).val(),
-			dropcapNumberOfLines = $( '#dropcap_number_of_lines' ).val(),
+		var bodyLineHeight = $( '#body_line_height' ).val(),
+			dropcapCharacters = parseInt( $( '#dropcap_number_of_characters' ).val() ),
+			dropcapNumberOfLines = parseInt( $( '#dropcap_number_of_lines' ).val() ),
+			dropcapPadding = parseInt( $( '#dropcap_padding' ).val() ),
 			dropcapParagraph = $( '.apple-news-component p' ).first();
+
+		// Adjust number of lines to remain within tolerance.
+		if ( dropcapNumberOfLines < 2 ) {
+			dropcapNumberOfLines = 2;
+			$( '#dropcap_number_of_lines' ).val( 2 )
+		} else if ( dropcapNumberOfLines > 10 ) {
+			dropcapNumberOfLines = 10;
+			$( '#dropcap_number_of_lines' ).val( 10 )
+		}
 
 		// Remove existing dropcap.
 		dropcapParagraph.html(
@@ -81,17 +90,16 @@
 			// what renders in Apple News, so we need to adjust this by a coefficient
 			// to roughly match the actual behavior.
 			var targetLines = Math.ceil( dropcapNumberOfLines * 0.56 );
-			console.log( targetLines );
-			dropcapSize = bodyLineHeight * targetLines;
+			dropcapSize = bodyLineHeight * targetLines * 1.2 - dropcapPadding * 2;
 			dropcapLineHeight = dropcapSize;
 
-			// TODO: Calculate padding
 			// TODO: Calculate raised lines
 
 			// Apply computed styles.
 			$( '.apple-news-preview .apple-news-dropcap' )
 				.css( 'font-size', dropcapSize + 'px' )
-				.css( 'line-height', dropcapLineHeight + 'px' );
+				.css( 'line-height', dropcapLineHeight + 'px' )
+				.css( 'padding', dropcapPadding + 'px ' + ( dropcapPadding + 5 ) + 'px ' + dropcapPadding + 'px ' + dropcapPadding + 'px' );
 
 			// Apply direct styles.
 			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_background_color', 'background', null, null );

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -90,9 +90,9 @@
 			// Create the dropcap span with the specified number of characters.
 			dropcapParagraph.html(
 				'<span class="apple-news-dropcap">' +
-		        dropcapParagraph.html().substr( 0, dropcapCharacters ) +
+				dropcapParagraph.html().substr( 0, dropcapCharacters ) +
 				'</span>' +
-			    dropcapParagraph.html().substr( dropcapCharacters )
+				dropcapParagraph.html().substr( dropcapCharacters )
 			);
 
 			// Set the size based on the specified number of lines.
@@ -104,15 +104,15 @@
 			dropcapLineHeight = dropcapSize;
 
 			// Compute the adjusted number of target lines based on raised lines.
-			var adjustedLines = Math.round( -0.6 * dropcapNumberOfRaisedLines + targetLines );
+			var adjustedLines = Math.round( - 0.6 * dropcapNumberOfRaisedLines + targetLines );
 			dropcapParagraph.css( 'margin-top', ( 20 + bodyLineHeight * ( targetLines - adjustedLines ) / 2 ) + 'px' );
 
 			// Apply computed styles.
 			$( '.apple-news-preview .apple-news-dropcap' )
 				.css( 'font-size', dropcapSize + 'px' )
 				.css( 'line-height', ( dropcapLineHeight * .66 ) + 'px' )
-				.css( 'margin-bottom', ( -1 * bodyLineHeight * .33 ) + 'px' )
-				.css( 'margin-top', ( -1 * bodyLineHeight * ( targetLines - adjustedLines ) * .9 + bodyLineHeight * .33 ) + 'px' )
+				.css( 'margin-bottom', ( - 1 * bodyLineHeight * .33 ) + 'px' )
+				.css( 'margin-top', ( - 1 * bodyLineHeight * ( targetLines - adjustedLines ) * .9 + bodyLineHeight * .33 ) + 'px' )
 				.css( 'padding', dropcapPadding + 'px ' + ( dropcapPadding + 5 ) + 'px ' + dropcapPadding + 'px ' + dropcapPadding + 'px' );
 
 			// Apply direct styles.

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -57,8 +57,7 @@
 		var bodySize = $( '#body_size' ).val(),
 			bodyLineHeight = $( '#body_line_height' ).val(),
 			dropcapCharacters = $( '#dropcap_number_of_characters' ).val(),
-			dropcapSize = bodySize,
-			dropcapLineHeight = bodyLineHeight,
+			dropcapNumberOfLines = $( '#dropcap_number_of_lines' ).val(),
 			dropcapParagraph = $( '.apple-news-component p' ).first();
 
 		// Remove existing dropcap.
@@ -68,17 +67,33 @@
 
 		// If enabled, add it back.
 		if ( 'yes' === $( '#initial_dropcap' ).val() ) {
+
+			// Create the dropcap span with the specified number of characters.
 			dropcapParagraph.html(
 				'<span class="apple-news-dropcap">' +
 		        dropcapParagraph.html().substr( 0, dropcapCharacters ) +
 				'</span>' +
 			    dropcapParagraph.html().substr( dropcapCharacters )
 			);
-			dropcapSize = bodySize * 5;
-			dropcapLineHeight = bodySize * 3.5;
+
+			// Set the size based on the specified number of lines.
+			// There is not an actual 1:1 relationship between this setting and
+			// what renders in Apple News, so we need to adjust this by a coefficient
+			// to roughly match the actual behavior.
+			var targetLines = Math.ceil( dropcapNumberOfLines * 0.56 );
+			console.log( targetLines );
+			dropcapSize = bodyLineHeight * targetLines;
+			dropcapLineHeight = dropcapSize;
+
+			// TODO: Calculate padding
+			// TODO: Calculate raised lines
+
+			// Apply computed styles.
 			$( '.apple-news-preview .apple-news-dropcap' )
 				.css( 'font-size', dropcapSize + 'px' )
 				.css( 'line-height', dropcapLineHeight + 'px' );
+
+			// Apply direct styles.
 			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_background_color', 'background', null, null );
 			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_color', 'color', null, null );
 			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_font', 'font-family', null, null );

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -54,22 +54,35 @@
 		appleNewsSetCSS( '.apple-news-image', 'body_line_height', 'margin-bottom', 'px', null );
 
 		// Dropcap
-		appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_color', 'color', null, null );
-		appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_font', 'font-family', null, null );
-		var bodySize = $( '#body_size' ).val();
-		var bodyLineHeight = $( '#body_line_height' ).val();
-		var dropcapSize = bodySize;
-		var dropcapLineHeight = bodyLineHeight;
+		var bodySize = $( '#body_size' ).val(),
+			bodyLineHeight = $( '#body_line_height' ).val(),
+			dropcapCharacters = $( '#dropcap_number_of_characters' ).val(),
+			dropcapSize = bodySize,
+			dropcapLineHeight = bodyLineHeight,
+			dropcapParagraph = $( '.apple-news-component p' ).first();
 
+		// Remove existing dropcap.
+		dropcapParagraph.html(
+			dropcapParagraph.html().replace( /<span[^>]*>([^<]+)<\/span>/, '$1' )
+		);
+
+		// If enabled, add it back.
 		if ( 'yes' === $( '#initial_dropcap' ).val() ) {
+			dropcapParagraph.html(
+				'<span class="apple-news-dropcap">' +
+		        dropcapParagraph.html().substr( 0, dropcapCharacters ) +
+				'</span>' +
+			    dropcapParagraph.html().substr( dropcapCharacters )
+			);
 			dropcapSize = bodySize * 5;
 			dropcapLineHeight = bodySize * 3.5;
-			$( '.apple-news-preview .apple-news-dropcap' ).addClass( 'apple-news-dropcap-enabled' );
-		} else {
-			$( '.apple-news-preview .apple-news-dropcap' ).removeClass( 'apple-news-dropcap-enabled' );
+			$( '.apple-news-preview .apple-news-dropcap' )
+				.css( 'font-size', dropcapSize + 'px' )
+				.css( 'line-height', dropcapLineHeight + 'px' );
+			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_background_color', 'background', null, null );
+			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_color', 'color', null, null );
+			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_font', 'font-family', null, null );
 		}
-		$( '.apple-news-preview .apple-news-dropcap' ).css( 'font-size', dropcapSize + 'px' );
-		$( '.apple-news-preview .apple-news-dropcap' ).css( 'line-height', dropcapLineHeight + 'px' );
 
 		// Byline
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_font', 'font-family', null, null );

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -113,7 +113,7 @@
 				.css( 'line-height', ( dropcapLineHeight * .66 ) + 'px' )
 				.css( 'margin-bottom', ( - 1 * bodyLineHeight * .33 ) + 'px' )
 				.css( 'margin-top', ( - 1 * bodyLineHeight * ( targetLines - adjustedLines ) * .9 + bodyLineHeight * .33 ) + 'px' )
-				.css( 'padding', dropcapPadding + 'px ' + ( dropcapPadding + 5 ) + 'px ' + dropcapPadding + 'px ' + dropcapPadding + 'px' );
+				.css( 'padding', ( 5 + dropcapPadding ) + 'px ' + ( 10 + dropcapPadding ) + 'px ' + dropcapPadding + 'px ' + ( 5 + dropcapPadding ) + 'px' );
 
 			// Apply direct styles.
 			appleNewsSetCSS( '.apple-news-preview .apple-news-dropcap', 'dropcap_background_color', 'background', null, null );

--- a/assets/js/theme-edit.js
+++ b/assets/js/theme-edit.js
@@ -102,13 +102,19 @@
 		$( '.apple-news-color-picker' ).iris({
 			palettes: true,
 			width: 320,
-			change: appleNewsThemeEditUpdated
+			change: appleNewsColorPickerChange,
+			clear: appleNewsColorPickerChange
 		});
 
 		$( '.apple-news-color-picker' ).on( 'click', function() {
 			$( '.apple-news-color-picker' ).iris( 'hide' );
 			$( this ).iris( 'show' );
 		});
+	}
+
+	function appleNewsColorPickerChange( event, ui ) {
+		$( event.target ).val( ui.color.toString() );
+		appleNewsThemeEditUpdated();
 	}
 
 }( jQuery ) );

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -57,8 +57,13 @@ class Settings {
 		'body_tracking' => 0,
 
 		'initial_dropcap' => 'yes',
-		'dropcap_font' => 'AvenirNext-Bold',
+		'dropcap_background_color' => '',
 		'dropcap_color' => '#4f4f4f',
+		'dropcap_font' => 'AvenirNext-Bold',
+		'dropcap_number_of_characters' => 1,
+		'dropcap_number_of_lines' => 4,
+		'dropcap_number_of_raised_lines' => 0,
+		'dropcap_padding' => 5,
 
 		'byline_font' => 'AvenirNext-Medium',
 		'byline_size' => 13,

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -196,19 +196,24 @@ class Body extends Component {
 	 * @access private
 	 */
 	private function set_initial_dropcap_style() {
-		$this->json[ 'textStyle' ] = 'dropcapBodyStyle';
-		$this->register_style( 'dropcapBodyStyle', array_merge(
-			$this->get_default_style(),
-		 	array(
-				'dropCapStyle' => array (
-					'numberOfLines' 		=> 4,
-					'numberOfCharacters' 	=> 1,
-					'padding' 				=> 5,
-					'fontName' 				=> $this->get_setting( 'dropcap_font' ),
-					'textColor'				=> $this->get_setting( 'dropcap_color' ),
-				),
+		$this->json['textStyle'] = 'dropcapBodyStyle';
+		$this->register_style(
+			'dropcapBodyStyle',
+			array_merge(
+				$this->get_default_style(),
+				array(
+					'dropCapStyle' => array(
+						'backgroundColor' => $this->get_setting( 'dropcap_background_color' ),
+						'fontName' => $this->get_setting( 'dropcap_font' ),
+						'numberOfCharacters' => $this->get_setting( 'dropcap_number_of_characters' ),
+						'numberOfLines' => $this->get_setting( 'dropcap_number_of_lines' ),
+						'numberOfRaisedLines' => $this->get_setting( 'dropcap_number_of_raised_lines' ),
+						'padding' => $this->get_setting( 'dropcap_padding' ),
+						'textColor' => $this->get_setting( 'dropcap_color' ),
+					),
+				)
 			)
-	 	) );
+		);
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -197,11 +197,19 @@ class Body extends Component {
 	 */
 	private function set_initial_dropcap_style() {
 
+		// Negotiate the number of lines.
+		$number_of_lines = absint( $this->get_setting( 'dropcap_number_of_lines' ) );
+		if ( $number_of_lines < 2 ) {
+			$number_of_lines = 2;
+		} elseif ( $number_of_lines > 10 ) {
+			$number_of_lines = 10;
+		}
+
 		// Start building the custom dropcap body style.
 		$dropcap_style = array(
 			'fontName' => $this->get_setting( 'dropcap_font' ),
 			'numberOfCharacters' => absint( $this->get_setting( 'dropcap_number_of_characters' ) ),
-			'numberOfLines' => absint( $this->get_setting( 'dropcap_number_of_lines' ) ),
+			'numberOfLines' => $number_of_lines,
 			'numberOfRaisedLines' => absint( $this->get_setting( 'dropcap_number_of_raised_lines' ) ),
 			'padding' => absint( $this->get_setting( 'dropcap_padding' ) ),
 			'textColor' => $this->get_setting( 'dropcap_color' ),

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -196,22 +196,32 @@ class Body extends Component {
 	 * @access private
 	 */
 	private function set_initial_dropcap_style() {
+
+		// Start building the custom dropcap body style.
+		$dropcap_style = array(
+			'fontName' => $this->get_setting( 'dropcap_font' ),
+			'numberOfCharacters' => absint( $this->get_setting( 'dropcap_number_of_characters' ) ),
+			'numberOfLines' => absint( $this->get_setting( 'dropcap_number_of_lines' ) ),
+			'numberOfRaisedLines' => absint( $this->get_setting( 'dropcap_number_of_raised_lines' ) ),
+			'padding' => absint( $this->get_setting( 'dropcap_padding' ) ),
+			'textColor' => $this->get_setting( 'dropcap_color' ),
+		);
+
+		// Add the background color, if defined.
+		$background_color = $this->get_setting( 'dropcap_background_color' );
+		if ( ! empty( $background_color ) ) {
+			$dropcap_style['backgroundColor'] = $background_color;
+		}
+
+		// Set the text style.
 		$this->json['textStyle'] = 'dropcapBodyStyle';
+
+		// Apply the dropcap body style.
 		$this->register_style(
 			'dropcapBodyStyle',
 			array_merge(
 				$this->get_default_style(),
-				array(
-					'dropCapStyle' => array(
-						'backgroundColor' => $this->get_setting( 'dropcap_background_color' ),
-						'fontName' => $this->get_setting( 'dropcap_font' ),
-						'numberOfCharacters' => $this->get_setting( 'dropcap_number_of_characters' ),
-						'numberOfLines' => $this->get_setting( 'dropcap_number_of_lines' ),
-						'numberOfRaisedLines' => $this->get_setting( 'dropcap_number_of_raised_lines' ),
-						'padding' => $this->get_setting( 'dropcap_padding' ),
-						'textColor' => $this->get_setting( 'dropcap_color' ),
-					),
-				)
+				array( 'dropCapStyle' => $dropcap_style )
 			)
 		);
 	}

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -123,6 +123,13 @@ HTML;
 		$this->settings->body_link_color = '#fedcba';
 		$this->settings->body_line_height = 28;
 		$this->settings->body_tracking = 50;
+		$this->settings->dropcap_background_color = '#abcabc';
+		$this->settings->dropcap_color = '#defdef';
+		$this->settings->dropcap_font = 'TestFontName2';
+		$this->settings->dropcap_number_of_characters = 15;
+		$this->settings->dropcap_number_of_lines = 10;
+		$this->settings->dropcap_number_of_raised_lines = 5;
+		$this->settings->dropcap_padding = 20;
 
 		// Run the export.
 		$exporter = new Exporter( $content, null, $this->settings );
@@ -152,6 +159,34 @@ HTML;
 		$this->assertEquals(
 			0.5,
 			$json['componentTextStyles']['default-body']['tracking']
+		);
+		$this->assertEquals(
+			'#abcabc',
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['backgroundColor']
+		);
+		$this->assertEquals(
+			'#defdef',
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['textColor']
+		);
+		$this->assertEquals(
+			'TestFontName2',
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['fontName']
+		);
+		$this->assertEquals(
+			15,
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['numberOfCharacters']
+		);
+		$this->assertEquals(
+			10,
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['numberOfLines']
+		);
+		$this->assertEquals(
+			5,
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['numberOfRaisedLines']
+		);
+		$this->assertEquals(
+			20,
+			$json['componentTextStyles']['dropcapBodyStyle']['dropCapStyle']['padding']
 		);
 	}
 


### PR DESCRIPTION
* Adds support for configurable background color, number of characters, number of lines, number of raised lines, and padding to dropcap settings.
* Adds preview support for the new settings.
* Adds unit test coverage for the new settings.
* Fixes a display bug where new values in the color picker don't take effect right away.
* Fixes a bug in which numerical settings with a valid value of `0` are overwritten by the default on save.

Fixes #247.