### PR TITLE
AN-78 Adds a button to load example themes on demand

### DIFF
--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -181,6 +181,10 @@ class Admin_Apple_Themes extends Apple_News {
 				'callback' => array( $this, '_set_theme' ),
 				'nonce' => 'apple_news_themes',
 			),
+			'apple_news_load_example_themes' => array(
+				'callback' => array( $this, 'load_example_themes' ),
+				'nonce' => 'apple_news_themes',
+			),
 		);
 
 		add_action( 'admin_menu', array( $this, 'setup_theme_pages' ), 99 );

--- a/admin/partials/page_themes.php
+++ b/admin/partials/page_themes.php
@@ -2,6 +2,8 @@
 <div class="wrap apple-news-themes">
 	<h1 id="apple_news_themes_title"><?php esc_html_e( 'Manage Themes', 'apple-news' ) ?></h1>
 
+	<p><?php esc_html_e( 'As of version 1.3.0, a number of example themes are available. These example themes come bundled with a fresh installation of the plugin. To add them to an existing installation, or to restore them if they have been deleted, use the Load Example Themes button below.', 'apple-news' ); ?></p>
+
 	<form method="post" action="" id="apple-news-themes-form" enctype="multipart/form-data">
 		<?php wp_nonce_field( 'apple_news_themes' ); ?>
 		<input type="hidden" id="apple_news_action" name="action" value="apple_news_set_theme" />
@@ -12,6 +14,12 @@
 			__( 'Import Theme', 'apple-news' ),
 			'secondary',
 			'apple_news_start_import',
+			false
+		); ?>
+		<?php submit_button(
+			__( 'Load Example Themes', 'apple-news' ),
+			'secondary',
+			'apple_news_load_example_themes',
 			false
 		); ?>
 

--- a/assets/js/themes.js
+++ b/assets/js/themes.js
@@ -6,6 +6,11 @@
 			appleNewsThemesSubmit( $( this ), 'apple_news_create_theme' );
 		});
 
+		$( '#apple_news_load_example_themes' ).on( 'click', function( e ) {
+			e.preventDefault();
+			appleNewsThemesSubmit( $( this ), 'apple_news_load_example_themes' );
+		});
+
 		$( '#apple_news_start_import' ).on( 'click', function( e ) {
 			e.preventDefault();
 			$( '.apple-news-theme-form' ).hide();

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -301,36 +301,7 @@ class Apple_News {
 		$theme->set_active();
 
 		// Load the example themes, if they do not exist.
-		$example_themes = array(
-			'classic' => __( 'Classic', 'apple-news' ),
-			'colorful' => __( 'Colorful', 'apple-news' ),
-			'dark' => __( 'Dark', 'apple-news' ),
-			'modern' => __( 'Modern', 'apple-news' ),
-			'pastel' => __( 'Pastel', 'apple-news' ),
-		);
-		foreach ( $example_themes as $slug => $name ) {
-
-			// Determine if the theme already exists.
-			$theme = new \Apple_Exporter\Theme;
-			$theme->set_name( $name );
-			if ( $theme->load() ) {
-				continue;
-			}
-
-			// Load the theme data from the JSON configuration file.
-			$filename = dirname( __DIR__ ) . '/assets/themes/' . $slug . '.json';
-			$options = json_decode( file_get_contents( $filename ), true );
-
-			// Negotiate screenshot URL.
-			$options['screenshot_url'] = plugins_url(
-				'/assets/screenshots/' . $slug . '.png',
-				__DIR__
-			);
-
-			// Save the theme.
-			$theme->load( $options );
-			$theme->save();
-		}
+		$this->load_example_themes();
 	}
 
 	/**
@@ -652,6 +623,48 @@ class Apple_News {
 
 		// Remove all formatting settings from the primary settings array.
 		$this->remove_global_formatting_settings();
+	}
+
+	/**
+	 * Load example themes into the theme list.
+	 *
+	 * @access protected
+	 */
+	protected function load_example_themes() {
+
+		// Set configuration for example themes.
+		$example_themes = array(
+			'classic' => __( 'Classic', 'apple-news' ),
+			'colorful' => __( 'Colorful', 'apple-news' ),
+			'dark' => __( 'Dark', 'apple-news' ),
+			'modern' => __( 'Modern', 'apple-news' ),
+			'pastel' => __( 'Pastel', 'apple-news' ),
+		);
+
+		// Loop over example theme configuration and load each.
+		foreach ( $example_themes as $slug => $name ) {
+
+			// Determine if the theme already exists.
+			$theme = new \Apple_Exporter\Theme;
+			$theme->set_name( $name );
+			if ( $theme->load() ) {
+				continue;
+			}
+
+			// Load the theme data from the JSON configuration file.
+			$filename = dirname( __DIR__ ) . '/assets/themes/' . $slug . '.json';
+			$options = wp_json_decode( file_get_contents( $filename ), true );
+
+			// Negotiate screenshot URL.
+			$options['screenshot_url'] = plugins_url(
+				'/assets/screenshots/' . $slug . '.png',
+				__DIR__
+			);
+
+			// Save the theme.
+			$theme->load( $options );
+			$theme->save();
+		}
 	}
 
 	/**

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -653,7 +653,7 @@ class Apple_News {
 
 			// Load the theme data from the JSON configuration file.
 			$filename = dirname( __DIR__ ) . '/assets/themes/' . $slug . '.json';
-			$options = wp_json_decode( file_get_contents( $filename ), true );
+			$options = json_decode( file_get_contents( $filename ), true );
 
 			// Negotiate screenshot URL.
 			$options['screenshot_url'] = plugins_url(


### PR DESCRIPTION
* Moves the example theme load functionality to a standalone function.
* Adds a button to load example themes on the Themes page.
* Adds descriptive text about the new example themes to the Themes page.