### PR TITLE
Making administrator email requirement conditional

### DIFF
--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -194,6 +194,14 @@ class Admin_Apple_Settings extends Apple_News {
 			array( 'jquery' ),
 			self::$version
 		);
+
+		wp_enqueue_script(
+			'apple-news-settings',
+			plugin_dir_url( __FILE__ ) . '../assets/js/settings.js',
+			array( 'jquery' ),
+			self::$version,
+			true
+		);
 	}
 
 	/**

--- a/admin/settings/class-admin-apple-settings-section-developer-tools.php
+++ b/admin/settings/class-admin-apple-settings-section-developer-tools.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Publish to Apple News Admin Settings: Admin_Apple_Settings_Section_Developer_Tools class
+ *
+ * Contains a class which is used to handle settings in the developer tools section.
+ *
+ * @package Apple_News
+ * @since 0.6.0
+ */
 
 /**
- * Describes a WordPress setting section
+ * A class which is used to handle settings in the developer tools section.
  *
  * @since 0.6.0
  */
@@ -22,25 +30,29 @@ class Admin_Apple_Settings_Section_Developer_Tools extends Admin_Apple_Settings_
 	 */
 	function __construct( $page ) {
 		// Set the name
-		$this->name =  __( 'Developer Tools', 'apple-news' );
+		$this->name = __( 'Developer Tools', 'apple-news' );
 
 		// Add the settings
 		$this->settings = array(
 			'apple_news_enable_debugging' => array(
-				'label'   => __( 'Enable Debugging', 'apple-news' ),
-				'type'    => array( 'no', 'yes' ),
+				'label' => __( 'Enable Debugging', 'apple-news' ),
+				'type' => array( 'no', 'yes' ),
 			),
 			'apple_news_admin_email' => array(
-				'label'    		=> __( 'Administrator Email', 'apple-news' ),
-				'type'     		=> 'text',
+				'label' => __( 'Administrator Email', 'apple-news' ),
+				'required' => false,
+				'type' => 'text',
 			),
 		);
 
 		// Add the groups
 		$this->groups = array(
 			'debugging_settings' => array(
-				'label'       => __( 'Debugging Settings', 'apple-news' ),
-				'settings'    => array( 'apple_news_enable_debugging', 'apple_news_admin_email' ),
+				'label' => __( 'Debugging Settings', 'apple-news' ),
+				'settings' => array(
+					'apple_news_enable_debugging',
+					'apple_news_admin_email'
+				),
 			),
 		);
 

--- a/admin/settings/class-admin-apple-settings-section-developer-tools.php
+++ b/admin/settings/class-admin-apple-settings-section-developer-tools.php
@@ -26,13 +26,14 @@ class Admin_Apple_Settings_Section_Developer_Tools extends Admin_Apple_Settings_
 	/**
 	 * Constructor.
 	 *
-	 * @param string $page
+	 * @param string $page The name of the submenu page that this section is part of.
 	 */
 	function __construct( $page ) {
-		// Set the name
+
+		// Set the name.
 		$this->name = __( 'Developer Tools', 'apple-news' );
 
-		// Add the settings
+		// Add the settings.
 		$this->settings = array(
 			'apple_news_enable_debugging' => array(
 				'label' => __( 'Enable Debugging', 'apple-news' ),
@@ -45,13 +46,13 @@ class Admin_Apple_Settings_Section_Developer_Tools extends Admin_Apple_Settings_
 			),
 		);
 
-		// Add the groups
+		// Add the groups.
 		$this->groups = array(
 			'debugging_settings' => array(
 				'label' => __( 'Debugging Settings', 'apple-news' ),
 				'settings' => array(
 					'apple_news_enable_debugging',
-					'apple_news_admin_email'
+					'apple_news_admin_email',
 				),
 			),
 		);
@@ -66,6 +67,9 @@ class Admin_Apple_Settings_Section_Developer_Tools extends Admin_Apple_Settings_
 	 * @access public
 	 */
 	public function get_section_info() {
-		return __( 'If debugging is enabled, emails will be sent to an administrator for every publish, update or delete action with a detailed API response.', 'apple-news' );
+		return __(
+			'If debugging is enabled, emails will be sent to an administrator for every publish, update or delete action with a detailed API response.',
+			'apple-news'
+		);
 	}
 }

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,15 @@
+(
+	function ( $, window, undefined ) {
+		'use strict';
+
+		// Listen for changes to the debugging settings.
+		$( '#apple_news_enable_debugging' ).on( 'change', function () {
+			var $email = $( '#apple_news_admin_email' );
+			if ( 'yes' === $( this ).val() ) {
+				$email.attr( 'required', 'required' );
+			} else {
+				$email.removeAttr( 'required' );
+			}
+		} ).change();
+	}
+)( jQuery, window );


### PR DESCRIPTION
* Makes administrator email field on the settings page required only when debug is enabled.
* Cleans up developer settings section class to adhere to WordPress coding standards.

Fixes #342.