### PR TITLE
AN-115 Work around bug with wp_kses that doesn't fully strip script tags

### DIFF
--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -67,6 +67,9 @@ class HTML {
 	 */
 	public function format( $html ) {
 
+		// Since wp_kses has an issue with some <script> tags, proactively strip them.
+		$html = preg_replace( '/<script[^>]*?>.*?<\/script>/', '', $html );
+
 		// Strip out all tags and attributes other than what is allowed.
 		$html = wp_kses( $html, $this->_allowed_html );
 

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -238,6 +238,39 @@ HTML;
 	}
 
 	/**
+	 * Tests the removal of script tags.
+	 *
+	 * @access public
+	 */
+	public function testRemoveScriptTags() {
+
+		// Setup.
+		$this->settings->html_support = 'yes';
+		$html = <<<HTML
+<p><strong>Lorem ipsum dolor sit amet<script>if (1 > 0) { console.log('something'); }</script></strong></p>
+HTML;
+		$component = new Body(
+			$html,
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test.
+		$this->assertEquals(
+			array(
+				'text'      => '<p><strong>Lorem ipsum dolor sit amet</strong></p>',
+				'role'      => 'body',
+				'format'    => 'html',
+				'textStyle' => 'dropcapBodyStyle',
+				'layout'    => 'body-layout',
+			),
+			$component->to_array()
+		);
+	}
+
+	/**
 	 * Tests the transformation process for an HTML entity (e.g., &amp;).
 	 *
 	 * @access public


### PR DESCRIPTION
There appears to be a bug in `wp_kses` that doesn't properly strip `<script>` tags that contain CDATA with a `>` symbol. This PR adds a workaround to strip `<script>` tags proactively, with the addition of test coverage for this case.

Fixes #235 