### PR TITLE
Version 1.2.5 version bump and release notes

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -196,6 +196,7 @@ class Admin_Apple_News extends Apple_News {
 	 *
 	 * @param string $message The message to display.
 	 *
+	 * @since 1.2.5
 	 * @access public
 	 */
 	public static function show_error( $message ) {

--- a/apple-news.php
+++ b/apple-news.php
@@ -12,7 +12,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     1.2.4
+ * Version:     1.2.5
  * Author:      Alley Interactive
  * Author URI:  https://www.alleyinteractive.com
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '1.2.4';
+	public static $version = '1.2.5';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 4.7
-Stable tag: 1.2.4
+Stable tag: 1.2.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -44,6 +44,14 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 1.2.5 =
+
+* Bugfix: Fixed version of PHPUnit at 5.7.* for PHP 7.* and 4.8.* for PHP 5.* in the Travis configuration to fix a bug with incompatibility with PHPUnit 6
+* Bugfix: Set the base URL for the Apple News API to https://news-api.apple.com everywhere for better adherence to official guidance in the API docs (props to ffffelix for providing the initial PR)
+* Bugfix: Made the administrator email on the settings screen no longer required if debug mode is set to "no"
+* Bugfix: Converted the error that occurs when a list of sections cannot be retrieved from the API to a non-fatal to fix a problem where the content of the editor would appear white-on-white
+* Bugfix: Resolved an error that occurs on some systems during plugin activation on the Add New screen due to a duplicated root plugin file in the WordPress.org version of the plugin
 
 = 1.2.4 =
 * Added an interface for customizing of component JSON


### PR DESCRIPTION
* Updates version number to 1.2.5
* Updates release notes for bugfixes introduced in this version
* Adds a `@since` parameter for a function introduced in this version