### PR TITLE
AN-91 Prevent empty text nodes from being added

### DIFF
--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -62,6 +62,14 @@ class HTML {
 		// Strip out all tags and attributes other than what is allowed.
 		$html = wp_kses( $html, $this->_allowed_html );
 
+		// Replace non-breaking spaces with regular spaces.
+		$html = str_ireplace( '&nbsp;', ' ', $html );
+		$html = str_replace( '&#160;', ' ', $html );
+		$html = str_replace( chr( 160 ), ' ', $html );
+
+		// Replace the "null" character with a blank string.
+		$html = str_replace( chr( 194 ), '', $html );
+
 		// Remove any empty tags.
 		$html = preg_replace( '/<([a-z0-9]+)[^>]*>\s*<\/\1>/', '', $html );
 

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -58,6 +58,13 @@ class HTML {
 	 * @return string The formatted HTML.
 	 */
 	public function format( $html ) {
-		return wp_kses( $html, $this->_allowed_html );
+
+		// Strip out all tags and attributes other than what is allowed.
+		$html = wp_kses( $html, $this->_allowed_html );
+
+		// Remove any empty tags.
+		$html = preg_replace( '/<([a-z0-9]+)[^>]*>\s*<\/\1>/', '', $html );
+
+		return $html;
 	}
 }

--- a/includes/apple-exporter/class-markdown.php
+++ b/includes/apple-exporter/class-markdown.php
@@ -112,8 +112,9 @@ class Markdown {
 	private function _parse_node_emphasis( $node ) {
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 
@@ -131,8 +132,9 @@ class Markdown {
 	private function _parse_node_heading( $node ) {
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 
@@ -169,7 +171,8 @@ class Markdown {
 		$url = apply_filters( 'apple_news_markdown_hyperlink', $url );
 
 		// If there is no URL or no text, do not add the link.
-		if ( empty( $url ) || empty( trim( $text ) ) ) {
+		$check = trim( $text );
+		if ( empty( $url ) || empty( $check ) ) {
 			return '';
 		}
 
@@ -187,8 +190,9 @@ class Markdown {
 	private function _parse_node_list_item( $node ) {
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 
@@ -217,8 +221,9 @@ class Markdown {
 		$this->_list_index = 1;
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 
@@ -236,8 +241,9 @@ class Markdown {
 	private function _parse_node_paragraph( $node ) {
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 
@@ -255,8 +261,9 @@ class Markdown {
 	private function _parse_node_strong( $node ) {
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 
@@ -287,8 +294,9 @@ class Markdown {
 		$this->_list_mode = 'ul';
 
 		// If there is no text for this node, bail.
-		$text = $this->parse_nodes( $node->childNodes );
-		if ( empty( trim( $text ) ) ) {
+		$text  = $this->parse_nodes( $node->childNodes );
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return '';
 		}
 

--- a/includes/apple-exporter/class-markdown.php
+++ b/includes/apple-exporter/class-markdown.php
@@ -110,7 +110,14 @@ class Markdown {
 	 * @return string The processed node, converted to a string.
 	 */
 	private function _parse_node_emphasis( $node ) {
-		return '_' . $this->parse_nodes( $node->childNodes ) . '_';
+
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
+		return '_' . $text . '_';
 	}
 
 	/**
@@ -122,10 +129,17 @@ class Markdown {
 	 * @return string The processed node, converted to a string.
 	 */
 	private function _parse_node_heading( $node ) {
+
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
 		return sprintf(
 			'%s %s' . "\n",
 			str_repeat( '#', intval( substr( $node->nodeName, 1, 1 ) ) ),
-			$this->parse_nodes( $node->childNodes )
+			$text
 		);
 	}
 
@@ -142,6 +156,9 @@ class Markdown {
 		// Set the URL from the HREF parameter on the tag.
 		$url = $node->getAttribute( 'href' );
 
+		// Set the text from the content of the child nodes.
+		$text = $this->parse_nodes( $node->childNodes );
+
 		/**
 		 * Allows for filtering of the formatted content before return.
 		 *
@@ -151,15 +168,12 @@ class Markdown {
 		 */
 		$url = apply_filters( 'apple_news_markdown_hyperlink', $url );
 
-		if ( empty( $url ) ) {
-			return;
+		// If there is no URL or no text, do not add the link.
+		if ( empty( $url ) || empty( trim( $text ) ) ) {
+			return '';
 		}
 
-		return sprintf(
-			'[%s](%s)',
-			$this->parse_nodes( $node->childNodes ),
-			esc_url_raw( $url )
-		);
+		return sprintf( '[%s](%s)', $text, esc_url_raw( $url ) );
 	}
 
 	/**
@@ -172,16 +186,22 @@ class Markdown {
 	 */
 	private function _parse_node_list_item( $node ) {
 
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
 		// Fork for ordered list items.
 		if ( 'ol' === $this->_list_mode ) {
 			return sprintf(
 				'%d. %s',
 				$this->_list_index ++,
-			    $this->parse_nodes( $node->childNodes )
+			    $text
 			);
 		}
 
-		return '- ' . $this->parse_nodes( $node->childNodes );
+		return '- ' . $text;
 	}
 
 	/**
@@ -196,7 +216,13 @@ class Markdown {
 		$this->_list_mode = 'ol';
 		$this->_list_index = 1;
 
-		return $this->parse_nodes( $node->childNodes ) . "\n\n";
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
+		return $text . "\n\n";
 	}
 
 	/**
@@ -208,7 +234,14 @@ class Markdown {
 	 * @return string The processed node, converted to a string.
 	 */
 	private function _parse_node_paragraph( $node ) {
-		return $this->parse_nodes( $node->childNodes ) . "\n\n";
+
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
+		return $text . "\n\n";
 	}
 
 	/**
@@ -220,7 +253,14 @@ class Markdown {
 	 * @return string The processed node, converted to a string.
 	 */
 	private function _parse_node_strong( $node ) {
-		return '**' . $this->parse_nodes( $node->childNodes ) . '**';
+
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
+		return '**' . $text . '**';
 	}
 
 	/**
@@ -246,6 +286,12 @@ class Markdown {
 	private function _parse_node_unordered_list( $node ) {
 		$this->_list_mode = 'ul';
 
-		return $this->parse_nodes( $node->childNodes ) . "\n\n";
+		// If there is no text for this node, bail.
+		$text = $this->parse_nodes( $node->childNodes );
+		if ( empty( trim( $text ) ) ) {
+			return '';
+		}
+
+		return $text . "\n\n";
 	}
 }

--- a/includes/apple-exporter/class-parser.php
+++ b/includes/apple-exporter/class-parser.php
@@ -201,6 +201,10 @@ class Parser {
 			}
 		}
 
+		// Make nonbreaking spaces actual spaces.
+		$html = str_ireplace( '&nbsp;', ' ', $html );
+		$html = str_replace( '&#160;', ' ', $html );
+
 		// Return the clean HTML.
 		return $html;
 	}

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -216,7 +216,8 @@ class Body extends Component {
 
 		// If there is no text for this element, bail.
 		$text = $this->parser->parse( $text );
-		if ( empty( trim( $text ) ) ) {
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -213,10 +213,18 @@ class Body extends Component {
 	 * @access protected
 	 */
 	protected function build( $text ) {
+
+		// If there is no text for this element, bail.
+		$text = $this->parser->parse( $text );
+		if ( empty( trim( $text ) ) ) {
+			return;
+		}
+
+		// Add the JSON for this component.
 		$this->register_json(
 			'json',
 			array(
-				'#text#' => $this->parser->parse( $text ),
+				'#text#' => $text,
 				'#format#' => $this->parser->format,
 			)
 	 	);
@@ -397,13 +405,14 @@ class Body extends Component {
 	 * @return array
 	 */
 	public function to_array() {
-		$sanitized_text = sanitize_text_field( $this->json['text'] );
 
+		// If the text content evaluates to empty, just return an empty array.
+		$sanitized_text = sanitize_text_field( $this->json['text'] );
 		if ( empty( $sanitized_text ) ) {
-			return new \WP_Error( 'invalid', __( 'empty body component', 'apple-news' ) );
-		} else {
-			return parent::to_array();
+			return array();
 		}
+
+		return parent::to_array();
 	}
 }
 

--- a/includes/apple-exporter/components/class-byline.php
+++ b/includes/apple-exporter/components/class-byline.php
@@ -57,12 +57,18 @@ class Byline extends Component {
 	 * @access protected
 	 */
 	protected function build( $text ) {
+
+		// If there is no text for this element, bail.
+		if ( empty( trim( $text ) ) ) {
+			return;
+		}
+
 		$this->register_json(
 			'json',
 			array(
 				'#text#' => $text,
 			)
-	 	);
+		);
 
 		$this->set_default_style();
 		$this->set_default_layout();

--- a/includes/apple-exporter/components/class-byline.php
+++ b/includes/apple-exporter/components/class-byline.php
@@ -59,7 +59,8 @@ class Byline extends Component {
 	protected function build( $text ) {
 
 		// If there is no text for this element, bail.
-		if ( empty( trim( $text ) ) ) {
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -73,12 +73,19 @@ class Cover extends Component {
 	 * @access protected
 	 */
 	protected function build( $url ) {
+
+		// If we can't get a valid URL, bail.
+		$url = $this->maybe_bundle_source( $url );
+		if ( empty( trim( $url ) ) ) {
+			return;
+		}
+
 		$this->register_json(
 			'json',
 			array(
-				'#url#' => $this->maybe_bundle_source( $url ),
+				'#url#' => $url,
 			)
-	 	);
+		);
 
 		$this->set_default_layout();
 	}

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -76,7 +76,8 @@ class Cover extends Component {
 
 		// If we can't get a valid URL, bail.
 		$url = $this->maybe_bundle_source( $url );
-		if ( empty( trim( $url ) ) ) {
+		$check = trim( $url );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -105,7 +105,8 @@ class Facebook extends Component {
 
 		// Try to get Facebook URL.
 		$url = self::_get_facebook_url( strip_tags( $html ) );
-		if ( empty( trim( $url ) ) ) {
+		$check = trim( $url );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -103,10 +103,16 @@ class Facebook extends Component {
 			$html = $data_href[1];
 		}
 
+		// Try to get Facebook URL.
+		$url = self::_get_facebook_url( strip_tags( $html ) );
+		if ( empty( trim( $url ) ) ) {
+			return;
+		}
+
 		$this->register_json(
 			'json',
 			array(
-				'#url#' => self::_get_facebook_url( strip_tags( $html ) ),
+				'#url#' => $url,
 			)
 		);
 	}

--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -132,6 +132,11 @@ class Gallery extends Component {
 			$items[] = $content;
 		}
 
+		// Ensure we got items.
+		if ( empty( $items ) ) {
+			return;
+		}
+
 		// Build the JSON
 		$this->register_json(
 			'json',
@@ -139,7 +144,7 @@ class Gallery extends Component {
 				'#gallery_type#' => $theme->get_value( 'gallery_type' ),
 				'#items#' => $items,
 			)
-	 	);
+		);
 
 		// Set the layout.
 		$this->set_layout();

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -150,7 +150,7 @@ class Heading extends Component {
 				'#text#' => $text,
 				'#format#' => $this->parser->format,
 			)
-	 	);
+		);
 
 		$this->set_style( $level );
 		$this->set_layout();

--- a/includes/apple-exporter/components/class-instagram.php
+++ b/includes/apple-exporter/components/class-instagram.php
@@ -85,10 +85,9 @@ class Instagram extends Component {
 		$this->register_json(
 			'json',
 			array(
-				// Remove `www.` from URL as AN parser doesn't allow for it.
 				'#url#' => esc_url_raw( $url ),
 			)
-	 	);
+		);
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-intro.php
+++ b/includes/apple-exporter/components/class-intro.php
@@ -45,7 +45,8 @@ class Intro extends Component {
 	protected function build( $text ) {
 
 		// If there is no text for this element, bail.
-		if ( empty( trim( $text ) ) ) {
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-intro.php
+++ b/includes/apple-exporter/components/class-intro.php
@@ -43,12 +43,18 @@ class Intro extends Component {
 	 * @access protected
 	 */
 	protected function build( $text ) {
+
+		// If there is no text for this element, bail.
+		if ( empty( trim( $text ) ) ) {
+			return;
+		}
+
 		$this->register_json(
 			'json',
 			array(
 				'#text#' => $text . "\n",
 			)
-	 	);
+		);
 
 		$this->set_style();
 	}

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -237,6 +237,11 @@ class Quote extends Component {
 		preg_match( '#<blockquote.*?>(.*?)</blockquote>#si', $html, $matches );
 		$text = $matches[1];
 
+		// If there is no text for this element, bail.
+		if ( empty( trim( $text ) ) ) {
+			return;
+		}
+
 		// Split for pullquote vs. blockquote.
 		if ( 0 === strpos( $html, '<blockquote class="apple-news-pullquote">' ) ) {
 			$this->_build_pullquote( $text );

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -238,7 +238,8 @@ class Quote extends Component {
 		$text = $matches[1];
 
 		// If there is no text for this element, bail.
-		if ( empty( trim( $text ) ) ) {
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-title.php
+++ b/includes/apple-exporter/components/class-title.php
@@ -51,12 +51,18 @@ class Title extends Component {
 	 * @access protected
 	 */
 	protected function build( $text ) {
+
+		// If there is no text for this element, bail.
+		if ( empty( trim( $text ) ) ) {
+			return;
+		}
+
 		$this->register_json(
 			'json',
 			array(
 				'#text#' => $text,
 			)
-		 );
+		);
 
 		$this->set_style();
 		$this->set_layout();

--- a/includes/apple-exporter/components/class-title.php
+++ b/includes/apple-exporter/components/class-title.php
@@ -53,7 +53,8 @@ class Title extends Component {
 	protected function build( $text ) {
 
 		// If there is no text for this element, bail.
-		if ( empty( trim( $text ) ) ) {
+		$check = trim( $text );
+		if ( empty( $check ) ) {
 			return;
 		}
 

--- a/includes/apple-exporter/components/class-tweet.php
+++ b/includes/apple-exporter/components/class-tweet.php
@@ -63,7 +63,7 @@ class Tweet extends Component {
 	 * @access protected
 	 */
 	protected function build( $text ) {
-		// Find tweeter URL in HTML string
+		// Find Twitter URL in HTML string.
 		if ( ! preg_match_all( '/https?:\/\/(?:www\.)?twitter.com\/(?:#!\/)?([^\/]*)\/status(?:es)?\/(\d+)/', $text, $matches, PREG_SET_ORDER ) ) {
 			return null;
 		}

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -46,6 +46,30 @@ class Body_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Tests handling for empty content.
+	 *
+	 * @access public
+	 */
+	public function testEmptyContent() {
+
+		// Setup.
+		$html = '<p><a href="https://www.apple.com/">&nbsp;</a></p>';
+		$component = new Body(
+			$html,
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test.
+		$this->assertEquals(
+			array(),
+			$component->to_array()
+		);
+	}
+
+	/**
 	 * Test the `apple_news_body_json` filter.
 	 *
 	 * @access public
@@ -178,7 +202,6 @@ HTML;
 			$component->to_array()
 		);
 	}
-
 
 	/**
 	 * Tests the transformation process for an HTML entity (e.g., &amp;).

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -70,6 +70,40 @@ class Body_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Tests handling for empty HTML content.
+	 *
+	 * @access public
+	 */
+	public function testEmptyHTMLContent() {
+
+		// Setup.
+		$this->settings->html_support = 'yes';
+		$html = '<p>a</p><p>&nbsp;</p><p>b</p>';
+		$component = new Body(
+			$html,
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test.
+		$this->assertEquals(
+			array(
+				'role'      => 'body',
+				'text'      => '<p>a</p><p>b</p>',
+				'format'    => 'html',
+				'textStyle' => 'dropcapBodyStyle',
+				'layout'    => 'body-layout',
+			),
+			$component->to_array()
+		);
+
+		// Teardown.
+		$this->settings->html_support = 'no';
+	}
+
+	/**
 	 * Test the `apple_news_body_json` filter.
 	 *
 	 * @access public


### PR DESCRIPTION
* Add sanity checks to components to prevent empty text nodes from registering JSON.
* Add filter to the HTML parser to remove empty tags.
* Add sanity checks to the Markdown parser to not add empty text.
* Add handling for nonbreaking spaces.
* Add tests for empty content handling.

Fixes #365