### PR TITLE
AN-118 If a post push is skipped, explain why

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -133,12 +133,24 @@ class Push extends API_Action {
 		 * Default is false, but filterable.
 		 */
 		if ( apply_filters( 'apple_news_skip_push', false, $this->id ) ) {
-			return;
+			throw new \Apple_Actions\Action_Exception(
+				sprintf(
+					// Translators: Placeholder is a post ID.
+					__( 'Skipped push of article %d due to the apple_news_skip_push filter.', 'apple-news' ),
+					$this->id
+				)
+			);
 		}
 
 		// Ignore if the post is already in sync
 		if ( $this->is_post_in_sync() ) {
-			return;
+			throw new \Apple_Actions\Action_Exception(
+				sprintf(
+					// Translators: Placeholder is a post ID.
+					__( 'Skipped push of article %d because it is already in sync.', 'apple-news' ),
+					$this->id
+				)
+			);
 		}
 
 		// generate_article uses Exporter->generate, so we MUST clean the workspace


### PR DESCRIPTION
* If the skip_post filter is triggered, explain that the filter was the reason why the post was skipped, and include the post ID.
* If the post was not updated because it is already in sync, explain that to the user, and include the post ID.

Fixes #83 