### PR TITLE
AN-90 Make component HTML support sensitive to global setting

### DIFF
--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -238,11 +238,13 @@ class Body extends Component {
 	/**
 	 * Whether HTML format is enabled for this component type.
 	 *
+	 * @param bool $enabled Optional. Whether to enable HTML support for this component. Defaults to true.
+	 *
 	 * @access protected
 	 * @return bool Whether HTML format is enabled for this component type.
 	 */
-	protected function html_enabled() {
-		return true;
+	protected function html_enabled( $enabled = true ) {
+		return parent::html_enabled( $enabled );
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -420,13 +420,23 @@ abstract class Component {
 	/**
 	 * Whether HTML format is enabled for this component type.
 	 *
-	 * This function is intended to be overridden in child classes.
+	 * This function is intended to be overridden in child classes, but to call
+	 * this parent function with the value it intends to set. This function
+	 * will use the provided value if HTML support is enabled via settings.
+	 *
+	 * @param bool $enabled Optional. Whether to enable HTML for this component. Defaults to false.
 	 *
 	 * @access protected
 	 * @return bool Whether HTML format is enabled for this component type.
 	 */
-	protected function html_enabled() {
-		return false;
+	protected function html_enabled( $enabled = false ) {
+		if ( empty( $this->settings->html_support )
+			|| 'yes' !== $this->settings->html_support
+		) {
+			return false;
+		}
+
+		return $enabled;
 	}
 
 	/**

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -107,6 +107,36 @@ HTML;
 		);
 	}
 
+
+	/**
+	 * Tests the transformation process for an HTML entity (e.g., &amp;).
+	 *
+	 * @access public
+	 */
+	public function testTransformHtmlEntities() {
+
+		// Setup.
+		$body_component = new Body(
+			'<p>my &amp; text</p>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test.
+		$this->assertEquals(
+			array(
+				'text' => "my & text\n\n",
+				'role' => 'body',
+				'format' => 'markdown',
+				'textStyle' => 'dropcapBodyStyle',
+				'layout' => 'body-layout',
+			),
+			$body_component->to_array()
+		);
+	}
+
 	/**
 	 * Tests transformation of lists with nested images.
 	 *


### PR DESCRIPTION
* Only allow components to support HTML if HTML support is turned on globally in the settings.