### PR TITLE
AN-129 Add collapse/expand functionality to preview pane

### DIFF
--- a/assets/css/preview.css
+++ b/assets/css/preview.css
@@ -14,6 +14,28 @@
 	clear: both;
 }
 
+.apple-news-settings-left .collapsed td {
+	display: none;
+	visibility: hidden;
+}
+
+.apple-news-settings-left th:before {
+	background: #333;
+	border-radius: 1em;
+	color: #eee;
+	content: '-';
+	display: inline-block;
+	height: 1.5em;
+	line-height: 1.25em;
+	margin-right: 0.5em;
+	text-align: center;
+	width: 1.5em;
+}
+
+.apple-news-settings-left .collapsed th:before {
+	content: '+';
+}
+
 .apple-news-preview {
 	padding-bottom: 50px;
 }

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -3,6 +3,8 @@
 	var componentKey = '';
 
 	$(document).ready(function () {
+		appleNewsSettingsToggleInit();
+
 		$( 'body' ).on( 'apple-news-settings-loaded', function( e ) {
 			appleNewsPreviewInit();
 		} );
@@ -15,6 +17,32 @@
 			e.preventDefault();
 		} );
 	} );
+
+	/**
+	 * Sets up settings toggle by collapsing all settings initially and
+	 * setting up click listeners to hide and show settings.
+	 */
+	function appleNewsSettingsToggleInit() {
+		var tableRows = document
+			.querySelector( '.form-table.apple-news' )
+			.querySelectorAll( 'tr' );
+		for ( var i = 0; i < tableRows.length; i += 1 ) {
+			tableRows[i].classList.add( 'collapsed' );
+			tableRows[i]
+				.querySelector( 'th' )
+				.addEventListener( 'click', appleNewsSettingsToggleVisibility );
+		}
+	}
+
+	/**
+	 * A click handler for a settings visibility toggle event.
+	 * @param {Event} e - The click event.
+	 */
+	function appleNewsSettingsToggleVisibility(e) {
+		e.preventDefault();
+		e.stopPropagation();
+		e.target.parentNode.classList.toggle('collapsed');
+	}
 
 	function appleNewsPreviewInit() {
 		// Do an initial update


### PR DESCRIPTION
Now that table settings have been added, the number of options on the theme preview page is significantly longer than the preview pane itself. In order to help keep the configurable options next to the preview pane, this PR introduces collapsible settings groups that start out collapsed.