### PR TITLE
AN-78 Adds sort to theme registry

### DIFF
--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -424,7 +424,7 @@ class Theme {
 			return array();
 		}
 
-		return $registry;
+		return self::_sort_registry( $registry );
 	}
 
 	/**
@@ -496,6 +496,29 @@ class Theme {
 	 */
 	public static function theme_key( $name ) {
 		return 'apple_news_theme_' . md5( $name );
+	}
+
+	/**
+	 * Sorts a registry array, ensuring that the active theme is first.
+	 *
+	 * @param array $registry The registry to sort.
+	 *
+	 * @return array The sorted registry array.
+	 */
+	private static function _sort_registry( $registry ) {
+
+		// Sort the regsitry.
+		sort( $registry );
+
+		// Ensure the active theme is first.
+		$active_theme = self::get_active_theme_name();
+		$active_theme_key = array_search( $active_theme, $registry, true );
+		if ( ! empty( $active_theme_key ) ) {
+			unset( $registry[ $active_theme_key ] );
+			array_unshift( $registry, $active_theme );
+		}
+
+		return $registry;
 	}
 
 	/**
@@ -1059,6 +1082,9 @@ class Theme {
 
 		// Add the theme from the registry.
 		$registry[] = $name;
+
+		// Sort the registry.
+		$registry = self::_sort_registry( $registry );
 
 		// Update the registry.
 		update_option( self::INDEX_KEY, $registry, false );
@@ -1775,6 +1801,9 @@ class Theme {
 
 		// Remove the theme from the registry.
 		unset( $registry[ $key ] );
+
+		// Sort the registry.
+		$registry = self::_sort_registry( $registry );
 
 		// Update the registry.
 		update_option( self::INDEX_KEY, $registry, false );

--- a/tests/apple-exporter/test-class-theme.php
+++ b/tests/apple-exporter/test-class-theme.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Publish to Apple News Tests: Theme_Test class
+ *
+ * Contains a class to test the functionality of the Apple_Exporter\Theme class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+use Apple_Exporter\Theme;
+
+/**
+ * A class used to test the functionality of the Apple_Exporter\Theme class.
+ *
+ * @since 1.3.0
+ */
+class Theme_Test extends WP_UnitTestCase {
+
+	/**
+	 * Tests the functionality of the get_registry function.
+	 *
+	 * @see Apple_Exporter\Theme::get_registry()
+	 *
+	 * @access public
+	 */
+	public function testGetRegistry() {
+
+		// Setup.
+		update_option(
+			Theme::INDEX_KEY,
+			array( 'Theme 3', 'Theme 2', 'Theme 1' ),
+			false
+		);
+		update_option( Theme::ACTIVE_KEY, 'Theme 2', false );
+
+		// Ensure the get_registry function returns in sorted order with active 1st.
+		$this->assertSame(
+			array( 'Theme 2', 'Theme 1', 'Theme 3' ),
+			Theme::get_registry()
+		);
+	}
+}


### PR DESCRIPTION
* Sorts theme registry when retrieved, added to, or removed from.
* Ensures the active theme is first, followed by the rest of the themes in alphabetical order.
* Adds test coverage for retrieving a sorted theme list.