### PR TITLE
AN-17 Add support for HTML in titles

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -205,7 +205,7 @@ class Exporter {
 			'version'    => '1.1',
 			'identifier' => 'post-' . $this->content_id(),
 			'language'   => 'en',
-			'title'      => $this->content_title(),
+			'title'      => wp_strip_all_tags( $this->content_title() ),
 		);
 
 		// Builders

--- a/includes/apple-exporter/components/class-title.php
+++ b/includes/apple-exporter/components/class-title.php
@@ -15,6 +15,7 @@ class Title extends Component {
 			array(
 				'role' => 'title',
 				'text' => '#text#',
+				'format' => 'html',
 			)
 		);
 

--- a/tests/apple-exporter/components/test-class-title.php
+++ b/tests/apple-exporter/components/test-class-title.php
@@ -14,6 +14,7 @@ class Title_Test extends Component_TestCase {
 			array(
 				'role' => 'title',
 				'text' => 'Example Title',
+				'format' => 'html',
 				'textStyle' => 'default-title',
 				'layout' => 'title-layout',
 		 	),
@@ -34,6 +35,7 @@ class Title_Test extends Component_TestCase {
 			array(
 				'role' => 'title',
 				'text' => 'Example Title',
+				'format' => 'html',
 				'textStyle' => 'fancy-title',
 				'layout' => 'title-layout',
 		 	),


### PR DESCRIPTION
* Explicitly sets the format for the title component to HTML to support HTML in titles.
* Adds wp_strip_all_tags to the main document title to remove any HTML tags that may have been added.
* Adjusts unit tests accordingly.

Addresses https://wordpress.org/support/topic/solution-apple-news-formatting-problems-with-exposed-html/.