### PR TITLE
AN-104 Remove overzealous check for invalid Unicode sequences

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -237,26 +237,6 @@ class Exporter {
 		$this->prepare_for_encoding( $json );
 		$json = wp_json_encode( $json );
 
-		// Check the JSON for unicode errors.
-		// For now, we'll assume that multiple unicode characters in sequence
-		// containing the Â (\u00C2) indicate a problem as that has been the
-		// most common indication of the issue.
-		preg_match_all( '/(\\\u[0-9a-fA-F]{4}){2,}/', $json, $matches );
-		if ( ! empty( $matches[0] ) ) {
-			// Get a unique list of character sequences
-			$character_sequences = array_unique( $matches[0] );
-			foreach ( $character_sequences as &$sequence ) {
-				// Convert back to a display format
-				$sequence = json_decode( '{ "value":"' . $sequence . '"}' );
-				$sequence = $sequence->value;
-			}
-
-			$this->workspace->log_error( 'json_errors', sprintf(
-				__( 'Invalid unicode character sequences were found that could cause display issues on Apple News: %s', 'apple-news' ),
-				implode( ', ', $character_sequences )
-			) );
-		}
-
 		return $json;
 	}
 


### PR DESCRIPTION
Over the past several releases, enhancements have been made to better identify and fix problems with content that would cause issues upon pushing to Apple News. Therefore, the check for invalid Unicode character sequences is now not providing much value, and is inhibiting valid content (including emoji) from being pushed to Apple News. This PR removes the check for invalid Unicode character sequences, and updates tests to reflect this change.

Fixes #404 