### PR TITLE
AN-17 Expanding media source support

### DIFF
--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -4,7 +4,7 @@ namespace Apple_Exporter\Builders;
 require_once plugin_dir_path( __FILE__ ) . '../../../admin/class-admin-apple-news.php';
 
 use \Admin_Apple_News;
-use \Apple_Exporter\Workspace;
+use \Apple_Exporter\Exporter_Content;
 
 /**
  * @since 0.4.0
@@ -64,21 +64,22 @@ class Metadata extends Builder {
 		if ( preg_match_all( '/<video[^>]+poster="([^"]+)".*?>(.+?)<\/video>/s', $this->content_text(), $matches ) ) {
 
 			// Loop through matched video elements looking for MP4 files.
-			for ( $i = 0; $i < count( $matches[2] ); $i ++ ) {
+			$total = count( $matches[2] );
+			for ( $i = 0; $i < $total; $i ++ ) {
 
 				// Try to match an MP4 source URL.
 				if ( preg_match( '/src="([^\?"]+\.mp4[^"]*)"/', $matches[2][ $i ], $src ) ) {
-					$meta['thumbnailURL'] = $this->maybe_bundle_source(
-						$matches[1][ $i ]
-					);
-					$meta['videoURL'] = $src[1];
 
-					// If the videoURL is root-relative, make it absolute.
-					if ( 0 === strpos( $meta['videoURL'], '/' ) ) {
-						$meta['videoURL'] = site_url( $meta['videoURL'] );
+					// Include the thumbnail and video URL if the video URL is valid.
+					$url = Exporter_Content::format_src_url( $src[1] );
+					if ( ! empty( $url ) ) {
+						$meta['thumbnailURL'] = $this->maybe_bundle_source(
+							$matches[1][ $i ]
+						);
+						$meta['videoURL'] = esc_url_raw( $url );
+
+						break;
 					}
-
-					break;
 				}
 			}
 		}

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -73,6 +73,11 @@ class Metadata extends Builder {
 					);
 					$meta['videoURL'] = $src[1];
 
+					// If the videoURL is root-relative, make it absolute.
+					if ( 0 === strpos( $meta['videoURL'], '/' ) ) {
+						$meta['videoURL'] = site_url( $meta['videoURL'] );
+					}
+
 					break;
 				}
 			}

--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -66,6 +66,42 @@ class Exporter_Content {
 	private $settings;
 
 	/**
+	 * Formats a URL from a `src` parameter to be compatible with remote sources.
+	 *
+	 * Will return a blank string if the URL is invalid.
+	 *
+	 * @param string $url The URL to format.
+	 *
+	 * @access protected
+	 * @return string The formatted URL on success, or a blank string on failure.
+	 */
+	public static function format_src_url( $url ) {
+
+		// If this is a root-relative path, make absolute.
+		if ( 0 === strpos( $url, '/' ) ) {
+			$url = site_url( $url );
+		}
+
+		// Escape the URL and ensure it is valid.
+		$url = esc_url_raw( $url );
+		if ( empty( $url ) ) {
+			return '';
+		}
+
+		// Ensure the URL begins with http.
+		if ( 0 !== strpos( $url, 'http' ) ) {
+			return '';
+		}
+
+		// Ensure the URL passes filter_var checks.
+		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return '';
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Contstructor.
 	 *
 	 * @param int $id

--- a/includes/apple-exporter/components/class-audio.php
+++ b/includes/apple-exporter/components/class-audio.php
@@ -54,6 +54,11 @@ class Audio extends Component {
 
 		$url = $match[1];
 
+		// If the URL is root-relative, make it absolute.
+		if ( 0 === strpos( $url, '/' ) ) {
+			$url = site_url( $url );
+		}
+
 		$this->register_json(
 			'json',
 			array(

--- a/includes/apple-exporter/components/class-audio.php
+++ b/includes/apple-exporter/components/class-audio.php
@@ -1,6 +1,8 @@
 <?php
 namespace Apple_Exporter\Components;
 
+use \Apple_Exporter\Exporter_Content;
+
 /**
  * An HTML audio tag.
  *
@@ -52,17 +54,16 @@ class Audio extends Component {
 			return null;
 		}
 
-		$url = $match[1];
-
-		// If the URL is root-relative, make it absolute.
-		if ( 0 === strpos( $url, '/' ) ) {
-			$url = site_url( $url );
+		// Ensure the URL is valid.
+		$url = Exporter_Content::format_src_url( $match[1] );
+		if ( empty( $url ) ) {
+			return;
 		}
 
 		$this->register_json(
 			'json',
 			array(
-				'#url#' => $url,
+				'#url#' => esc_url_raw( $url ),
 			)
 	 	);
 	}

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -3,8 +3,9 @@ namespace Apple_Exporter\Components;
 
 require_once __DIR__ . '/../class-markdown.php';
 
-use Apple_Exporter\Parser;
-use Apple_Exporter\Component_Spec;
+use \Apple_Exporter\Component_Spec;
+use \Apple_Exporter\Exporter_Content;
+use \Apple_Exporter\Parser;
 
 /**
  * Base component class. All components must inherit from this class and
@@ -654,28 +655,13 @@ abstract class Component {
 		// Loop through matches, returning the first valid URL found.
 		foreach ( $matches[1] as $url ) {
 
-			// If this is a root-relative path, make absolute.
-			if ( 0 === strpos( $url, '/' ) ) {
-				$url = site_url( $url );
-			}
+			// Run the URL through the formatter.
+			$url = Exporter_Content::format_src_url( $url );
 
-			// Ensure the path begins with http.
-			if ( 0 !== strpos( $url, 'http' ) ) {
-				continue;
+			// If the URL passes validation, return it.
+			if ( ! empty( $url ) ) {
+				return $url;
 			}
-
-			// Escape the URL and ensure it is valid.
-			$url = esc_url_raw( $url );
-			if ( empty( $url ) ) {
-				continue;
-			}
-
-			// Ensure the URL passes filter_var checks.
-			if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
-				continue;
-			}
-
-			return $url;
 		}
 
 		return '';

--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -11,6 +11,7 @@
 
 namespace Apple_Exporter\Components;
 
+use \Apple_Exporter\Exporter_Content;
 use \DOMDocument;
 use \DOMElement;
 
@@ -98,14 +99,15 @@ class Gallery extends Component {
 				continue;
 			}
 
-			// If the URL is root-relative, make it absolute.
-			if ( 0 === strpos( $matches[1], '/' ) ) {
-				$matches[1] = site_url( $matches[1] );
+			// Ensure the URL is valid.
+			$url = Exporter_Content::format_src_url( $matches[1] );
+			if ( empty( $url ) ) {
+				continue;
 			}
 
 			// Start building the item.
 			$content = array(
-				'URL' => $this->maybe_bundle_source( $matches[1] ),
+				'URL' => $this->maybe_bundle_source( esc_url_raw( $url ) ),
 			);
 
 			// Try to add the caption.

--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -98,6 +98,11 @@ class Gallery extends Component {
 				continue;
 			}
 
+			// If the URL is root-relative, make it absolute.
+			if ( 0 === strpos( $matches[1], '/' ) ) {
+				$matches[1] = site_url( $matches[1] );
+			}
+
 			// Start building the item.
 			$content = array(
 				'URL' => $this->maybe_bundle_source( $matches[1] ),

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -20,7 +20,7 @@ class Image extends Component {
 	public static function node_matches( $node ) {
 		// Is this an image node?
 		if (
-		 	( 'img' === $node->nodeName || 'figure' === $node->nodeName )
+		 	( 'img' === (string) $node->nodeName || 'figure' === (string) $node->nodeName )
 			&& self::remote_file_exists( $node )
 		) {
 			return $node;
@@ -89,7 +89,7 @@ class Image extends Component {
 				'margin' => array(
 					'bottom' => 25,
 					'top' => 25,
-				)
+				),
 			)
 		);
 
@@ -128,19 +128,8 @@ class Image extends Component {
 	 */
 	protected function build( $text ) {
 
-		// Negotiate source URL.
-		preg_match( '/src="([^"]*?)"/im', $text, $matches );
-		$url = ( ! empty( $matches[1] ) ) ? $matches[1] : '';
-
-		// Convert root-relative paths to absolute paths.
-		if ( 0 === strpos( $url, '/' ) ) {
-			$url = site_url( $url );
-		}
-
-		// If the URL consists solely of a fragment, remove it.
-		if ( 0 === strpos( $url, '#' ) ) {
-			$url = '';
-		}
+		// Extract the URL from the text.
+		$url = self::url_from_src( $text );
 
 		/**
 		 * Allows for an image src value to be filtered before being applied.
@@ -151,7 +140,6 @@ class Image extends Component {
 		$url = esc_url_raw( apply_filters( 'apple_news_build_image_src', $url, $text ) );
 
 		// If we don't have a valid URL at this point, bail.
-		$url = esc_url_raw( $url );
 		if ( empty( $url ) ) {
 			return;
 		}

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -20,7 +20,7 @@ class Image extends Component {
 	public static function node_matches( $node ) {
 		// Is this an image node?
 		if (
-		 	( 'img' === (string) $node->nodeName || 'figure' === (string) $node->nodeName )
+		 	( 'img' === $node->nodeName || 'figure' === $node->nodeName )
 			&& self::remote_file_exists( $node )
 		) {
 			return $node;

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -278,13 +278,9 @@ class Image extends Component {
 				'#caption_tracking#' => intval( $this->get_setting( 'caption_tracking' ) ) / 100,
 				'#caption_line_height#' => intval( $this->get_setting( 'caption_line_height' ) ),
 				'#caption_color#' => $this->get_setting( 'caption_color' ),
+				'#full_bleed_images#' => ( 'yes' === $this->get_setting( 'full_bleed_images' ) ),
 			)
 		);
-
-		// Add full bleed image option.
-		if ( 'yes' === $this->get_setting( 'full_bleed_images' ) ) {
-			$values['#full_bleed_images#'] = true;
-		}
 
 		return $values;
 	}

--- a/includes/apple-exporter/components/class-video.php
+++ b/includes/apple-exporter/components/class-video.php
@@ -11,6 +11,7 @@
 
 namespace Apple_Exporter\Components;
 
+use \Apple_Exporter\Exporter_Content;
 use \DOMElement;
 
 /**
@@ -69,19 +70,23 @@ class Video extends Component {
 			return;
 		}
 
-		// If the video URL is root-relative, make it absolute.
-		if ( 0 === strpos( $matches[1], '/' ) ) {
-			$matches[1] = site_url( $matches[1] );
+		// Ensure the source URL is valid.
+		$url = Exporter_Content::format_src_url( $matches[1] );
+		if ( empty( $url ) ) {
+			return;
 		}
 
 		// Set values.
 		$values = array(
-			'#url#' => $matches[1],
+			'#url#' => esc_url_raw( $url ),
 		);
 
 		// Add poster frame, if defined.
 		if ( preg_match( '/poster="([^"]+)"/', $html, $poster ) ) {
-			$values['#still_url#'] = $this->maybe_bundle_source( $poster[1] );
+			$still_url = Exporter_Content::format_src_url( $poster[1] );
+			if ( ! empty( $still_url ) ) {
+				$values['#still_url#'] = $this->maybe_bundle_source( $poster[1] );
+			}
 		}
 
 		$this->register_json(

--- a/includes/apple-exporter/components/class-video.php
+++ b/includes/apple-exporter/components/class-video.php
@@ -69,7 +69,12 @@ class Video extends Component {
 			return;
 		}
 
-		// Set values
+		// If the video URL is root-relative, make it absolute.
+		if ( 0 === strpos( $matches[1], '/' ) ) {
+			$matches[1] = site_url( $matches[1] );
+		}
+
+		// Set values.
 		$values = array(
 			'#url#' => $matches[1],
 		);

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -35,6 +35,29 @@ class Image_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Test empty src attribute.
+	 *
+	 * @access public
+	 */
+	public function testEmptySrc() {
+
+		// Setup.
+		$this->settings->set( 'use_remote_images', 'yes' );
+		$workspace = new \Apple_Exporter\Workspace( 1 );
+		$component = new Image(
+			'<img src="" alt="Example" align="left" />',
+			$workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		$result = $component->to_array();
+
+		// Test.
+		$this->assertEmpty( $result );
+	}
+
+	/**
 	 * Test the `apple_news_image_json` filter.
 	 *
 	 * @access public
@@ -69,6 +92,29 @@ class Image_Test extends Component_TestCase {
 			'apple_news_image_json',
 			array( $this, 'filter_apple_news_image_json' )
 		);
+	}
+
+	/**
+	 * Test src attribute that is just a fragment.
+	 *
+	 * @access public
+	 */
+	public function testFragmentSrc() {
+
+		// Setup.
+		$this->settings->set( 'use_remote_images', 'yes' );
+		$workspace = new \Apple_Exporter\Workspace( 1 );
+		$component = new Image(
+			'<img src="#fragment" alt="Example" align="left" />',
+			$workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		$result = $component->to_array();
+
+		// Test.
+		$this->assertEmpty( $result );
 	}
 
 	/**
@@ -126,6 +172,31 @@ class Image_Test extends Component_TestCase {
 		// Test.
 		$this->assertEquals( 'photo', $result['role'] );
 		$this->assertEquals( 'http://someurl.com/filename.jpg', $result['URL'] );
+		$this->assertEquals( 'anchored-image', $result['layout'] );
+	}
+
+	/**
+	 * Test relative src attribute.
+	 *
+	 * @access public
+	 */
+	public function testRelativeSrc() {
+
+		// Setup.
+		$this->settings->set( 'use_remote_images', 'yes' );
+		$workspace = new \Apple_Exporter\Workspace( 1 );
+		$component = new Image(
+			'<img src="/relative/path/to/image.jpg" alt="Example" align="left" />',
+			$workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		$result = $component->to_array();
+
+		// Test.
+		$this->assertEquals( 'photo', $result['role'] );
+		$this->assertEquals( 'http://example.org/relative/path/to/image.jpg', $result['URL'] );
 		$this->assertEquals( 'anchored-image', $result['layout'] );
 	}
 


### PR DESCRIPTION
* Adds support for root-relative URLs for audio, images, and videos.
* Adds additional checks on image sources to ensure they are valid.
* Prevents images from being added with empty URLs.
* Adds test coverage for empty image sources, fragment sources, and root-relative sources for images.

Fixes #316.
Fixes #351.