### PR TITLE
Cleans up API URLs

### DIFF
--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -72,7 +72,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 	public function testCreateWithSections() {
 		// Create post
 		$post_id = $this->factory->post->create();
-		update_post_meta( $post_id, 'apple_news_sections', array( 'http://news-api.apple.com/sections/123' ) );
+		update_post_meta( $post_id, 'apple_news_sections', array( 'https://news-api.apple.com/sections/123' ) );
 
 		// Prophesize the action
 		$response = $this->dummy_response();
@@ -85,7 +85,7 @@ class Admin_Action_Index_Push_Test extends WP_UnitTestCase {
 				'data' => array(
 					'links' => array(
 						'sections' => array(
-							'http://news-api.apple.com/sections/123',
+							'https://news-api.apple.com/sections/123',
 						),
 					),
 				)

--- a/tests/apple-push-api/test-class-api.php
+++ b/tests/apple-push-api/test-class-api.php
@@ -15,7 +15,7 @@ class API_Test extends WP_UnitTestCase {
 
 		$key        = '12345';
 		$secret     = '12345';
-		$endpoint   = 'https://u48r14.digitalhub.com';
+		$endpoint   = 'https://news-api.apple.com';
 		$credentials = new Credentials( $key, $secret );
 	}
 


### PR DESCRIPTION
* Replaces last reference to digitalhub.com with news-api.apple.com
* Ensures all API URLs are https