### PR TITLE
Using class variables rather than using function parameters directly

### DIFF
--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -34,15 +34,15 @@ class Admin_Apple_Post_Sync {
 		}
 
 		// Register update hook if needed.
-		if ( 'yes' === $settings->get( 'api_autosync' )
-			|| 'yes' === $settings->get( 'api_autosync_update' )
+		if ( 'yes' === $this->settings->get( 'api_autosync' )
+			|| 'yes' === $this->settings->get( 'api_autosync_update' )
 		) {
 			// This needs to happen after meta boxes save.
 			add_action( 'save_post', array( $this, 'do_publish' ), 99, 2 );
 		}
 
 		// Register delete hook if needed.
-		if ( 'yes' === $settings->get( 'api_autosync_delete' ) ) {
+		if ( 'yes' === $this->settings->get( 'api_autosync_delete' ) ) {
 			add_action( 'before_delete_post', array( $this, 'do_delete' ) );
 		}
 	}


### PR DESCRIPTION
This PR fixing the issue: https://github.com/alleyinteractive/apple-news/issues/409

In `Admin_Apple_Post_Sync` constructor, we are setting the [$settings](https://github.com/alleyinteractive/apple-news/blob/master/admin/class-admin-apple-post-sync.php#L20) variable with the instance of class `Admin_Apple_Settings`, if the constructor not getting the valid parameter.

But that variable not been used on the followed lines [here](https://github.com/alleyinteractive/apple-news/blob/master/admin/class-admin-apple-post-sync.php#L37), instead we are using the function parameter directly. 