### PR TITLE
Converting sections API error into a non-fatal

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -192,6 +192,19 @@ class Admin_Apple_News extends Apple_News {
 	}
 
 	/**
+	 * A function to display an error message.
+	 *
+	 * @param string $message The message to display.
+	 *
+	 * @access public
+	 */
+	public static function show_error( $message ) {
+		echo '<div class="apple-news-notice apple-news-notice-error"><p>'
+			. esc_html( $message )
+			. '</p></div>';
+	}
+
+	/**
 	 * Actions to be run on the `init` action hook.
 	 *
 	 * @access public

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -90,7 +90,10 @@ class Admin_Apple_Sections extends Apple_News {
 		$section_api = new Section( $admin_settings->fetch_settings() );
 		$sections = $section_api->get_sections();
 		if ( empty( $sections ) || ! is_array( $sections ) ) {
-			wp_die( __( 'Unable to fetch a list of sections.', 'apple-news' ) );
+			$sections = array();
+			Admin_Apple_News::show_error(
+				__( 'Unable to fetch a list of sections.', 'apple-news' )
+			);
 		}
 
 		return $sections;


### PR DESCRIPTION
* Adds a generic function for printing error messages within the admin.
* Converts the `wp_die()` call which fires when the plugin is unable to fetch a list of sections from the API to use the non-fatal generic function for printing error messages to the user.

Fixes #341.