### PR TITLE
Add filter docblock for new language filter

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -200,11 +200,25 @@ class Exporter {
 	 * @access private
 	 */
 	private function generate_json() {
+		/**
+		 * Allows the exporter language to be filtered.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param string $language The language value to be filtered.
+		 * @param int    $post_id  The ID of the post being exported.
+		 */
+		$language = apply_filters(
+			'apple_news_exporter_language',
+			get_bloginfo( 'language' ),
+			$this->content_id()
+		);
+
 		// Base JSON
 		$json = array(
 			'version'    => '1.7',
 			'identifier' => 'post-' . $this->content_id(),
-			'language'   => apply_filters( 'apple_news_exporter_language', get_bloginfo( 'language' ), $this->content_id() ),
+			'language'   => $language,
 			'title'      => wp_strip_all_tags( $this->content_title() ),
 		);
 


### PR DESCRIPTION
This builds on #321 and adds the required filter docblock from the WP documentation standards (https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters).