### PR TITLE
Fix blank lines causing null text errors when html format is used

### DIFF
--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -58,6 +58,10 @@ class HTML {
 	 * @return string The formatted HTML.
 	 */
 	public function format( $html ) {
-		return wp_kses( $html, $this->_allowed_html );
+		$html = wp_kses( $html, $this->_allowed_html );
+        if($html == '<p> </p>') {
+            $html = '<p>&nbsp; </p>';
+        }
+        return $html;
 	}
 }


### PR DESCRIPTION
Having blank lines in the post content made apple news throw an error about text field being null. This was basically true because blank lines created an component with no real content. This fixes it by adding an &nbsp; which still keeps the blank line in the content.