### PR TITLE
Add a 'full' option to body orientation to use no margin columns

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-formatting.php
+++ b/admin/settings/class-admin-apple-settings-section-formatting.php
@@ -77,8 +77,8 @@ class Admin_Apple_Settings_Section_Formatting extends Admin_Apple_Settings_Secti
 			),
 			'body_orientation' => array(
 				'label' => __( 'Body orientation', 'apple-news' ),
-				'type' => array( 'left', 'center', 'right' ),
-				'description' => __( 'Controls margins on larger screens. Left orientation includes one column of margin on the right, right orientation includes one column of margin on the left, and center orientation includes one column of margin on either side.', 'apple-news' ),
+				'type' => array( 'left', 'center', 'right', 'full' ),
+				'description' => __( 'Controls margins on larger screens. Left orientation includes one column of margin on the right, right orientation includes one column of margin on the left, center orientation includes one column of margin on either side, and full orientation uses no margin columns.', 'apple-news' ),
 			),
 			'body_tracking' => array(
 				'label' => __( 'Body tracking', 'apple-news' ),

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -248,7 +248,7 @@ class Settings {
 	 * @return int The number of columns for the body to span.
 	 */
 	public function body_column_span() {
-		return ( 'center' === $this->body_orientation ) ? 7 : 6;
+		return ( 'center' === $this->body_orientation || 'full' === $this->body_orientation ) ? 7 : 6;
 	}
 
 	/**


### PR DESCRIPTION
I didn't like how center added 2 extra columns to the layout which just seemed like way too much margin on ipad devices. Adds a new 'full' option which keeps the body column span at 7.