### PR TITLE
AN-113 Make cover art opt-in

### DIFF
--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -96,6 +96,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 
 				$post = get_post( $id );
 				$post_meta = get_post_meta( $id );
+				$enable_cover_art = ( 'yes' === $this->settings->enable_cover_art );
 				include plugin_dir_path( __FILE__ ) . 'partials/page_single_push.php';
 				break;
 			default:

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -215,7 +215,6 @@ class Admin_Apple_News extends Apple_News {
 	public function action_init() {
 
 		// Register custom image crops.
-		$test = self::$settings->enable_cover_art;
 		if ( 'yes' === self::$settings->enable_cover_art ) {
 			$image_sizes = self::get_image_sizes();
 			foreach ( $image_sizes as $name => $data ) {

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -215,9 +215,12 @@ class Admin_Apple_News extends Apple_News {
 	public function action_init() {
 
 		// Register custom image crops.
-		$image_sizes = self::get_image_sizes();
-		foreach ( $image_sizes as $name => $data ) {
-			add_image_size( $name, $data['width'], $data['height'], true );
+		$test = self::$settings->enable_cover_art;
+		if ( 'yes' === self::$settings->enable_cover_art ) {
+			$image_sizes = self::get_image_sizes();
+			foreach ( $image_sizes as $name => $data ) {
+				add_image_size( $name, $data['width'], $data['height'], true );
+			}
 		}
 	}
 

--- a/admin/partials/metabox_publish.php
+++ b/admin/partials/metabox_publish.php
@@ -67,7 +67,20 @@
 	</div>
 	<div id="apple-news-metabox-coverart" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
 		<h3><?php esc_html_e( 'Cover art', 'apple-news' ) ?></h3>
-		<?php include plugin_dir_path( __FILE__ ) . 'cover_art.php'; ?>
+		<?php if ( 'yes' === $this->settings->get( 'enable_cover_art' ) ) : ?>
+			<?php include plugin_dir_path( __FILE__ ) . 'cover_art.php'; ?>
+		<?php else : ?>
+			<p>
+			<?php
+				printf(
+					/* translators: First token is opening a tag, second is closing a tag */
+					esc_html__( 'Cover Art must be enabled on the %1$ssettings page%2$s.', 'apple-news' ),
+					'<a href="' . esc_url( admin_url( 'admin.php?page=apple-news-options' ) ) . '">',
+					'</a>'
+				);
+			?>
+			</p>
+		<?php endif; ?>
 	</div>
 	<?php if ( 'yes' !== $this->settings->get( 'api_autosync' )
 		 && current_user_can( apply_filters( 'apple_news_publish_capability', Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type ) ) )

--- a/admin/partials/page_single_push.php
+++ b/admin/partials/page_single_push.php
@@ -85,7 +85,18 @@
 			<tr>
 				<th scope="row"><?php esc_html_e( 'Cover art', 'apple-news' ) ?></th>
 				<td>
-					<?php include plugin_dir_path( __FILE__ ) . 'cover_art.php'; ?>
+					<?php if ( $enable_cover_art ) : ?>
+						<?php include plugin_dir_path( __FILE__ ) . 'cover_art.php'; ?>
+					<?php else : ?>
+						<?php
+							printf(
+								/* translators: First token is opening a tag, second is closing a tag */
+								esc_html__( 'Cover Art must be enabled on the %1$ssettings page%2$s.', 'apple-news' ),
+								'<a href="' . esc_url( admin_url( 'admin.php?page=apple-news-options' ) ) . '">',
+								'</a>'
+							);
+						?>
+					<?php endif; ?>
 				</td>
 			</tr>
 		</table>

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -46,6 +46,11 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'type' => array( 'yes', 'no' ),
 				'description' => __( 'If set to yes, images that are centered or have no alignment will span edge-to-edge rather than being constrained within the body margins.', 'apple-news' ),
 			),
+			'enable_cover_art' => array(
+				'description' => __( 'Enables the <a href="https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html">cover art</a> feature, which requires additional image sizes to be created. To avoid adding a significant number of additional image crops to your uploads folder, we recommend using an on-demand image resizing service such as <a href="https://jetpack.com/support/photon/">Jetpack\'s Image CDN</a>.', 'apple-news' ),
+				'label'       => __( 'Use Cover Art?', 'apple-news' ),
+				'type'        => array( 'yes', 'no' ),
+			),
 			'html_support' => array(
 				'label' => __( 'Enable HTML support?', 'apple-news' ),
 				'type' => array( 'yes', 'no' ),
@@ -67,7 +72,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			),
 			'images' => array(
 				'label'       => __( 'Image Settings', 'apple-news' ),
-				'settings'    => array( 'use_remote_images', 'full_bleed_images' ),
+				'settings'    => array( 'use_remote_images', 'full_bleed_images', 'enable_cover_art' ),
 			),
 			'format' => array(
 				'label'       => __( 'Format Settings', 'apple-news' ),

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -142,7 +142,17 @@ class Metadata extends Builder {
 				|| $data['width'] !== $image['sizes'][ $key ]['width']
 				|| $data['height'] !== $image['sizes'][ $key ]['height']
 			) {
-				continue;
+				/**
+				 * If the full size of the image is *exactly* the requested
+				 * dimensions, a crop won't be generated, but we don't want
+				 * to fail it either. So we need to check the height and
+				 * width of the original also.
+				 */
+				if ( $data['width'] !== $image['width']
+					|| $data['height'] !== $image['height']
+				) {
+					continue;
+				}
 			}
 
 			// Bundle source, if necessary.

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -40,6 +40,7 @@ class Settings {
 		'apple_news_admin_email' => '',
 		'apple_news_enable_debugging' => 'no',
 		'component_alerts' => 'none',
+		'enable_cover_art' => 'no',
 		'full_bleed_images' => 'no',
 		'html_support' => 'no',
 		'json_alerts' => 'warn',

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -702,6 +702,11 @@ class Apple_News {
 				$this->migrate_table_settings( $theme );
 			}
 		}
+
+		// Default cover art to on for existing installations.
+		$wp_settings = get_option( self::$option_name );
+		$wp_settings['enable_cover_art'] = 'yes';
+		update_option( self::$option_name, $wp_settings, 'no' );
 	}
 
 	/**

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -63,6 +63,15 @@ class Metadata_Test extends WP_UnitTestCase {
 	 */
 	public function testCoverArt() {
 
+		/**
+		 * Due to how the cover art setting is processed, we need to
+		 * manually register the image sizes here.
+		 */
+		$image_sizes = Admin_Apple_News::get_image_sizes();
+		foreach ( $image_sizes as $name => $data ) {
+			add_image_size( $name, $data['width'], $data['height'], true );
+		}
+
 		// Create dummy content.
 		$title = 'My Title';
 		$content = '<p>Hello, World!</p>';


### PR DESCRIPTION
* Adds a setting to allow users to opt in to using the Cover Art feature, rather than having it on by default, since it adds a significant number of image crops that are only useful if using this feature.
* Sets the setting to enabled for existing installations during upgrade, since there is not a good way to know whether a user has utilized this feature without running a very expensive postmeta query.
* Sets fallback messaging for the metabox and single push screens if the cover art feature is disabled, directing the user to the settings page to enable it.

Fixes #339 