### PR TITLE
README cleanup for version 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Publish to Apple News
+# Publish to Apple News
 
 The Publish to Apple News plugin enables your WordPress blog content to be published to your Apple News channel.
 
@@ -14,6 +14,6 @@ To enable content from your WordPress blog to be published to your Apple News ch
 
 Please see the [Apple Developer](https://developer.apple.com/) and [Apple News Publisher documentation](https://developer.apple.com/news-publisher/) and terms on Apple's website for complete information.
 
-#Wiki
+# Wiki
 
 Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for detailed [installation instructions](https://github.com/alleyinteractive/apple-news/wiki/Installation) as well as [configuration](https://github.com/alleyinteractive/apple-news/wiki/Configuration) and [usage instructions](https://github.com/alleyinteractive/apple-news/wiki/Usage), [troubleshooting information](https://github.com/alleyinteractive/apple-news/wiki/Usage#troubleshooting) and [details about contributing](https://github.com/alleyinteractive/apple-news/wiki/Contributing).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: potatomaster, kevinfodness, alleyinteractive, beezwaxbuzz, gosukiw
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 4.0
-Tested up to: 4.7
+Tested up to: 4.7.3
 Stable tag: 1.2.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html

--- a/readme.txt
+++ b/readme.txt
@@ -46,7 +46,6 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 == Changelog ==
 
 = 1.2.5 =
-
 * Bugfix: Fixed version of PHPUnit at 5.7.* for PHP 7.* and 4.8.* for PHP 5.* in the Travis configuration to fix a bug with incompatibility with PHPUnit 6
 * Bugfix: Set the base URL for the Apple News API to https://news-api.apple.com everywhere for better adherence to official guidance in the API docs (props to ffffelix for providing the initial PR)
 * Bugfix: Made the administrator email on the settings screen no longer required if debug mode is set to "no"


### PR DESCRIPTION
* Proper spacing after subheading in readme.txt
* Added minor version in "tested up to"
* Added spacing after `#` to produce proper headings in README.md