### PR TITLE
AN-111 Add WordPress.com/OpenGraph Facebook Embeds Handler

### DIFF
--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -37,6 +37,17 @@ class Facebook extends Component {
 	);
 
 	/**
+	 * Regular expressions for extracting post URLs from HTML markup.
+	 *
+	 * @access private
+	 * @var array
+	 */
+	private static $_url_signatures = array(
+		'/data-href="([^"]+)"/i',
+		'/<fb:post\s.*?href="([^"]+)"/i',
+	);
+
+	/**
 	 * Register all specs for the component.
 	 *
 	 * @access public
@@ -113,9 +124,12 @@ class Facebook extends Component {
 	 */
 	protected function build( $html ) {
 
-		// Check for data-href property on rendered <div>.
-		if ( preg_match( '/data-href="([^"]+)"/i', $html, $data_href ) ) {
-			$html = $data_href[1];
+		// Check for href properties on rendered embeds.
+		foreach ( self::$_url_signatures as $signature ) {
+			if ( preg_match( $signature, $html, $matches ) ) {
+				$html = $matches[1];
+				break;
+			}
 		}
 
 		// Try to get Facebook URL.

--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -44,7 +44,7 @@ class Facebook extends Component {
 	 */
 	private static $_url_signatures = array(
 		'/data-href="([^"]+)"/i',
-		'/<fb:post\s.*?href="([^"]+)"/i',
+		'/<(?:fb:)?post\s.*?href="([^"]+)"/i',
 	);
 
 	/**

--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -85,6 +85,21 @@ class Facebook extends Component {
 			}
 		}
 
+		// Handling for a rendered WordPress.com Facebook embed.
+		$fb_post = $node->getElementsByTagName( 'post' );
+		if ( ! empty( $fb_post->length ) && 1 === $fb_post->length ) {
+
+			// Extract Facebook URL from element's href property.
+			$fb_url = $fb_post[0]->getAttribute( 'href' );
+
+			// Ensure we have a valid Facebook embed url.
+			if ( ! empty( $fb_url )
+				&& false !== self::_get_facebook_url( $fb_url )
+			) {
+				return $node;
+			}
+		}
+
 		// facebook not found.
 		return null;
 	}

--- a/tests/apple-exporter/components/test-class-facebook.php
+++ b/tests/apple-exporter/components/test-class-facebook.php
@@ -121,6 +121,14 @@ class Facebook_Test extends Component_TestCase {
 			$node
 		);
 
+		// Test the node - WordPress.com embed syntax.
+		$node = self::build_node( '<p><fb:post href="' . esc_url( $url ) . '" data-width="552" class=" fb_iframe_widget" fb-xfbml-state="rendered" fb-iframe-plugin-query="app_id=249643311490&amp;container_width=0&amp;href=https%3A%2F%2Fwww.facebook.com%2FWordPresscom%2Fposts%2F10156452969778980&amp;locale=en_US&amp;sdk=joey&amp;width=552"><span style="vertical-align: bottom; width: 552px; height: 504px;"><iframe name="f1d6c220128422" width="552px" height="1000px" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" title="fb:post Facebook Social Plugin" src="https://www.facebook.com/v2.3/plugins/post.php?app_id=249643311490&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter%2Fr%2FRQ7NiRXMcYA.js%3Fversion%3D42%23cb%3Df31851b8eec581%26domain%3Dexample.wordpress.com%26origin%3Dhttps%253A%252F%252Fexample.wordpress.com%252Ff59b6814ddce14%26relation%3Dparent.parent&amp;container_width=0&amp;href=https%3A%2F%2Fwww.facebook.com%2FWordPresscom%2Fposts%2F10156452969778980&amp;locale=en_US&amp;sdk=joey&amp;width=552" style="border: none; visibility: visible; width: 552px; height: 504px;" class=""></iframe></span></fb:post></p>' );
+
+		$this->assertEquals(
+			$component->node_matches( $node ),
+			$node
+		);
+
 		// Test the node - *incorrect* css class and fb url.
 		$node_failure = self::build_node( sprintf( '<div class="invalid-fb-post" data-href="%s"></div>', esc_url( $url ) ) );
 

--- a/tests/apple-exporter/components/test-class-facebook.php
+++ b/tests/apple-exporter/components/test-class-facebook.php
@@ -122,11 +122,28 @@ class Facebook_Test extends Component_TestCase {
 		);
 
 		// Test the node - WordPress.com embed syntax.
-		$node = self::build_node( '<p><fb:post href="' . esc_url( $url ) . '" data-width="552" class=" fb_iframe_widget" fb-xfbml-state="rendered" fb-iframe-plugin-query="app_id=249643311490&amp;container_width=0&amp;href=https%3A%2F%2Fwww.facebook.com%2FWordPresscom%2Fposts%2F10156452969778980&amp;locale=en_US&amp;sdk=joey&amp;width=552"><span style="vertical-align: bottom; width: 552px; height: 504px;"><iframe name="f1d6c220128422" width="552px" height="1000px" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" title="fb:post Facebook Social Plugin" src="https://www.facebook.com/v2.3/plugins/post.php?app_id=249643311490&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter%2Fr%2FRQ7NiRXMcYA.js%3Fversion%3D42%23cb%3Df31851b8eec581%26domain%3Dexample.wordpress.com%26origin%3Dhttps%253A%252F%252Fexample.wordpress.com%252Ff59b6814ddce14%26relation%3Dparent.parent&amp;container_width=0&amp;href=https%3A%2F%2Fwww.facebook.com%2FWordPresscom%2Fposts%2F10156452969778980&amp;locale=en_US&amp;sdk=joey&amp;width=552" style="border: none; visibility: visible; width: 552px; height: 504px;" class=""></iframe></span></fb:post></p>' );
+		$wpcom_embed_html = '<p><fb:post href="' . esc_url( $url ) . '" data-width="552" class=" fb_iframe_widget" fb-xfbml-state="rendered" fb-iframe-plugin-query="app_id=249643311490&amp;container_width=0&amp;href=https%3A%2F%2Fwww.facebook.com%2FWordPresscom%2Fposts%2F10156452969778980&amp;locale=en_US&amp;sdk=joey&amp;width=552"><span style="vertical-align: bottom; width: 552px; height: 504px;"><iframe name="f1d6c220128422" width="552px" height="1000px" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" title="fb:post Facebook Social Plugin" src="https://www.facebook.com/v2.3/plugins/post.php?app_id=249643311490&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter%2Fr%2FRQ7NiRXMcYA.js%3Fversion%3D42%23cb%3Df31851b8eec581%26domain%3Dexample.wordpress.com%26origin%3Dhttps%253A%252F%252Fexample.wordpress.com%252Ff59b6814ddce14%26relation%3Dparent.parent&amp;container_width=0&amp;href=https%3A%2F%2Fwww.facebook.com%2FWordPresscom%2Fposts%2F10156452969778980&amp;locale=en_US&amp;sdk=joey&amp;width=552" style="border: none; visibility: visible; width: 552px; height: 504px;" class=""></iframe></span></fb:post></p>';
+		$node             = self::build_node( $wpcom_embed_html );
 
 		$this->assertEquals(
 			$component->node_matches( $node ),
 			$node
+		);
+
+		$component = new Facebook(
+			$wpcom_embed_html,
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		$this->assertEquals(
+			array(
+				'role' => 'facebook_post',
+				'URL'  => $url,
+			),
+			$component->to_array()
 		);
 
 		// Test the node - *incorrect* css class and fb url.


### PR DESCRIPTION
* Adds handling for Facebook embeds in the form of `<fb:post href="url">`.
* Adds tests to cover the new format.

Fixes #388 