### PR TITLE
AN-85 Fix bug where empty text in headings triggers an error

### DIFF
--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -137,11 +137,17 @@ class Heading extends Component {
 		// textStyle in headings.
 		$text = wp_strip_all_tags( $matches[2] );
 
+		// Parse and trim the resultant text, and if there is nothing left, bail.
+		$text = trim( $this->parser->parse( $text ) );
+		if ( empty( $text ) ) {
+			return;
+		}
+
 		$this->register_json(
 			'json',
 			array(
 				'#heading_level#' => 'heading' . $level,
-				'#text#' => trim( $this->parser->parse( $text ) ),
+				'#text#' => $text,
 				'#format#' => $this->parser->format,
 			)
 	 	);

--- a/tests/apple-exporter/components/test-class-heading.php
+++ b/tests/apple-exporter/components/test-class-heading.php
@@ -65,6 +65,38 @@ class Heading_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Tests image splitting where the image is wrapped in a link.
+	 *
+	 * @access public
+	 */
+	public function testImageSplittingWithLink() {
+
+		// Setup.
+		$content = <<<HTML
+<h2><a href="https://www.google.com/"><img src="/example-image.jpg" /></a></h2>
+HTML;
+		$file = dirname( dirname( __DIR__ ) ) . '/data/test-image.jpg';
+		$cover = $this->factory->attachment->create_upload_object( $file );
+		$content = new Exporter_Content( 3, 'Title', $content, null, $cover );
+
+		// Run the export.
+		$exporter = new Exporter( $content, null, $this->settings );
+		$json = $exporter->export();
+		$this->ensure_tokens_replaced( $json );
+		$json = json_decode( $json, true );
+
+		// Validate image split in generated JSON.
+		$this->assertEquals(
+			array(
+				'role'   => 'photo',
+				'URL'    => 'bundle://example-image.jpg',
+				'layout' => 'full-width-image',
+			),
+			$json['components'][1]['components'][1]
+		);
+	}
+
+	/**
 	 * Ensures that headings are not produced from paragraphs.
 	 *
 	 * @access public


### PR DESCRIPTION
* Fixes a bug whereby an image wrapped in a link wrapped in a heading tag triggers an empty text node for the heading, which causes an error when publishing to Apple News.
* Adds a test case to validate the fix.

Fixes #320.