### PR TITLE
Use API URL from official documentation

### DIFF
--- a/admin/apple-actions/class-api-action.php
+++ b/admin/apple-actions/class-api-action.php
@@ -18,7 +18,7 @@ abstract class API_Action extends Action {
 	/**
 	 * The API endpoint for all Apple News requests.
 	 */
-	const API_ENDPOINT = 'https://u48r14.digitalhub.com';
+	const API_ENDPOINT = 'https://news-api.apple.com';
 
 	/**
 	 * Instance of the API class.

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -136,7 +136,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		) );
 
 		// Cache as a transient to bypass the API call
-		$self = 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789a';
+		$self = 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a';
 		set_transient(
 			'apple_news_sections',
 			array(
@@ -145,7 +145,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 					'id' => 'abcdef01-2345-6789-abcd-ef012356789a',
 					'isDefault' => true,
 					'links' => (object) array(
-						'channel' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
+						'channel' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
 						'self' => $self,
 					),
 					'modifiedAt' => '2017-01-01T00:00:00Z',
@@ -190,7 +190,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		) );
 
 		// Set it to a fake section
-		$section_id = 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789a';
+		$section_id = 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a';
 		update_post_meta( $post_id, 'apple_news_sections', array( $section_id ) );
 
 		// Create a mapping from that section to the test theme

--- a/tests/admin/test-class-admin-apple-meta-boxes.php
+++ b/tests/admin/test-class-admin-apple-meta-boxes.php
@@ -20,7 +20,7 @@ class Admin_Apple_Meta_Boxes_Test extends WP_UnitTestCase {
 
 		// Create post data
 		$_POST['post_ID'] = $post_id;
-		$_POST['apple_news_sections'] = array( 'https://u48r14.digitalhub.com/sections/1234567890' );
+		$_POST['apple_news_sections'] = array( 'https://news-api.apple.com/sections/1234567890' );
 		$_POST['apple_news_is_preview'] = 0;
 		$_POST['apple_news_is_sponsored'] = 0;
 		$_POST['apple_news_maturity_rating'] = 'MATURE';
@@ -36,7 +36,7 @@ class Admin_Apple_Meta_Boxes_Test extends WP_UnitTestCase {
 		}
 
 		// Check the meta values
-		$this->assertEquals( array( 'https://u48r14.digitalhub.com/sections/1234567890' ), get_post_meta( $post_id, 'apple_news_sections', true ) );
+		$this->assertEquals( array( 'https://news-api.apple.com/sections/1234567890' ), get_post_meta( $post_id, 'apple_news_sections', true ) );
 		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_preview', true ) );
 		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_sponsored', true ) );
 		$this->assertEquals( 'MATURE', get_post_meta( $post_id, 'apple_news_maturity_rating', true ) );
@@ -54,7 +54,7 @@ class Admin_Apple_Meta_Boxes_Test extends WP_UnitTestCase {
 
 		// Create post data
 		$_POST['post_ID'] = $post_id;
-		$_POST['apple_news_sections'] = array( 'https://u48r14.digitalhub.com/sections/1234567890' );
+		$_POST['apple_news_sections'] = array( 'https://news-api.apple.com/sections/1234567890' );
 		$_POST['apple_news_is_preview'] = 0;
 		$_POST['apple_news_is_sponsored'] = 0;
 		$_POST['apple_news_maturity_rating'] = 'MATURE';
@@ -70,7 +70,7 @@ class Admin_Apple_Meta_Boxes_Test extends WP_UnitTestCase {
 		}
 
 		// Check the meta values
-		$this->assertEquals( array( 'https://u48r14.digitalhub.com/sections/1234567890' ), get_post_meta( $post_id, 'apple_news_sections', true ) );
+		$this->assertEquals( array( 'https://news-api.apple.com/sections/1234567890' ), get_post_meta( $post_id, 'apple_news_sections', true ) );
 		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_preview', true ) );
 		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_sponsored', true ) );
 		$this->assertEquals( 'MATURE', get_post_meta( $post_id, 'apple_news_maturity_rating', true ) );

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -41,8 +41,8 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 					'id' => 'abcdef01-2345-6789-abcd-ef012356789a',
 					'isDefault' => true,
 					'links' => (object) array(
-						'channel' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
-						'self' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
+						'channel' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
+						'self' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
 					),
 					'modifiedAt' => '2017-01-01T00:00:00Z',
 					'name' => 'Main',
@@ -54,8 +54,8 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 					'id' => 'abcdef01-2345-6789-abcd-ef012356789b',
 					'isDefault' => false,
 					'links' => (object) array(
-						'channel' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
-						'self' => 'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
+						'channel' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
+						'self' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
 					),
 					'modifiedAt' => '2017-01-01T00:00:00Z',
 					'name' => 'Secondary Section',
@@ -142,7 +142,7 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 		// Validate automatic section assignment.
 		$this->assertEquals(
 			array(
-				'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
+				'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
 			),
 			Admin_Apple_Sections::get_sections_for_post( $post_id )
 		);
@@ -186,14 +186,14 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 			$post_id,
 			'apple_news_sections',
 			array(
-				'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
+				'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
 			)
 		);
 
 		// Validate manual section assignment.
 		$this->assertEquals(
 			array(
-				'https://u48r14.digitalhub.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
+				'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
 			),
 			Admin_Apple_Sections::get_sections_for_post( $post_id )
 		);


### PR DESCRIPTION
> All News API requests should be issued against the URL https://news-api.apple.com.

The [official API docs](https://developer.apple.com/library/content/documentation/General/Conceptual/News_API_Ref/index.html) say requests should be sent to https://news-api.apple.com/ - I can't find any reference to the digitalhub.com URL.