### PR TITLE
Hotfixes for urgent issues

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -154,11 +154,8 @@ class Push extends API_Action {
 		// Process errors
 		$this->process_errors( $errors );
 
-		// Validate the data before using since it's filterable.
-		// JSON should just be a string.
-		// Apple News format is complex and has too many options to validate otherwise.
-		// Let's just make sure it's not doing anything bad and is the right data type.
-		$json = sanitize_text_field( $json );
+		// Sanitize the data before using since it's filterable.
+		$json = $this->sanitize_json( $json );
 
 		// Bundles should be an array of URLs
 		if ( ! empty( $bundles ) && is_array( $bundles ) ) {
@@ -385,5 +382,24 @@ class Push extends API_Action {
 		$this->exporter->generate();
 
 		return array( $this->exporter->get_json(), $this->exporter->get_bundles(), $this->exporter->get_errors() );
+	}
+
+	/**
+	 * Sanitize the JSON output based on whether HTML or markdown is used.
+	 *
+	 * @access private
+	 * @param string $json
+	 * @return string
+	 * @since 1.2.7
+	 */
+	private function sanitize_json( $json ) {
+		// Apple News format is complex and has too many options to validate otherwise.
+		// Let's just make sure the JSON is valid
+		$decoded = json_decode( $json );
+		if ( ! $decoded ) {
+			 throw new \Apple_Actions\Action_Exception( __( 'The Apple News JSON is invalid and cannot be published.', 'apple-news' ) );
+		} else {
+			 return wp_json_encode( $decoded );
+		}
 	}
 }

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -693,7 +693,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function validate_data( $data ) {
 		$settings = new \Apple_Exporter\Settings();
-		$valid_settings = array_keys( $settings->all() );
+		$default_settings = $settings->all();
 		$clean_settings = array();
 
 		// Check for the theme name
@@ -718,10 +718,17 @@ class Admin_Apple_Themes extends Apple_News {
 		// the appropriate validation and sanitization for each
 		foreach ( $valid_settings as $setting ) {
 			if ( ! isset( $data[ $setting ] ) ) {
-				return sprintf(
-					__( 'The theme was missing the required setting %s', 'apple-news' ),
-					$setting
-				);
+				// Get the default value instead.
+				// This ensures backwards compatiblity with theme files
+				// when new settings are added in future plugin versions.
+				if ( isset( $default_settings[ $setting ] ) ) {
+					$data[ $setting ] = $default_settings[ $setting ];
+				} else {
+					return sprintf(
+						__( 'The theme was missing the required setting %s and no default was found', 'apple-news' ),
+						$setting
+					);
+				}
 			}
 
 			// Find the appropriate sanitization method for each setting

--- a/apple-news.php
+++ b/apple-news.php
@@ -12,7 +12,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     1.2.6
+ * Version:     1.2.7
  * Author:      Alley Interactive
  * Author URI:  https://www.alleyinteractive.com
  * Text Domain: apple-news

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -144,6 +144,38 @@ abstract class Component {
 	public $specs;
 
 	/**
+	 * Allowed HTML tags for components that support it.
+	 *
+	 * @since 1.2.7
+	 * @var array
+	 * @access public
+	 */
+	public $allowed_html = array(
+		'p' => array(),
+		'strong' => array(),
+		'b' => array(),
+		'em' => array(),
+		'i' => array(),
+		'a' => array(
+			'href' => array(),
+		),
+		'ul' => array(),
+		'ol' => array(),
+		'li' => array(),
+		'br' => array(),
+		'sub' => array(),
+		'sup' => array(),
+		'del' => array(),
+		's' => array(),
+		'pre' => array(),
+		'code' => array(),
+		'samp' => array(),
+		'footer' => array(),
+		'aside' => array(),
+		'blockquote' => array(),
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $text
@@ -233,6 +265,11 @@ abstract class Component {
 	 * @access public
 	 */
 	public function to_array() {
+		// If HTML support is enabled, provide an extra level of validation for supported tags.
+		if ( ! empty( $this->json['text'] ) && $this->html_enabled() ) {
+			$this->json['text'] = wp_kses( $this->json['text'], $this->allowed_html );
+		}
+
 		return apply_filters( 'apple_news_' . $this->get_component_name() . '_json', $this->json );
 	}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '1.2.6';
+	public static $version = '1.2.7';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: potatomaster, kevinfodness, alleyinteractive, beezwaxbuzz, gosukiw
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 4.0
-Tested up to: 4.7.3
-Stable tag: 1.2.6
+Tested up to: 4.7.4
+Stable tag: 1.2.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -44,6 +44,10 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 1.2.7 =
+* Fixed a bug where HTML tags were being stripped before being sent to the API.
+* Fixed a bug where older theme files couldn't be imported if new formatting settings were added.
 
 = 1.2.6 =
 * WP Standards: Ensured all instances of in_array use the strict parameter


### PR DESCRIPTION
Fixes #352 where HTML tags are being stripped when pushed to the API.

Fixes #362 to ensure backwards compatibility with older theme files when new formatting settings are added.