### PR TITLE
AN-102 Make HTML the default output format

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -55,12 +55,11 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'label' => __( 'Enable HTML support?', 'apple-news' ),
 				'type' => array( 'yes', 'no' ),
 				'description' => sprintf(
-					'%s <a href="%s" target="_blank">%s</a> %s',
-					__( 'Experimental. If set to yes, certain text fields will use', 'apple-news' ),
-					__( 'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/HTMLMarkupforAppleNewsFormat.html', 'apple-news' ),
-					__( 'Apple News HTML format', 'apple-news' ),
-					__( 'instead of Markdown, allowing for proper display of certain HTML tags in content.', 'apple-news' )
-				)
+					// Translators: Placeholder 1 is an opening <a> tag, placeholder 2 is </a>.
+					__( 'If set to no, certain text fields will use Markdown instead of %1$sApple News HTML format%2$s. As of version 1.4.0, HTML format is the preferred output format. Support for Markdown may be removed in the future.', 'apple-news' ),
+					'<a href="' . esc_url( 'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/HTMLMarkupforAppleNewsFormat.html' ) . '">',
+					'</a>'
+				),
 			),
 		);
 

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -42,7 +42,7 @@ class Settings {
 		'component_alerts' => 'none',
 		'enable_cover_art' => 'no',
 		'full_bleed_images' => 'no',
-		'html_support' => 'no',
+		'html_support' => 'yes',
 		'json_alerts' => 'warn',
 		'post_types' => array( 'post' ),
 		'show_metabox' => 'yes',

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -92,6 +92,18 @@ class Heading extends Component {
 	}
 
 	/**
+	 * Whether HTML format is enabled for this component type.
+	 *
+	 * @param bool $enabled Optional. Whether to enable HTML support for this component. Defaults to true.
+	 *
+	 * @access protected
+	 * @return bool Whether HTML format is enabled for this component type.
+	 */
+	protected function html_enabled( $enabled = true ) {
+		return parent::html_enabled( $enabled );
+	}
+
+	/**
 	 * Split the image parts.
 	 *
 	 * @param string $html

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -252,6 +252,18 @@ class Quote extends Component {
 	}
 
 	/**
+	 * Whether HTML format is enabled for this component type.
+	 *
+	 * @param bool $enabled Optional. Whether to enable HTML support for this component. Defaults to true.
+	 *
+	 * @access protected
+	 * @return bool Whether HTML format is enabled for this component type.
+	 */
+	protected function html_enabled( $enabled = true ) {
+		return parent::html_enabled( $enabled );
+	}
+
+	/**
 	 * Processes given text to apply smart quotes on either end of provided text.
 	 *
 	 * @param string $text The text to process.

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -276,6 +276,10 @@ class Quote extends Component {
 		// Trim the fat before beginning.
 		$text = trim( $text );
 
+		// If using HTML format, also strip the beginning and ending paragraph tags.
+		$text = preg_replace( '/^<p>/i', '', $text );
+		$text = preg_replace( '/<\/p>$/i', '', $text );
+
 		// Strip any double quotes already present.
 		$modified_text = trim( $text, '"“”' );
 
@@ -296,8 +300,12 @@ class Quote extends Component {
 			$text
 		);
 
-		// Re-add the line breaks.
-		$modified_text .= "\n\n";
+		// Re-add removed elements depending on format.
+		if ( 'yes' === $this->settings->html_support ) {
+			$modified_text = '<p>' . $modified_text . '</p>';
+		} else {
+			$modified_text .= "\n\n";
+		}
 
 		return $modified_text;
 	}

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -299,7 +299,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		$export = new Export( $this->settings, $post_id, $sections );
 		$json = json_decode( $export->perform() );
 		$this->assertEquals(
-			'is exporting',
+			'<p>is exporting</p>',
 			$json->components[3]->text
 		);
 

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -53,6 +53,7 @@ class Body_Test extends Component_TestCase {
 	public function testEmptyContent() {
 
 		// Setup.
+		$this->settings->html_support = 'no';
 		$html = '<p><a href="https://www.apple.com/">&nbsp;</a></p>';
 		$component = new Body(
 			$html,
@@ -67,6 +68,9 @@ class Body_Test extends Component_TestCase {
 			array(),
 			$component->to_array()
 		);
+
+		// Teardown.
+		$this->settings->html_support = 'yes';
 	}
 
 	/**
@@ -77,7 +81,6 @@ class Body_Test extends Component_TestCase {
 	public function testEmptyHTMLContent() {
 
 		// Setup.
-		$this->settings->html_support = 'yes';
 		$html = '<p>a</p><p>&nbsp;</p><p>b</p>';
 		$component = new Body(
 			$html,
@@ -98,9 +101,6 @@ class Body_Test extends Component_TestCase {
 			),
 			$component->to_array()
 		);
-
-		// Teardown.
-		$this->settings->html_support = 'no';
 	}
 
 	/**
@@ -111,6 +111,7 @@ class Body_Test extends Component_TestCase {
 	public function testFilter() {
 
 		// Setup.
+		$this->settings->html_support = 'no';
 		$theme = new \Apple_Exporter\Theme;
 		$theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
 		$theme->load();
@@ -138,6 +139,7 @@ class Body_Test extends Component_TestCase {
 			'apple_news_body_json',
 			array( $this, 'filter_apple_news_body_json' )
 		);
+		$this->settings->html_support = 'yes';
 	}
 
 	/**
@@ -146,9 +148,6 @@ class Body_Test extends Component_TestCase {
 	 * @access public
 	 */
 	public function testFilterHTML() {
-
-		// Setup.
-		$this->settings->html_support = 'yes';
 
 		// Test before filter.
 		$component = new Body(
@@ -193,7 +192,6 @@ class Body_Test extends Component_TestCase {
 		);
 
 		// Teardown.
-		$this->settings->html_support = 'no';
 		remove_filter(
 			'apple_news_body_html_enabled',
 			array( $this, 'filter_apple_news_body_html_enabled' )
@@ -208,7 +206,6 @@ class Body_Test extends Component_TestCase {
 	public function testHTML() {
 
 		// Setup.
-		$this->settings->html_support = 'yes';
 		$html = <<<HTML
 <p>Lorem ipsum. <a href="https://wordpress.org">Dolor sit amet</a>.</p>
 <pre>
@@ -245,7 +242,6 @@ HTML;
 	public function testRemoveScriptTags() {
 
 		// Setup.
-		$this->settings->html_support = 'yes';
 		$html = <<<HTML
 <p><strong>Lorem ipsum dolor sit amet<script>if (1 > 0) { console.log('something'); }</script></strong></p>
 HTML;
@@ -278,6 +274,7 @@ HTML;
 	public function testTransformHtmlEntities() {
 
 		// Setup.
+		$this->settings->html_support = 'no';
 		$body_component = new Body(
 			'<p>my &amp; text</p>',
 			null,
@@ -297,6 +294,9 @@ HTML;
 			),
 			$body_component->to_array()
 		);
+
+		// Teardown.
+		$this->settings->html_support = 'yes';
 	}
 
 	/**
@@ -307,6 +307,7 @@ HTML;
 	public function testLists() {
 
 		// Setup.
+		$this->settings->html_support = 'no';
 		$content = <<<HTML
 <ul>
 <li>item 1</li>
@@ -349,6 +350,9 @@ HTML;
 			'- item 2' . "\n" . '- item 3',
 			$json['components'][1]['components'][3]['text']
 		);
+
+		// Teardown.
+		$this->settings->html_support = 'yes';
 	}
 
 	/**
@@ -487,6 +491,7 @@ HTML;
 	public function testTransform() {
 
 		// Setup.
+		$this->settings->html_support = 'no';
 		$component = new Body(
 			'<p>my text</p>',
 			null,
@@ -506,6 +511,9 @@ HTML;
 			),
 			$component->to_array()
 		);
+
+		// Teardown.
+		$this->settings->html_support = 'yes';
 	}
 
 	/**
@@ -516,6 +524,7 @@ HTML;
 	public function testWithoutDropcap() {
 
 		// Setup.
+		$this->settings->html_support = 'no';
 		$theme = \Apple_Exporter\Theme::get_used();
 		$settings = $theme->all_settings();
 		$settings['initial_dropcap'] = 'no';
@@ -540,5 +549,8 @@ HTML;
 			),
 			$body_component->to_array()
 		);
+
+		// Teardown.
+		$this->settings->html_support = 'yes';
 	}
 }

--- a/tests/apple-exporter/components/test-class-heading.php
+++ b/tests/apple-exporter/components/test-class-heading.php
@@ -510,6 +510,6 @@ HTML;
 		// Test.
 		$this->assertEquals( 'heading1', $json['role'] );
 		$this->assertEquals( 'This is a heading', $json['text'] );
-		$this->assertEquals( 'markdown', $json['format'] );
+		$this->assertEquals( 'html', $json['format'] );
 	}
 }

--- a/tests/apple-exporter/components/test-class-quote.php
+++ b/tests/apple-exporter/components/test-class-quote.php
@@ -29,10 +29,10 @@ class Quote_Test extends Component_TestCase {
 	 */
 	public function dataTransformPullquote() {
 		return array(
-			array( 'my text', 'my text' . "\n\n", 'no' ),
-			array( 'my text', '“my text”' . "\n\n", 'yes' ),
-			array( '"my text"', '“my text”' . "\n\n", 'yes' ),
-			array( '“my text”', '“my text”' . "\n\n", 'yes' ),
+			array( 'my text', '<p>my text</p>', 'no' ),
+			array( 'my text', '<p>“my text”</p>', 'yes' ),
+			array( '"my text"', '<p>“my text”</p>', 'yes' ),
+			array( '“my text”', '<p>“my text”</p>', 'yes' ),
 		);
 	}
 
@@ -93,7 +93,7 @@ class Quote_Test extends Component_TestCase {
 		// Test.
 		$result = $component->to_array();
 		$this->assertEquals(
-			'«my quote»' . "\n\n",
+			'<p>«my quote»</p>',
 			$result['components'][0]['text']
 		);
 
@@ -293,8 +293,8 @@ class Quote_Test extends Component_TestCase {
 		// Test.
 		$this->assertEquals( 'container', $result_wrapper['role'] );
 		$this->assertEquals( 'quote', $result['role'] );
-		$this->assertEquals( "my quote\n\n", $result['text'] );
-		$this->assertEquals( 'markdown', $result['format'] );
+		$this->assertEquals( '<p>my quote</p>', $result['text'] );
+		$this->assertEquals( 'html', $result['format'] );
 		$this->assertEquals( 'default-blockquote', $result['textStyle'] );
 		$this->assertEquals( 'blockquote-layout', $result['layout'] );
 	}
@@ -332,7 +332,7 @@ class Quote_Test extends Component_TestCase {
 		$this->assertEquals( 'container', $result_wrapper['role'] );
 		$this->assertEquals( 'quote', $result['role'] );
 		$this->assertEquals( $expected, $result['text'] );
-		$this->assertEquals( 'markdown', $result['format'] );
+		$this->assertEquals( 'html', $result['format'] );
 		$this->assertEquals( 'default-pullquote', $result['textStyle'] );
 		$this->assertEquals( 'pullquote-layout', $result['layout'] );
 	}


### PR DESCRIPTION
* Set default setting for `html_support` to be `yes`.
* Update language describing the setting, indicating that it is the preferred output format.
* Update `Heading` and `Quote` components to support HTML.
* Update tests to reflect these changes.

Fixes #448 