### PR TITLE
AN-132 Fix Squiz.Commenting.InlineComment.InvalidEndChar errors

### DIFF
--- a/admin/apple-actions/index/class-delete.php
+++ b/admin/apple-actions/index/class-delete.php
@@ -60,7 +60,7 @@ class Delete extends API_Action {
 			do_action( 'apple_news_before_delete', $remote_id, $this->id );
 			$this->get_api()->delete_article( $remote_id );
 
-			// Delete the API references and mark as deleted
+			// Delete the API references and mark as deleted.
 			delete_post_meta( $this->id, 'apple_news_api_id' );
 			delete_post_meta( $this->id, 'apple_news_api_revision' );
 			delete_post_meta( $this->id, 'apple_news_api_created_at' );
@@ -68,7 +68,7 @@ class Delete extends API_Action {
 			delete_post_meta( $this->id, 'apple_news_api_share_url' );
 			update_post_meta( $this->id, 'apple_news_api_deleted', time() );
 
-			// Clear the cache for post status
+			// Clear the cache for post status.
 			delete_transient( 'apple_news_post_state_' . $this->id );
 
 			do_action( 'apple_news_after_delete', $remote_id, $this->id );

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -83,24 +83,26 @@ class Export extends Action {
 
 		do_action( 'apple_news_do_fetch_exporter', $this->id );
 
-		// Fetch WP_Post object, and all required post information to fill up the
-		// Exporter_Content instance.
+		/**
+		 * Fetch WP_Post object, and all required post information to fill up the
+		 * Exporter_Content instance.
+		 */
 		$post = get_post( $this->id );
 
-		// Build the excerpt if required
+		// Build the excerpt if required.
 		if ( empty( $post->post_excerpt ) ) {
 			$excerpt = wp_trim_words( wp_strip_all_tags( $this->remove_tags( strip_shortcodes( $post->post_content ) ) ), 55, '...' );
 		} else {
 			$excerpt = wp_strip_all_tags( $post->post_excerpt );
 		}
 
-		// Get the post thumbnail
+		// Get the post thumbnail.
 		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) ) ?: null;
 
-		// Build the byline
+		// Build the byline.
 		$byline = $this->format_byline( $post );
 
-		// Get the content
+		// Get the content.
 		$content = $this->get_content( $post );
 
 		// Filter each of our items before passing into the exporter class.
@@ -139,7 +141,7 @@ class Export extends Action {
 		// Get information about the currently used theme.
 		$theme = \Apple_Exporter\Theme::get_used();
 
-		// Get the author
+		// Get the author.
 		if ( empty( $author ) ) {
 
 			// Try to get the author information from Co-Authors Plus.
@@ -150,35 +152,37 @@ class Export extends Action {
 			}
 		}
 
-		// Get the date
+		// Get the date.
 		if ( empty( $date ) && ! empty( $post->post_date ) ) {
 			$date = $post->post_date;
 		}
 
-		// Set the default date format
+		// Set the default date format.
 		$date_format = 'M j, Y | g:i A';
 
-		// Check for a custom byline format
+		// Check for a custom byline format.
 		$byline_format = $theme->get_value( 'byline_format' );
 		if ( ! empty( $byline_format ) ) {
-			// Find and replace the author format placeholder name with a temporary placeholder
-			// This is because some bylines could contain hashtags!
+			/**
+			 * Find and replace the author format placeholder name with a temporary placeholder.
+			 * This is because some bylines could contain hashtags!
+			 */
 			$temp_byline_placeholder = 'AUTHOR' . time();
 			$byline = str_replace( '#author#', $temp_byline_placeholder, $byline_format );
 
-			// Attempt to parse the date format from the remaining string
+			// Attempt to parse the date format from the remaining string.
 			$matches = array();
 			preg_match( '/#(.*?)#/', $byline, $matches );
 			if ( ! empty( $matches[1] ) && ! empty( $date ) ) {
-				// Set the date using the custom format
+				// Set the date using the custom format.
 				$byline = str_replace( $matches[0], date( $matches[1], strtotime( $date ) ), $byline );
 			}
 
-			// Replace the temporary placeholder with the actual byline
+			// Replace the temporary placeholder with the actual byline.
 			$byline = str_replace( $temp_byline_placeholder, $author, $byline );
 
 		} else {
-			// Use the default format
+			// Use the default format.
 			$byline = sprintf(
 				'by %1$s | %2$s',
 				$author,
@@ -198,9 +202,11 @@ class Export extends Action {
 	 * @access private
 	 */
 	private function get_content( $post ) {
-		// The post_content is not raw HTML, as WordPress editor cleans up
-		// paragraphs and new lines, so we need to transform the content to
-		// HTML. We use 'the_content' filter for that.
+		/**
+		 * The post_content is not raw HTML, as WordPress editor cleans up
+		 * paragraphs and new lines, so we need to transform the content to
+		 * HTML. We use 'the_content' filter for that.
+		 */
 		$content = apply_filters( 'apple_news_exporter_content_pre', $post->post_content, $post->ID );
 		$content = apply_filters( 'the_content', $content );
 		$content = $this->remove_tags( $content );

--- a/admin/apple-actions/index/class-get.php
+++ b/admin/apple-actions/index/class-get.php
@@ -40,7 +40,7 @@ class Get extends API_Action {
 			return null;
 		}
 
-		// Get the article from the API
+		// Get the article from the API.
 		$article = $this->get_api()->get_article( $apple_id );
 		if ( empty( $article->data ) ) {
 			return null;

--- a/admin/apple-actions/index/class-section.php
+++ b/admin/apple-actions/index/class-section.php
@@ -35,7 +35,7 @@ class Section extends API_Action {
 	 * @access public
 	 */
 	public function perform() {
-		// Get the section from the API
+		// Get the section from the API.
 		$section = $this->get_api()->get_section( $this->section_id );
 		if ( empty( $section->data ) ) {
 			return null;

--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -32,11 +32,11 @@ class Admin_Apple_Async extends Apple_News {
 	function __construct( $settings ) {
 		$this->settings = $settings;
 
-		// If async mode is enabled create the action hook
+		// If async mode is enabled create the action hook.
 		if ( 'yes' === $settings->get( 'api_async' ) ) {
 			add_action( self::ASYNC_PUSH_HOOK, array( $this, 'async_push' ), 10, 2 );
 
-			// If we're on VIP, set async mode to use the jobs system
+			// If we're on VIP, set async mode to use the jobs system.
 			if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
 				add_filter( 'wpcom_vip_passthrough_cron_to_jobs', array( $this, 'passthrough_cron_to_jobs' ) );
 			}
@@ -52,15 +52,17 @@ class Admin_Apple_Async extends Apple_News {
 	 * @since 1.0.0
 	 */
 	public function async_push( $post_id, $user_id ) {
-		// This hook could be used for an ini_set to increase max execution time
-		// for asynchronous publishing to handle large push requests.
-		// Since some hosts wouldn't support it, the code isn't added directly here.
-		//
-		// On WordPress VIP this isn't necessary since the plugin
-		// will automatically use the jobs system which can handle requests up to 12 hours.
+		/**
+		 * This hook could be used for an ini_set to increase max execution time
+		 * for asynchronous publishing to handle large push requests.
+		 * Since some hosts wouldn't support it, the code isn't added directly here.
+		 *
+		 * On WordPress VIP this isn't necessary since the plugin
+		 * will automatically use the jobs system which can handle requests up to 12 hours.
+		 */
 		do_action( 'apple_news_before_async_push' );
 
-		// Ensure that the job can't be picked up twice
+		// Ensure that the job can't be picked up twice.
 		$in_progress = get_post_meta( $post_id, 'apple_news_api_async_in_progress', true );
 		if ( ! empty( $in_progress ) ) {
 			return;
@@ -68,7 +70,7 @@ class Admin_Apple_Async extends Apple_News {
 
 		update_post_meta( $post_id, 'apple_news_api_async_in_progress', time() );
 
-		// Ensure that the post is still published
+		// Ensure that the post is still published.
 		$post = get_post( $post_id );
 		if ( 'publish' !== $post->post_status ) {
 			Admin_Apple_Notice::error( sprintf(

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -44,12 +44,12 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 	 */
 	public function register_page() {
 		add_submenu_page(
-			null,                                // Parent, if null, it won't appear in any menu
-			__( 'Bulk Export', 'apple-news' ),   // Page title
-			__( 'Bulk Export', 'apple-news' ),   // Menu title
-			apply_filters( 'apple_news_bulk_export_capability', 'manage_options' ),	// Capability
-			$this->plugin_slug . '_bulk_export', // Menu Slug
-			array( $this, 'build_page' )         // Function
+			null,                                // Parent, if null, it won't appear in any menu.
+			__( 'Bulk Export', 'apple-news' ),   // Page title.
+			__( 'Bulk Export', 'apple-news' ),   // Menu title.
+			apply_filters( 'apple_news_bulk_export_capability', 'manage_options' ),	// Capability.
+			$this->plugin_slug . '_bulk_export', // Menu Slug.
+			array( $this, 'build_page' )         // Function.
 	 	);
 	}
 
@@ -84,7 +84,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 			}
 		}
 
-		// Populate $articles array with a set of valid posts
+		// Populate $articles array with a set of valid posts.
 		$articles = array();
 		foreach ( explode( '.', $ids ) as $id ) {
 			if ( $post = get_post( absint( $id ) ) ) {
@@ -101,13 +101,13 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 	 * @access public
 	 */
 	public function ajax_push_post() {
-		// Check the nonce
+		// Check the nonce.
 		check_ajax_referer( self::ACTION );
 
-		// Sanitize input data
+		// Sanitize input data.
 		$id = absint( $_GET['id'] );
 
-		// Ensure the post exists and that it's published
+		// Ensure the post exists and that it's published.
 		$post = get_post( $id );
 		if ( empty( $post ) ) {
 			echo wp_json_encode( array(
@@ -155,7 +155,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 			) );
 		}
 
-		// This is required to terminate immediately and return a valid response
+		// This is required to terminate immediately and return a valid response.
 		wp_die();
 	}
 

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -41,7 +41,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		parent::__construct();
 		$this->settings = $settings;
 
-		// Handle routing to various admin pages
+		// Handle routing to various admin pages.
 		add_action( 'admin_init', array( $this, 'page_router' ) );
 		add_action( 'admin_menu', array( $this, 'setup_admin_page' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'setup_assets' ) );
@@ -55,7 +55,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @access public
 	 */
 	public function setup_admin_page() {
-		// Set up main page. This page reads parameters and handles actions
+		// Set up main page. This page reads parameters and handles actions.
 		// accordingly.
 		add_menu_page(
 			__( 'Apple News', 'apple-news' ),
@@ -122,7 +122,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		$action		= isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : null;
 		$action2	= isset( $_GET['action2'] ) ? sanitize_text_field( $_GET['action2'] ) : null;
 
-		// Allow for bulk actions from top or bottom
+		// Allow for bulk actions from top or bottom.
 		if ( ( empty( $action ) || '-1' === $action ) && ! empty( $action2 ) ) {
 			$action = $action2;
 		}
@@ -181,7 +181,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @access public
 	 */
 	private function do_redirect() {
-		// Perform the redirect
+		// Perform the redirect.
 		wp_safe_redirect( esc_url_raw( self::action_query_params( '', menu_page_url( $this->plugin_slug . '_index', false ) ) ) );
 		if ( ! defined( 'APPLE_NEWS_UNIT_TESTS' ) || ! APPLE_NEWS_UNIT_TESTS ) {
 			exit;
@@ -208,7 +208,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @access public
 	 */
 	public static function action_query_params( $action, $url ) {
-		// Set the keys we need to pay attention to
+		// Set the keys we need to pay attention to.
 		$keys = array(
 			'apple_news_publish_status',
 			'apple_news_date_from',
@@ -217,20 +217,20 @@ class Admin_Apple_Index_Page extends Apple_News {
 			'paged',
 		);
 
-		// Start the params
+		// Start the params.
 		$params = array();
 		if ( ! empty( $action ) ) {
 			$params['action'] = self::namespace_action( $action );
 		}
 
-		// Add the other params
+		// Add the other params.
 		foreach ( $keys as $key ) {
 			if ( ! empty( $_GET[ $key ] ) ) {
 				$params[ $key ] = urlencode( sanitize_text_field( $_GET[ $key ] ) );
 			}
 		}
 
-		// Add to the action URL
+		// Add to the action URL.
 		return add_query_arg( $params, $url );
 	}
 
@@ -272,10 +272,10 @@ class Admin_Apple_Index_Page extends Apple_News {
 			return;
 		}
 
-		// Enable jQuery datepicker for the export table date filter
+		// Enable jQuery datepicker for the export table date filter.
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 
-		// Add the export table script and style
+		// Add the export table script and style.
 		wp_enqueue_style(
 			$this->plugin_slug . '_export_table_css',
 			plugin_dir_url( __FILE__ ) .  '../assets/css/export-table.css',
@@ -297,7 +297,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 			true
 		);
 
-		// Localize strings
+		// Localize strings.
 		wp_localize_script( $this->plugin_slug . '_export_table_js', 'apple_news_export_table', array(
 			'reset_confirmation' => __( "Are you sure you want to reset status? Please only proceed if you're certain the post is stuck or this could reset in duplicate posts in Apple News.", 'apple-news' ),
 			'delete_confirmation' => __( 'Are you sure you want to delete this post from Apple News?', 'apple-news' ),
@@ -343,7 +343,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @access private
 	 */
 	private function push_action( $id ) {
-		// Ensure the post is published
+		// Ensure the post is published.
 		if ( 'publish' !== get_post_status( $id ) ) {
 			$this->notice_error( sprintf(
 				__( 'Article %s is not published and cannot be pushed to Apple News.', 'apple-news' ),
@@ -363,17 +363,17 @@ class Admin_Apple_Index_Page extends Apple_News {
 			$this->notice_error( __( 'Invalid nonce.', 'apple-news' ) );
 		}
 
-		// Save fields
+		// Save fields.
 		\Admin_Apple_Meta_Boxes::save_post_meta( $id );
 
 		$message = __( 'Settings saved.', 'apple-news' );
 
-		// Push the post
+		// Push the post.
 		$action = new Apple_Actions\Index\Push( $this->settings, $id );
 		try {
 			$action->perform();
 
-			// In async mode, success or failure will be displayed later
+			// In async mode, success or failure will be displayed later.
 			if ( 'yes' !== $this->settings->get( 'api_async' ) ) {
 				$this->notice_success( __( 'Your article has been pushed successfully!', 'apple-news' ) );
 			} else {
@@ -407,17 +407,17 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @access private
 	 */
 	private function reset_action( $id ) {
-		// Remove the pending designation if it exists
+		// Remove the pending designation if it exists.
 		delete_post_meta( $id, 'apple_news_api_pending' );
 
-		// Remove the async in progress flag
+		// Remove the async in progress flag.
 		delete_post_meta( $id, 'apple_news_api_async_in_progress' );
 
-		// Manually clean the workspace
+		// Manually clean the workspace.
 		$workspace = new Workspace( $id );
 		$workspace->clean_up();
 
-		// This can only succeed
+		// This can only succeed.
 		$this->notice_success( __( 'Your article status has been successfully reset!', 'apple-news' ) );
 	}
 

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -55,16 +55,16 @@ class Admin_Apple_JSON extends Apple_News {
 	 * @access public
 	 */
 	public function action_router() {
-		// Check for a valid action
+		// Check for a valid action.
 		$action	= isset( $_POST['apple_news_action'] ) ? sanitize_text_field( $_POST['apple_news_action'] ) : null;
 		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
 			return;
 		}
 
-		// Check the nonce
+		// Check the nonce.
 		check_admin_referer( 'apple_news_json' );
 
-		// Call the callback for the action for further processing
+		// Call the callback for the action for further processing.
 		call_user_func( $this->valid_actions[ $action ]['callback'] );
 	}
 
@@ -273,7 +273,7 @@ class Admin_Apple_JSON extends Apple_News {
 		// Keep track of which ones were updated.
 		$updates = array();
 		foreach ( $specs as $spec ) {
-			// Ensure the value exists
+			// Ensure the value exists.
 			$key = 'apple_news_json_' . $spec->key_from_name( $spec->name );
 			if ( isset( $_POST[ $key ] ) ) {
 				$custom_spec = stripslashes( sanitize_text_field( $_POST[ $key ] ) );
@@ -326,7 +326,7 @@ class Admin_Apple_JSON extends Apple_News {
 		$component_factory->initialize();
 		$components = $component_factory::get_components();
 
-		// Make this alphabetized and pretty
+		// Make this alphabetized and pretty.
 		$components_sanitized = array();
 		foreach ( $components as $component ) {
 			$component_key = str_replace( $this->namespace, '', $component );

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -32,12 +32,12 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	    parent::__construct();
 		$this->settings = $settings;
 
-		// Register hooks if enabled
+		// Register hooks if enabled.
 		if ( 'yes' === $settings->get( 'show_metabox' ) ) {
-			// Handle a publish action and saving fields
+			// Handle a publish action and saving fields.
 			add_action( 'save_post', array( $this, 'do_publish' ), 10, 2 );
 
-			// Add the custom meta boxes to each post type
+			// Add the custom meta boxes to each post type.
 			$post_types = $settings->get( 'post_types' );
 			if ( ! is_array( $post_types ) ) {
 				$post_types = array( $post_types );
@@ -47,7 +47,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 				add_action( 'add_meta_boxes_' . $post_type, array( $this, 'add_meta_boxes' ) );
 			}
 
-			// Register assets used by the meta box
+			// Register assets used by the meta box.
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_assets' ) );
 		}
 	}
@@ -67,16 +67,16 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			return;
 		}
 
-		// Check the nonce
+		// Check the nonce.
 		if ( ! wp_verify_nonce( $_POST['apple_news_nonce'], $this->publish_action ) ) {
 			return;
 		}
 
-		// Save meta box fields
+		// Save meta box fields.
 		$post_id = absint( $_POST['post_ID'] );
 		self::save_post_meta( $post_id );
 
-		// If this is set to autosync or no action is set, we're done here
+		// If this is set to autosync or no action is set, we're done here.
 		if ( 'yes' === $this->settings->get( 'api_autosync' )
 			|| 'publish' !== $post->post_status
 			|| empty( $_POST['apple_news_publish_action'] )
@@ -84,12 +84,12 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			return;
 		}
 
-		// Proceed with the push
+		// Proceed with the push.
 		$action = new Apple_Actions\Index\Push( $this->settings, $post_id );
 		try {
 			$action->perform();
 
-			// In async mode, success or failure will be displayed later
+			// In async mode, success or failure will be displayed later.
 			if ( 'yes' !== $this->settings->get( 'api_async' ) ) {
 				Admin_Apple_Notice::success( __( 'Your article has been pushed successfully to Apple News!', 'apple-news' ) );
 			} else {
@@ -181,7 +181,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access public
 	 */
 	public function add_meta_boxes( $post ) {
-		// Add the publish meta box
+		// Add the publish meta box.
 		add_meta_box(
 			'apple_news_publish',
 			__( 'Apple News', 'apple-news' ),

--- a/admin/class-admin-apple-news-list-table.php
+++ b/admin/class-admin-apple-news-list-table.php
@@ -36,10 +36,10 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @param Settings $settings
 	 */
 	function __construct( $settings ) {
-		// Load current settings
+		// Load current settings.
 		$this->settings = $settings;
 
-		// Initialize the table
+		// Initialize the table.
 		parent::__construct( array(
 			'singular' => __( 'article', 'apple-news' ),
 			'plural'   => __( 'articles', 'apple-news' ),
@@ -113,7 +113,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 		$remote_id = get_post_meta( $post->ID, 'apple_news_api_id', true );
 
 		if ( ! $remote_id ) {
-			// There is no remote id, check for a delete mark
+			// There is no remote id, check for a delete mark.
 			$deleted = get_post_meta( $post->ID, 'apple_news_api_deleted', true );
 			if ( $deleted ) {
 				return __( 'Deleted', 'apple-news' );
@@ -159,7 +159,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			return;
 		}
 
-		// Build the base URL
+		// Build the base URL.
 		$base_url = add_query_arg(
 			array(
 				'page' => $current_screen->parent_base,
@@ -168,7 +168,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			get_admin_url( null, 'admin.php' )
 		);
 
-		// Add common actions
+		// Add common actions.
 		$actions = array(
 			'export' => sprintf(
 				"<a href='%s'>%s</a>",
@@ -177,7 +177,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			),
 		);
 
-		// Only add push if the article is not pending publish
+		// Only add push if the article is not pending publish.
 		$pending = get_post_meta( $item->ID, 'apple_news_api_pending', true );
 		if ( empty( $pending ) ) {
 			$actions['push'] = sprintf(
@@ -196,7 +196,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			);
 		}
 
-		// Add the delete action, if required
+		// Add the delete action, if required.
 		if ( get_post_meta( $item->ID, 'apple_news_api_id', true ) ) {
 			$actions['delete'] = sprintf(
 				"<a title='%s' href='%s' class='delete-button'>%s</a>",
@@ -206,7 +206,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			);
 		}
 
-		// Create the share URL
+		// Create the share URL.
 		$share_url = get_post_meta( $item->ID, 'apple_news_api_share_url', true );
 		if ( $share_url ) {
 			$actions['share'] = sprintf(
@@ -218,11 +218,11 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			);
 		}
 
-		// Return the row action HTML
+		// Return the row action HTML.
 		return apply_filters( 'apple_news_column_title', sprintf( '%1$s <span>(id:%2$s)</span> %3$s',
 			esc_html( $item->post_title ),
 			absint( $item->ID ),
-			$this->row_actions( $actions ) // can't be escaped but all elements are fully escaped above
+			$this->row_actions( $actions ) // Can't be escaped but all elements are fully escaped above.
 		), $item, $actions );
 	}
 
@@ -256,7 +256,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access public
 	 */
 	public function column_cb( $item ) {
-		// Omit if the article is pending publish
+		// Omit if the article is pending publish.
 		$pending = get_post_meta( $item->ID, 'apple_news_api_pending', true );
 		if ( ! empty( $pending ) ) {
 			return '';
@@ -286,12 +286,14 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access public
 	 */
 	public function prepare_items() {
-		// Set column headers. It expects an array of columns, and as second
-		// argument an array of hidden columns, which in this case is empty.
+		/**
+		 * Set column headers. It expects an array of columns, and as second
+		 * argument an array of hidden columns, which in this case is empty.
+		 */
 		$columns = $this->get_columns();
 		$this->_column_headers = array( $columns, array(), array() );
 
-		// Build the default args for the query
+		// Build the default args for the query.
 		$current_page = $this->get_pagenum();
 		$args = array(
 			'post_type'     => $this->settings->get( 'post_types' ),
@@ -302,7 +304,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			'order'          => 'DESC',
 		);
 
-		// Add the publish status filter if set
+		// Add the publish status filter if set.
 		$publish_status = $this->get_publish_status_filter();
 		if ( ! empty( $publish_status ) ) {
 			switch ( $publish_status ) {
@@ -355,7 +357,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			}
 		}
 
-		// Add the date filters if set
+		// Add the date filters if set.
 		$date_from = $this->get_date_from_filter();
 		$date_to = $this->get_date_to_filter();
 		if ( ! empty( $date_from ) || ! empty( $date_to ) ) {
@@ -374,16 +376,16 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			}
 		}
 
-		// Add the search filter if set
+		// Add the search filter if set.
 		$search = $this->get_search_filter();
 		if ( ! empty( $search ) ) {
 			$args['s'] = $search;
 		}
 
-		// Data fetch
+		// Data fetch.
 		$query = new WP_Query( apply_filters( 'apple_news_export_table_get_posts_args', $args ) );
 
-		// Set data
+		// Set data.
 		$this->items = $query->posts;
 		$total_items = $query->found_posts;
 		$this->set_pagination_args( apply_filters( 'apple_news_export_table_pagination_args', array(
@@ -400,20 +402,20 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access protected
 	 */
 	protected function extra_tablenav( $which ) {
-		// Only display on the top of the table
+		// Only display on the top of the table.
 		if ( 'top' !== $which ) {
 			return;
 		}
 		?>
 		<div class="alignleft actions">
 		<?php
-		// Add a publish state filter
+		// Add a publish state filter.
 		$this->publish_status_filter_field();
 
-		// Add a dange range filter
+		// Add a dange range filter.
 		$this->date_range_filter_field();
 
-		// Allow for further options to be added within themes and plugins
+		// Allow for further options to be added within themes and plugins.
 		do_action( 'apple_news_extra_tablenav' );
 
 		submit_button( __( 'Filter', 'apple-news' ), 'button', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
@@ -468,7 +470,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access protected
 	 */
 	protected function publish_status_filter_field() {
-		// Add available statuses
+		// Add available statuses.
 		$publish_statuses = apply_filters( 'apple_news_publish_statuses', array(
 			'' => __( 'Show All Statuses', 'apple-news' ),
 			'published' => __( 'Published', 'apple-news' ),
@@ -477,7 +479,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 			'deleted' => __( 'Deleted', 'apple-news' ),
 		) );
 
-		// Build the dropdown
+		// Build the dropdown.
 		?>
 		<select name="apple_news_publish_status" id="apple_news_publish_status">
 		<?php

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -34,46 +34,48 @@ class Admin_Apple_News extends Apple_News {
 	 * Constructor.
 	 */
 	function __construct() {
-		// Register hooks
+		// Register hooks.
 		add_action( 'admin_print_styles-toplevel_page_apple_news_index', array( $this, 'plugin_styles' ) );
 		add_action( 'init', array( $this, 'action_init' ) );
 
-		// Admin_Settings builds the settings page for the plugin. Besides setting
-		// it up, let's get the settings getter and setter object and save it into
-		// $settings.
+		/**
+		 * Admin_Settings builds the settings page for the plugin. Besides setting
+		 * it up, let's get the settings getter and setter object and save it into
+		 * $settings.
+		 */
 		$admin_settings = new Admin_Apple_Settings;
 		self::$settings = $admin_settings->fetch_settings();
 
-		// Initialize notice messaging utility
+		// Initialize notice messaging utility.
 		add_action( 'admin_enqueue_scripts', 'Admin_Apple_Notice::register_assets' );
 		add_action( 'admin_notices', 'Admin_Apple_Notice::show' );
 		add_action( 'wp_ajax_apple_news_dismiss_notice', 'Admin_Apple_Notice::wp_ajax_dismiss_notice' );
 
-		// Set up main page
+		// Set up main page.
 		new Admin_Apple_Index_Page( self::$settings );
 
-		// Set up all sub pages
+		// Set up all sub pages.
 		new Admin_Apple_Bulk_Export_Page( self::$settings );
 
-		// Set up posts syncing if enabled in the settings
+		// Set up posts syncing if enabled in the settings.
 		new Admin_Apple_Post_Sync( self::$settings );
 
-		// Set up the publish meta box if enabled in the settings
+		// Set up the publish meta box if enabled in the settings.
 		new Admin_Apple_Meta_Boxes( self::$settings );
 
-		// Set up asynchronous publishing features
+		// Set up asynchronous publishing features.
 		new Admin_Apple_Async( self::$settings );
 
-		// Add section support
+		// Add section support.
 		new Admin_Apple_Sections( self::$settings );
 
-		// Add theme support
+		// Add theme support.
 		new Admin_Apple_Themes();
 
-		// Add preview support
+		// Add preview support.
 		new Admin_Apple_Preview();
 
-		// Add JSON customization support
+		// Add JSON customization support.
 		new Admin_Apple_JSON();
 	}
 
@@ -233,7 +235,7 @@ class Admin_Apple_News extends Apple_News {
 		echo '<style type="text/css">';
 		echo '.wp-list-table .column-sync { width: 15%; }';
 		echo '.wp-list-table .column-updated_at { width: 15%; }';
-		// Clipboard fix
+		// Clipboard fix.
 		echo '.row-actions.is-active { visibility: visible }';
 		echo '</style>';
 	}

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -23,9 +23,11 @@ class Admin_Apple_Post_Sync {
 	 * Constructor.
 	 */
 	function __construct( $settings = null ) {
-		// Don't re-fetch settings if they've been previously obtained.
-		// However, this class may be used within themes and therefore may
-		// need to get it's own settings.
+		/**
+		 * Don't re-fetch settings if they've been previously obtained.
+		 * However, this class may be used within themes and therefore may
+		 * need to get its own settings.
+		 */
 		if ( ! empty( $settings ) ) {
 			$this->settings = $settings;
 		} else {
@@ -76,7 +78,7 @@ class Admin_Apple_Post_Sync {
 			return;
 		}
 
-		// Proceed with the push
+		// Proceed with the push.
 		$action = new Apple_Actions\Index\Push( $this->settings, $id );
 		try {
 			$action->perform();
@@ -100,7 +102,7 @@ class Admin_Apple_Post_Sync {
 			return;
 		}
 
-		// If it does not have a remote API ID just ignore
+		// If it does not have a remote API ID just ignore.
 		if ( ! get_post_meta( $id, 'apple_news_api_id', true ) ) {
 			return;
 		}

--- a/admin/class-admin-apple-preview.php
+++ b/admin/class-admin-apple-preview.php
@@ -48,7 +48,7 @@ class Admin_Apple_Preview extends Apple_News {
 		?>
 		<div class="apple-news-preview">
 			<?php
-				// Build sample content
+				// Build sample content.
 				$title = sprintf(
 					'<h1 class="apple-news-title apple-news-component apple-news-meta-component">%s</h1>',
 					__( 'Sample Article', 'apple-news' )

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -456,7 +456,7 @@ class Admin_Apple_Sections extends Apple_News {
 				}
 			}
 
-			// Determine if there is theme data for this section
+			// Determine if there is theme data for this section.
 			$theme_key = 'theme-mapping-' . $section_id;
 			if ( ! empty( $_POST[ $theme_key ] ) ) {
 				$theme_mappings[ $section_id ] = sanitize_text_field( $_POST[ $theme_key ] );

--- a/admin/partials/index.php
+++ b/admin/partials/index.php
@@ -1,1 +1,1 @@
-<?php // Silence is golden
+<?php // Silence is golden.

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -21,10 +21,10 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 	 * @param string $page
 	 */
 	function __construct( $page ) {
-		// Set the name
+		// Set the name.
 		$this->name =  __( 'Advanced Settings', 'apple-news' );
 
-		// Add the settings
+		// Add the settings.
 		$this->settings = array(
 			'component_alerts' => array(
 				'label'   => __( 'Component Alerts', 'apple-news' ),
@@ -63,7 +63,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			),
 		);
 
-		// Add the groups
+		// Add the groups.
 		$this->groups = array(
 			'alerts' => array(
 				'label'       => __( 'Alerts', 'apple-news' ),

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -21,10 +21,10 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 	 * @param string $page
 	 */
 	function __construct( $page ) {
-		// Set the name
+		// Set the name.
 		$this->name =  __( 'API Settings', 'apple-news' );
 
-		// Add the settings
+		// Add the settings.
 		$this->settings = array(
 			'api_channel' => array(
 				'label'   => __( 'Channel ID', 'apple-news' ),
@@ -57,7 +57,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 			),
 		);
 
-		// Add the groups
+		// Add the groups.
 		$this->groups = array(
 			'apple_news' => array(
 				'label'       => __( 'Apple News API', 'apple-news' ),

--- a/admin/settings/class-admin-apple-settings-section-post-types.php
+++ b/admin/settings/class-admin-apple-settings-section-post-types.php
@@ -21,10 +21,10 @@ class Admin_Apple_Settings_Section_Post_Types extends Admin_Apple_Settings_Secti
 	 * @param string $page
 	 */
 	function __construct( $page ) {
-		// Set the name
+		// Set the name.
 		$this->name =  __( 'Post Type Options', 'apple-news' );
 
-		// Add the settings
+		// Add the settings.
 		$this->settings = array(
 			'show_metabox' => array(
 				'label'   => __( 'Show a publish meta box on post types that have Apple News enabled.', 'apple-news' ),
@@ -32,7 +32,7 @@ class Admin_Apple_Settings_Section_Post_Types extends Admin_Apple_Settings_Secti
 			),
 		);
 
-		// Build the post types to display
+		// Build the post types to display.
 		$post_types = apply_filters( 'apple_news_post_types', get_post_types( array(
 			'public' => true,
 			'show_ui' => true,
@@ -52,7 +52,7 @@ class Admin_Apple_Settings_Section_Post_Types extends Admin_Apple_Settings_Secti
 			);
 		}
 
-		// Add the groups
+		// Add the groups.
 		$this->groups = array(
 			'post_type_settings' => array(
 				'label'       => __( 'Post Types', 'apple-news' ),

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -168,7 +168,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		$this->groups = apply_filters( 'apple_news_section_groups', $this->groups, $page );
 		$this->hidden = $hidden;
 
-		// Save settings if necessary
+		// Save settings if necessary.
 		$this->save_settings();
 	}
 
@@ -239,24 +239,26 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		$value = self::get_value( $name, self::$loaded_settings );
 		$field = null;
 
-		// Get the field size
+		// Get the field size.
 		$size = $this->get_size_for( $name );
 
-		// FIXME: A cleaner object-oriented solution would create Input objects
-		// and instantiate them according to their type.
+		/**
+		 * TODO: A cleaner object-oriented solution would create Input objects
+		 * and instantiate them according to their type.
+		 */
 		if ( is_array( $type ) ) {
-			// Check if this is a multiple select
+			// Check if this is a multiple select.
 			$multiple_name = $multiple_attr = '';
 			if ( $this->is_multiple( $name ) ) {
 				$multiple_name = '[]';
 				$multiple_attr = 'multiple="multiple"';
 			}
 
-			// Check if we're using names as values
+			// Check if we're using names as values.
 			$keys = array_keys( $type );
 			$use_name_as_value = ( array_keys( $keys ) === $keys );
 
-			// Use select2 only when there is a considerable ammount of options available
+			// Use select2 only when there is a considerable amount of options available.
 			if ( count( $type ) > 10 ) {
 				$field = '<select class="select2 standard" id="%s" name="%s' . $multiple_name . '" ' . $multiple_attr . '>';
 			} else {
@@ -291,7 +293,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field .= apply_filters( 'apple_news_field_description_output_html', '<br/><i>' . $description . '</i>', $name );
 		}
 
-		// Use the proper template to build the field
+		// Use the proper template to build the field.
 		if ( is_array( $type ) ) {
 			return sprintf(
 				$field,
@@ -478,22 +480,24 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 * since only it knows the nature of the fields and sanitization methods.
 	 */
 	public function save_settings() {
-		// Check if we're saving options and that there are settings to save
+		// Check if we're saving options and that there are settings to save.
 		if ( empty( $_POST['action'] )
 			|| $this->save_action !== $_POST['action']
 			|| empty( $this->settings ) ) {
 			return;
 		}
 
-		// Form nonce check
+		// Form nonce check.
 		check_admin_referer( $this->save_action );
 
-		// Get the current Apple News settings
+		// Get the current Apple News settings.
 		$settings = get_option( self::$section_option_name, array() );
 
-		// Iterate over the settings and save each value.
-		// Settings can't be empty unless allowed, so if no value is found
-		// use the default value to be safe.
+		/**
+		 * Iterate over the settings and save each value.
+		 * Settings can't be empty unless allowed, so if no value is found
+		 * use the default value to be safe.
+		 */
 		$default_settings = new Settings();
 		foreach ( $this->settings as $key => $attributes ) {
 			if ( ! empty( $_POST[ $key ] )
@@ -501,22 +505,22 @@ class Admin_Apple_Settings_Section extends Apple_News {
 					&& in_array( $_POST[ $key ], array( 0, '0' ), true )
 				)
 			) {
-				// Sanitize the value
+				// Sanitize the value.
 				$sanitize = ( empty( $attributes['sanitize'] ) || ! is_callable( $attributes['sanitize'] ) ) ? 'sanitize_text_field' : $attributes['sanitize'];
 				$value = call_user_func( $sanitize, $_POST[ $key ] );
 			} else {
-				// Use the default value
+				// Use the default value.
 				$value = $default_settings->$key;
 			}
 
-			// Add to the array
+			// Add to the array.
 			$settings[ $key ] = $value;
 		}
 
-		// Clear certain caches
+		// Clear certain caches.
 		delete_transient( 'apple_news_sections' );
 
-		// Save to options
+		// Save to options.
 		update_option( self::$section_option_name, $settings, 'no' );
 	}
 }

--- a/apple-news.php
+++ b/apple-news.php
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Activate the plugin.
  */
 function apple_news_activate_wp_plugin() {
-	// Check for PHP version
+	// Check for PHP version.
 	if ( version_compare( PHP_VERSION, '5.3.6' ) < 0 ) {
 		deactivate_plugins( basename( __FILE__ ) );
 		wp_die( esc_html__( 'This plugin requires at least PHP 5.3.6', 'apple-news' ) );
@@ -40,7 +40,6 @@ require plugin_dir_path( __FILE__ ) . 'includes/apple-exporter/class-settings.ph
  * Deactivate the plugin.
  */
 function apple_news_uninstall_wp_plugin() {
-	// Do something
 	$settings = new Apple_Exporter\Settings;
 	foreach ( $settings->all() as $name => $value ) {
 		delete_option( $name );
@@ -53,7 +52,7 @@ if ( ! defined( 'WPCOM_IS_VIP_ENV' ) || ! WPCOM_IS_VIP_ENV ) {
 	register_uninstall_hook( __FILE__, 'apple_news_uninstall_wp_plugin' );
 }
 
-// Initialize plugin class
+// Initialize plugin class.
 require plugin_dir_path( __FILE__ ) . 'includes/class-apple-news.php';
 require plugin_dir_path( __FILE__ ) . 'admin/class-admin-apple-news.php';
 

--- a/includes/apple-exporter/builders/class-component-layouts.php
+++ b/includes/apple-exporter/builders/class-component-layouts.php
@@ -93,9 +93,11 @@ class Component_Layouts extends Builder {
 			$position = 'right';
 			break;
 		case Component::ANCHOR_AUTO:
-			// The alignment position is the opposite of the body_orientation
-			// setting. In the case of centered body orientation, use left alignment.
-			// This behaviour was chosen by design.
+			/**
+			 * The alignment position is the opposite of the body_orientation
+			 * setting. In the case of centered body orientation, use left alignment.
+			 * This behaviour was chosen by design.
+			 */
 			if ( 'left' === $theme->get_value( 'body_orientation' ) ) {
 				$position = 'right';
 			} else {
@@ -115,8 +117,10 @@ class Component_Layouts extends Builder {
 			$body_column_span = $theme->get_body_column_span();
 			$layout_columns = $theme->get_layout_columns();
 
-			// Find out the starting column. This is easy enough if we are anchoring
-			// left, but for right side alignment, we have to make some math :)
+			/**
+			 * Find out the starting column. This is easy enough if we are anchoring
+			 * left, but for right side alignment, we have to make some math :)
+			 */
 			$col_start = $body_offset;
 			if ( 'right' === $position ) {
 				if ( $component->is_anchor_target() ) {
@@ -130,9 +134,11 @@ class Component_Layouts extends Builder {
 				$col_start = 0;
 			}
 
-			// Find the column span. For the target element, let's use the same
-			// column span as the Body component, that is, 5 columns, minus the
-			// defined offset. The element to be anchored uses the remaining space.
+			/**
+			 * Find the column span. For the target element, let's use the same
+			 * column span as the Body component, that is, 5 columns, minus the
+			 * defined offset. The element to be anchored uses the remaining space.
+			 */
 			$col_span = 0;
 			if ( $component->is_anchor_target() ) {
 				$col_span = $body_column_span - $alignment_offset;
@@ -140,7 +146,7 @@ class Component_Layouts extends Builder {
 				$col_span = $alignment_offset;
 			}
 
-			// Finally, register the layout
+			// Finally, register the layout.
 			$this->register_layout( $layout_name, array(
 				'columnStart' => $col_start,
 				'columnSpan'  => $col_span,

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -54,11 +54,13 @@ class Components extends Builder {
 			$components[] = $component_array;
 		}
 
-		// Process meta components.
-		//
-		// Meta components are handled after the body and then prepended, since they
-		// could change depending on the above body processing, such as if a
-		// thumbnail was used from the body.
+		/**
+		 * Process meta components.
+		 *
+		 * Meta components are handled after the body and then prepended, since they
+		 * could change depending on the above body processing, such as if a
+		 * thumbnail was used from the body.
+		 */
 		$components = array_merge( $this->_meta_components(), $components );
 
 		// Group body components to improve text flow at all orientations.
@@ -160,11 +162,13 @@ class Components extends Builder {
 				return;
 			}
 
-			// Isolate the bundle URL basename
+			// Isolate the bundle URL basename.
 			$bundle_basename = str_replace( 'bundle://', '', $json_url );
 
-			// We need to find the original URL from the bundle meta because it's
-			// needed in order to override the thumbnail.
+			/**
+			 * We need to find the original URL from the bundle meta because it's
+			 * needed in order to override the thumbnail.
+			 */
 			$workspace = new Workspace( $this->content_id() );
 			$bundles = $workspace->get_bundles();
 
@@ -227,8 +231,10 @@ class Components extends Builder {
 				continue;
 			}
 
-			// Anchor this component to the next component. If there is no next
-			// component available, try with the previous one.
+			/**
+			 * Anchor this component to the next component. If there is no next
+			 * component available, try with the previous one.
+			 */
 			if ( ! empty( $components[ $i + 1 ] ) ) {
 				$target_component = $components[ $i + 1 ];
 			} else {
@@ -306,9 +312,11 @@ class Components extends Builder {
 			);
 		}
 
-		// Regardless of what the component class specifies, add the
-		// targetComponentIdentifier here. There's no way for the class to know what
-		// this is before this point.
+		/**
+		 * Regardless of what the component class specifies, add the
+		 * targetComponentIdentifier here. There's no way for the class to know what
+		 * this is before this point.
+		 */
 		$anchor_json['targetComponentIdentifier'] = $target_component->uid();
 
 		// Add the JSON back to the component.
@@ -323,10 +331,12 @@ class Components extends Builder {
 			$other_position = Component::ANCHOR_RIGHT;
 		}
 
-		// The anchor method adds the required layout, thus making the actual
-		// anchoring. This must be called after using the UID, because we need to
-		// distinguish target components from anchor ones and components with
-		// UIDs are always anchor targets.
+		/**
+		 * The anchor method adds the required layout, thus making the actual
+		 * anchoring. This must be called after using the UID, because we need to
+		 * distinguish target components from anchor ones and components with
+		 * UIDs are always anchor targets.
+		 */
 		$target_component->set_anchor_position( $other_position );
 		$target_component->anchor();
 		$component->anchor();
@@ -631,8 +641,10 @@ class Components extends Builder {
 			return $new_components;
 		}
 
-		// All components after the cover must be grouped to avoid issues with
-		// parallax text scroll.
+		/**
+		 * All components after the cover must be grouped to avoid issues with
+		 * parallax text scroll.
+		 */
 		$regrouped_components = array(
 			'role' => 'container',
 			'layout' => array(
@@ -712,8 +724,10 @@ class Components extends Builder {
 	 */
 	private function _split_into_components() {
 
-		// Loop though the first-level nodes of the body element. Components might
-		// include child-components, like an Cover and Image.
+		/**
+		 * Loop though the first-level nodes of the body element. Components might
+		 * include child-components, like an Cover and Image.
+		 */
 		$components = array();
 		foreach ( $this->content_nodes() as $node ) {
 			$components = array_merge(

--- a/includes/apple-exporter/builders/class-layout.php
+++ b/includes/apple-exporter/builders/class-layout.php
@@ -24,8 +24,8 @@ class Layout extends Builder {
 		return apply_filters( 'apple_news_layout', array(
 			'columns' => intval( $theme->get_layout_columns() ),
 			'width' => intval( $theme->get_value( 'layout_width' ) ),
-			'margin' => intval( $theme->get_value( 'layout_margin' ) ),  // Defaults to 100
-			'gutter' => intval( $theme->get_value( 'layout_gutter' ) ),  // Defaults to 20
+			'margin' => intval( $theme->get_value( 'layout_margin' ) ),  // Defaults to 100.
+			'gutter' => intval( $theme->get_value( 'layout_gutter' ) ),  // Defaults to 20.
 		), $this->content_id() );
 	}
 

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -20,8 +20,10 @@ class Metadata extends Builder {
 	protected function build() {
 		$meta = array();
 
-		// The content's intro is optional. In WordPress, it's a post's
-		// excerpt. It's an introduction to the article.
+		/**
+		 * The content's intro is optional. In WordPress, it's a post's
+		 * excerpt. It's an introduction to the article.
+		 */
 		if ( $this->content_intro() ) {
 			$meta['excerpt'] = $this->content_intro();
 		}
@@ -33,9 +35,11 @@ class Metadata extends Builder {
 			);
 		}
 
-		// Add date fields.
-		// We need to get the WordPress post for this
-		// since the date functions are inconsistent.
+		/**
+		 * Add date fields.
+		 * We need to get the WordPress post for this
+		 * since the date functions are inconsistent.
+		 */
 		$post = get_post( $this->content_id() );
 		if ( ! empty( $post ) ) {
 			$post_date = date( 'c', strtotime( get_gmt_from_date( $post->post_date ) ) );
@@ -49,10 +53,10 @@ class Metadata extends Builder {
 		// Add canonical URL.
 		$meta['canonicalURL'] = get_permalink( $this->content_id() );
 
-		// Add plugin information to the generator metadata
+		// Add plugin information to the generator metadata.
 		$plugin_data = apple_news_get_plugin_data();
 
-		// Add generator information
+		// Add generator information.
 		$meta['generatorIdentifier'] = sanitize_title_with_dashes( $plugin_data['Name'] );
 		$meta['generatorName'] = $plugin_data['Name'];
 		$meta['generatorVersion'] = $plugin_data['Version'];

--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -81,14 +81,14 @@ class Component_Factory {
 		self::register_component( 'ul', '\\Apple_Exporter\\Components\\Body' );
 		self::register_component( 'pre', '\\Apple_Exporter\\Components\\Body' );
 		self::register_component( 'hr', '\\Apple_Exporter\\Components\\Divider' );
-		// Non HTML-based components
+		// Non HTML-based components.
 		self::register_component( 'intro', '\\Apple_Exporter\\Components\\Intro' );
 		self::register_component( 'cover', '\\Apple_Exporter\\Components\\Cover' );
 		self::register_component( 'title', '\\Apple_Exporter\\Components\\Title' );
 		self::register_component( 'byline', '\\Apple_Exporter\\Components\\Byline' );
 		self::register_component( 'advertisement', '\\Apple_Exporter\\Components\\Advertisement' );
 
-		// Allow built-in components and order to be overridden
+		// Allow built-in components and order to be overridden.
 		self::$components = apply_filters( 'apple_news_initialize_components', self::$components );
 	}
 
@@ -150,9 +150,11 @@ class Component_Factory {
 				continue;
 			}
 
-			// Did we match several components? If so, a hash is returned. Both the
-			// body and heading components can returns this, in the case they find
-			// non-markdown-able elements inside.
+			/**
+			 * Did we match several components? If so, a hash is returned. Both the
+			 * body and heading components can returns this, in the case they find
+			 * non-markdown-able elements inside.
+			 */
 			if ( is_array( $matched_node ) ) {
 				foreach ( $matched_node as $base_component ) {
 					$result[] = self::get_component( $base_component['name'], $base_component['value'] );
@@ -161,7 +163,7 @@ class Component_Factory {
 				return $result;
 			}
 
-			// We matched a single node
+			// We matched a single node.
 			$html = $node->ownerDocument->saveXML( $matched_node );
 			$result[] = self::get_component( $shortname, $html );
 			return $result;
@@ -172,14 +174,16 @@ class Component_Factory {
 			foreach ( $node->childNodes as $child ) {
 				$result = array_merge( $result, self::get_components_from_node( $child, $node ) );
 			}
-			// Remove all nulls from the array
+			// Remove all nulls from the array.
 			$result = array_filter( $result );
 		}
 
-		// If nothing was found, log this as a component error by recording the node name.
-		// Only record components with a tagName since otherwise there is nothing to report.
-		// Others nodes without a match are almost always just stray empty text nodes
-		// that are always safe to remove. Paragraphs should also be ignored for this reason.
+		/**
+		 * If nothing was found, log this as a component error by recording the node name.
+		 * Only record components with a tagName since otherwise there is nothing to report.
+		 * Others nodes without a match are almost always just stray empty text nodes
+		 * that are always safe to remove. Paragraphs should also be ignored for this reason.
+		 */
 		if ( empty( $result ) && ( ! empty( $node->tagName ) && 'p' !== $node->tagName ) ) {
 			self::$workspace->log_error( 'component_errors', $node->tagName );
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -214,7 +214,7 @@ class Exporter {
 			$this->content_id()
 		);
 
-		// Base JSON
+		// Base JSON.
 		$json = array(
 			'version'    => '1.7',
 			'identifier' => 'post-' . $this->content_id(),
@@ -222,7 +222,7 @@ class Exporter {
 			'title'      => wp_strip_all_tags( $this->content_title() ),
 		);
 
-		// Builders
+		// Builders.
 		$json['documentStyle'] = $this->build_article_style();
 		foreach ( $this->builders as $name => $builder ) {
 			$arr = $builder->to_array();

--- a/includes/apple-exporter/class-parser.php
+++ b/includes/apple-exporter/class-parser.php
@@ -58,9 +58,11 @@ class Parser {
 			return '';
 		}
 
-		// Clean up any issues prior to formatting.
-		// This needs to be done here to avoid duplicating efforts
-		// in the HTML and Markdown classes.
+		/**
+		 * Clean up any issues prior to formatting.
+		 * This needs to be done here to avoid duplicating efforts
+		 * in the HTML and Markdown classes.
+		 */
 		$html = $this->_clean_html( $html );
 
 		// Fork for format.

--- a/includes/apple-exporter/class-workspace.php
+++ b/includes/apple-exporter/class-workspace.php
@@ -89,9 +89,11 @@ class Workspace {
 	public function write_json( $content ) {
 		$json = apply_filters( 'apple_news_write_json', $content, $this->content_id );
 
-		// JSON should be decoded before being stored.
-		// Otherwise, stripslashes_deep could potentially remove valid characters
-		// such as newlines (\n).s
+		/**
+		 * JSON should be decoded before being stored.
+		 * Otherwise, stripslashes_deep could potentially remove valid characters
+		 * such as newlines (\n).
+		 */
 		$decoded_json = json_decode( $json );
 		if ( null === $decoded_json ) {
 			// This is invalid JSON.
@@ -133,23 +135,23 @@ class Workspace {
 	 * @since 1.0.6
 	 */
 	public function log_error( $key, $value ) {
-		// Get current errors
+		// Get current errors.
 		$errors = get_post_meta( $this->content_id, self::ERRORS_META_KEY, true );
 
-		// Initialize if needed
+		// Initialize if needed.
 		if ( empty( $errors ) ) {
 			$errors = array();
 		}
 
-		// Initialize the key if needed
+		// Initialize the key if needed.
 		if ( empty( $errors[ $key ] ) ) {
 			$errors[ $key ] = array();
 		}
 
-		// Log the error
+		// Log the error.
 		$errors[ $key ][] = $value;
 
-		// Save the errors
+		// Save the errors.
 		update_post_meta( $this->content_id, self::ERRORS_META_KEY, $errors );
 	}
 

--- a/includes/apple-exporter/components/class-audio.php
+++ b/includes/apple-exporter/components/class-audio.php
@@ -49,7 +49,7 @@ class Audio extends Component {
 	 * @access protected
 	 */
 	protected function build( $text ) {
-		// Remove initial and trailing tags: <video><p>...</p></video>
+		// Remove initial and trailing tags: <video><p>...</p></video>.
 		if ( ! preg_match( '/src="([^"]+)"/', $text, $match ) ) {
 			return null;
 		}

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -35,7 +35,7 @@ class Body extends Component {
 	 * @return array|null An array of matching HTML on success, or null on no match.
 	 */
 	public static function node_matches( $node ) {
-		// We are only interested in p, pre, ul and ol
+		// We are only interested in p, pre, ul and ol.
 		if ( ! in_array( $node->nodeName, array( 'p', 'pre', 'ul', 'ol' ), true ) ) {
 			return null;
 		}

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -186,7 +186,7 @@ abstract class Component {
 	 * @param Parser $parser
 	 */
 	function __construct( $text = null, $workspace = null, $settings = null, $styles = null, $layouts = null, $parser = null ) {
-		// Register specs for this component
+		// Register specs for this component.
 		$this->register_specs();
 
 		// If all params are null, then this was just used to get spec data.
@@ -402,9 +402,6 @@ abstract class Component {
 		$this->workspace->bundle_source( $filename, $source );
 	}
 
-	// Isolate settings dependency
-	// -------------------------------------------------------------------------
-
 	/**
 	 * Gets an exporter setting.
 	 *
@@ -471,7 +468,7 @@ abstract class Component {
 	 * @access protected
 	 */
 	protected function register_spec( $name, $label, $spec ) {
-		// Store as a multidimensional array with the label and spec, indexed by name
+		// Store as a multidimensional array with the label and spec, indexed by name.
 		$this->specs[ $name ] = new Component_Spec( $this->get_component_name(), $name, $label, $spec );
 	}
 
@@ -570,7 +567,7 @@ abstract class Component {
 		// Get information about the currently loaded theme.
 		$theme = \Apple_Exporter\Theme::get_used();
 
-		// Initial colStart and colSpan
+		// Initial colStart and colSpan.
 		$col_start = 0;
 		$col_span  = $theme->get_layout_columns();
 
@@ -580,10 +577,12 @@ abstract class Component {
 			$col_span = $theme->get_body_column_span();
 		}
 
-		// Merge this into the existing spec.
-		// These values just get hardcoded in the spec since the above logic
-		// would make them impossible to override manually.
-		// Changes to this should really be handled by the above plugin settings.
+		/**
+		 * Merge this into the existing spec.
+		 * These values just get hardcoded in the spec since the above logic
+		 * would make them impossible to override manually.
+		 * Changes to this should really be handled by the above plugin settings.
+		 */
 		if ( isset( $this->specs[ $spec_name ] ) ) {
 			$this->specs[ $spec_name ]->spec = array_merge(
 				$this->specs[ $spec_name ]->spec,
@@ -594,7 +593,7 @@ abstract class Component {
 			);
 		}
 
-		// Register the layout as normal
+		// Register the layout as normal.
 		$this->register_layout( $name, $spec_name, $values, $property );
 	}
 

--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -137,7 +137,7 @@ class Gallery extends Component {
 			return;
 		}
 
-		// Build the JSON
+		// Build the JSON.
 		$this->register_json(
 			'json',
 			array(

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -114,7 +114,7 @@ class Heading extends Component {
 			return array();
 		}
 
-		// Find the first image inside
+		// Find the first image inside.
 		preg_match( '#<img.*?>#si', $html, $matches );
 
 		if ( ! $matches ) {
@@ -142,10 +142,12 @@ class Heading extends Component {
 		}
 
 		$level = intval( $matches[1] );
-		// We won't be using markdown*, so we ignore all HTML tags, just fetch the
-		// contents.
-		// *: No markdown because the apple format doesn't support markdown with
-		// textStyle in headings.
+		/**
+		 * We won't be using markdown*, so we ignore all HTML tags, just fetch the
+		 * contents.
+		 * *: No markdown because the apple format doesn't support markdown with
+		 * textStyle in headings.
+		 */
 		$text = wp_strip_all_tags( $matches[2] );
 
 		// Parse and trim the resultant text, and if there is nothing left, bail.

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -163,7 +163,7 @@ class Image extends Component {
 			$this->set_anchor_position( Component::ANCHOR_NONE );
 		}
 
-		// Check for caption
+		// Check for caption.
 		if ( preg_match( '#<figcaption.*?>(.*?)</figcaption>#m', $text, $matches ) ) {
 			$caption = trim( $matches[1] );
 			$values['#caption#'] = $caption;
@@ -173,16 +173,18 @@ class Image extends Component {
 			$spec_name = 'json-without-caption';
 		}
 
-		// Full width images have top margin
-		// We can't use the standard layout registration due to grouping components
-		// with images so instead, send it through as a value.
+		/**
+		 * Full width images have top margin
+		 * We can't use the standard layout registration due to grouping components
+		 * with images so instead, send it through as a value.
+		 */
 		if ( Component::ANCHOR_NONE === $this->get_anchor_position() ) {
 			$values = $this->register_non_anchor_layout( $values );
 		} else {
 			$values = $this->register_anchor_layout( $values );
 		}
 
-		// Register the JSON
+		// Register the JSON.
 		$this->register_json( $spec_name, $values );
 	}
 
@@ -215,7 +217,7 @@ class Image extends Component {
 		// Get information about the currently loaded theme.
 		$theme = \Apple_Exporter\Theme::get_used();
 
-		// Set values to merge into the spec
+		// Set values to merge into the spec.
 		$layout_values = array();
 
 		if ( 'yes' === $this->get_setting( 'full_bleed_images' ) ) {

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -379,7 +379,7 @@ class Quote extends Component {
 			$spec_name = 'pullquote-without-border-json';
 		}
 
-		// Register the JSON
+		// Register the JSON.
 		$this->register_json( $spec_name, $values );
 
 		// Set component attributes.

--- a/includes/apple-exporter/components/class-tweet.php
+++ b/includes/apple-exporter/components/class-tweet.php
@@ -17,7 +17,7 @@ class Tweet extends Component {
 	 * @access public
 	 */
 	public static function node_matches( $node ) {
-		// Check if the body of a node is solely a tweet URL
+		// Check if the body of a node is solely a tweet URL.
 		$is_twitter_url = $node->nodeName === 'p' && preg_match(
 			'#https?://(www\.)?twitter\.com/.+?/status(es)?/.*#i',
 			trim( $node->nodeValue ) );

--- a/includes/apple-exporter/third-party/class-jetpack-tiled-gallery.php
+++ b/includes/apple-exporter/third-party/class-jetpack-tiled-gallery.php
@@ -51,8 +51,10 @@ class Jetpack_Tiled_Gallery {
 			return;
 		}
 
-		// Allow default rendering of gallery since we have
-		// builtin handling for the default WP galleries.
+		/**
+		 * Allow default rendering of gallery since we have
+		 * builtin handling for the default WP galleries.
+		 */
 		add_filter( 'jetpack_tiled_gallery_types', function() {
 			return array();
 		} );

--- a/includes/apple-push-api/class-api.php
+++ b/includes/apple-push-api/class-api.php
@@ -77,7 +77,7 @@ class API {
 	public function update_article( $uid, $revision, $article, $bundles = array(), $meta = array(), $post_id = null ) {
 		$url = $this->endpoint . '/articles/' . $uid;
 
-		// Always add the revision
+		// Always add the revision.
 		if ( empty( $meta['data'] ) || ! is_array( $meta['data'] ) ) {
 			$meta['data'] = array();
 		}
@@ -150,10 +150,6 @@ class API {
 		$url = $this->endpoint . '/sections/' . $section_id;
 		return $this->send_get_request( $url );
 	}
-
-	// Isolate request dependency.
-	// -------------------------------------------------------------------------
-
 
 	/**
 	 * Send a get request.

--- a/includes/apple-push-api/class-mime-builder.php
+++ b/includes/apple-push-api/class-mime-builder.php
@@ -128,10 +128,10 @@ class MIME_Builder {
 			$contents = wp_remote_retrieve_body( $request );
 		}
 
-		// Attempt to get the size
+		// Attempt to get the size.
 		$size = strlen( $contents );
 
-		// If this fails for some reason, try alternate methods
+		// If this fails for some reason, try alternate methods.
 		if ( empty( $size ) ) {
 			if ( filter_var( $filepath, FILTER_VALIDATE_URL ) ) {
 				$headers = get_headers( $filepath );
@@ -141,12 +141,12 @@ class MIME_Builder {
 					}
 				}
 			} else {
-				// This will be the final catch for local files
+				// This will be the final catch for local files.
 				$size = filesize( $filepath );
 			}
 		}
 
-		// If the name wasn't specified, build it from the filename
+		// If the name wasn't specified, build it from the filename.
 		$filename = \Apple_News::get_filename( $filepath );
 		if ( empty( $name ) ) {
 			$name = sanitize_key( $filename );
@@ -185,7 +185,7 @@ class MIME_Builder {
 	 * @access private
 	 */
 	private function build_attachment( $name, $filename, $content, $mime_type, $size ) {
-		// Ensure the file isn't empty
+		// Ensure the file isn't empty.
 		if ( empty( $content ) ) {
 			throw new Request_Exception( sprintf(
 				__( 'The attachment %s could not be included in the request because it was empty.', 'apple-news' ),
@@ -193,7 +193,7 @@ class MIME_Builder {
 			) );
 		}
 
-		// Ensure a valid size was provided
+		// Ensure a valid size was provided.
 		if ( 0 >= intval( $size ) ) {
 			throw new Request_Exception( sprintf(
 				__( 'The attachment %s could not be included in the request because its size was %s.', 'apple-news' ),
@@ -202,7 +202,7 @@ class MIME_Builder {
 			) );
 		}
 
-		// Build the attachment
+		// Build the attachment.
 		$attachment  = '--' . $this->boundary . $this->eol;
 		$attachment .= 'Content-Type: ' . $mime_type . $this->eol;
 		$attachment .= 'Content-Disposition: form-data; name=' . $name . '; filename=' . $filename . '; size=' . $size . $this->eol . $this->eol;
@@ -229,7 +229,7 @@ class MIME_Builder {
 	 * @access private
 	 */
 	private function get_mime_type_for( $filepath ) {
-		// TODO: rethink this for better integration with WordPress
+		// TODO: rethink this for better integration with WordPress.
 		return 'application/octet-stream';
 	}
 
@@ -254,8 +254,10 @@ class MIME_Builder {
 	public function get_debug_content( $args ) {
 		$content = '';
 
-		// Parse the header from the args and convert it into the format
-		// that would actually be sent to the API.
+		/**
+		 * Parse the header from the args and convert it into the format
+		 * that would actually be sent to the API.
+		 */
 		if ( ! empty( $args['headers'] ) && is_array( $args['headers'] ) ) {
 			foreach ( $args['headers'] as $key => $value ) {
 				$content .= sprintf(

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -60,7 +60,7 @@ class Request {
 		$this->debug        = $debug;
 		$this->mime_builder = $mime_builder ?: new MIME_Builder();
 
-		// Set the default WordPress HTTP API args
+		// Set the default WordPress HTTP API args.
 		$this->default_args = apply_filters( 'apple_news_request_args', array(
 			'reject_unsafe_urls' => true,
 			'timeout' => 5,
@@ -79,10 +79,10 @@ class Request {
 	 * @since 0.2.0
 	 */
 	public function post( $url, $article, $bundles = array(), $meta = null, $post_id = null ) {
-		// Assemble the content to send
+		// Assemble the content to send.
 		$content = $this->build_content( $article, $bundles, $meta, $post_id );
 
-		// Build the post request args
+		// Build the post request args.
 		$args = array(
 			'headers' => array(
 				'Authorization' => $this->sign( $url, 'POST', $content ),
@@ -90,19 +90,19 @@ class Request {
 				'Content-Type' => 'multipart/form-data; boundary=' . $this->mime_builder->boundary(),
 			),
 			'body' => $content,
-			'timeout' => 30, // required because we need to package all images
+			'timeout' => 30, // Required because we need to package all images.
 		);
 
-		// Allow filtering and merge with the default args
+		// Allow filtering and merge with the default args.
 		$args = apply_filters( 'apple_news_post_args', wp_parse_args( $args, $this->default_args ), $post_id );
 
-		// Perform the request
+		// Perform the request.
 		$response = wp_safe_remote_post( esc_url_raw( $url ), $args );
 
-		// Build a debug version of the MIME content for the debug email
+		// Build a debug version of the MIME content for the debug email.
 		$debug_mime_request = $this->mime_builder->get_debug_content( $args );
 
-		// Parse and return the response
+		// Parse and return the response.
 		return $this->parse_response( $response, true, 'post', $meta, $bundles, $article, $debug_mime_request );
 	}
 
@@ -114,7 +114,7 @@ class Request {
 	 * @since 0.2.0
 	 */
 	public function delete( $url ) {
-		// Build the delete request args
+		// Build the delete request args.
 		$args = array(
 			'headers' => array(
 				'Authorization' => $this->sign( $url, 'DELETE' ),
@@ -122,18 +122,18 @@ class Request {
 			'method' => 'DELETE',
 		);
 
-		// Allow filtering and merge with the default args
+		// Allow filtering and merge with the default args.
 		$args = apply_filters( 'apple_news_delete_args', wp_parse_args( $args, $this->default_args ) );
 
-		// Perform the delete
+		// Perform the delete.
 		$response = wp_safe_remote_request( esc_url_raw( $url ), $args );
 
-		// NULL is a valid response for DELETE
+		// NULL is a valid response for DELETE.
 		if ( is_null( $response ) ) {
 			return null;
 		}
 
-		// Parse and return the response
+		// Parse and return the response.
 		return $this->parse_response( $response, true, 'delete' );
 	}
 
@@ -145,20 +145,20 @@ class Request {
 	 * @since 0.2.0
 	 */
 	public function get( $url ) {
-		// Build the get request args
+		// Build the get request args.
 		$args = array(
 			'headers' => array(
 				'Authorization' => $this->sign( $url, 'GET' ),
 			),
 		);
 
-		// Allow filtering and merge with the default args
+		// Allow filtering and merge with the default args.
 		$args = apply_filters( 'apple_news_get_args', wp_parse_args( $args, $this->default_args ) );
 
-		// Perform the get
+		// Perform the get.
 		$response = wp_safe_remote_get( esc_url_raw( $url ), $args );
 
-		// Parse and return the response
+		// Parse and return the response.
 		return $this->parse_response( $response, true, 'get' );
 	}
 
@@ -176,12 +176,12 @@ class Request {
 	 * @since 0.2.0
 	 */
 	private function parse_response( $response, $json = true, $type = 'post', $meta = null, $bundles = null, $article = '', $debug_mime_request = '' ) {
-		// Ensure we have an expected response type
+		// Ensure we have an expected response type.
 		if ( ( ! is_array( $response ) || ! isset( $response['body'] ) ) && ! is_wp_error( $response ) ) {
 			throw new Request_Exception( __( 'Invalid response:', 'apple-news' ) . $response );
 		}
 
-		// If debugging mode is enabled, send an email
+		// If debugging mode is enabled, send an email.
 		$settings = get_option( 'apple_news_settings' );
 
 		if ( ! empty( $settings['apple_news_enable_debugging'] )
@@ -189,22 +189,22 @@ class Request {
 			&& 'yes' === $settings['apple_news_enable_debugging']
 			&& 'get' !== $type ) {
 
-			// Get the admin email
+			// Get the admin email.
 			$admin_email = filter_var( $settings['apple_news_admin_email'], FILTER_VALIDATE_EMAIL );
 			if ( empty( $admin_email ) ) {
 				return;
 			}
 
-			// Add the API response
+			// Add the API response.
 			$body = esc_html__( 'API Response', 'apple-news' ) . ":\n";
 			$body .= print_r( $response, true );
 
-			// Add the meta sent with the API request, if set
+			// Add the meta sent with the API request, if set.
 			if ( ! empty( $meta ) ) {
 				$body .= "\n\n" . esc_html__( 'Request Meta', 'apple-news' ) . ":\n\n" . print_r( $meta, true );
 			}
 
-			// Note image settings
+			// Note image settings.
 			$body .= "\n\n"  . esc_html__( 'Image Settings', 'apple-news' ) . ":\n";
 			if ( 'yes' === $settings['use_remote_images'] ) {
 				$body .= esc_html__( 'Use Remote images enabled ', 'apple-news' );
@@ -217,13 +217,13 @@ class Request {
 				}
 			}
 
-			// Add the JSON for the post
+			// Add the JSON for the post.
 			$body .= "\n\n" . esc_html__( 'JSON', 'apple-news' ) . ":\n" . $article . "\n";
 
-			// Add the MIME request
+			// Add the MIME request.
 			$body .= "\n\n" . esc_html__( 'MIME request', 'apple-news' ) . ":\n" . $debug_mime_request . "\n";
 
-			// Send the email
+			// Send the email.
 			if ( ! empty( $body ) ) {
 				wp_mail(
 					$admin_email,
@@ -233,7 +233,7 @@ class Request {
 			}
 		}
 
-		// Check for errors with the request itself
+		// Check for errors with the request itself.
 		if ( is_wp_error( $response ) ) {
 			$string_errors = '';
 			$error_messages = $response->get_error_messages();
@@ -243,13 +243,13 @@ class Request {
 			throw new Request_Exception( __( 'There has been an error with your request:', 'apple-news' ) . " $string_errors" );
 		}
 
-		// Check for errors from the API
+		// Check for errors from the API.
 		$response_decoded = json_decode( $response['body'] );
 		if ( ! empty( $response_decoded->errors ) && is_array( $response_decoded->errors ) ) {
 			$message = '';
 			$messages = array();
 			foreach ( $response_decoded->errors as $error ) {
-				// If there is a keyPath, build it into a string
+				// If there is a keyPath, build it into a string.
 				$key_path = '';
 				if ( ! empty( $error->keyPath ) && is_array( $error->keyPath ) ) {
 					foreach ( $error->keyPath as $i => $path ) {
@@ -263,7 +263,7 @@ class Request {
 					$key_path = " (keyPath $key_path)";
 				}
 
-				// Add the code, message and keyPath
+				// Add the code, message and keyPath.
 				$messages[] = sprintf(
 					'%s%s%s%s',
 					$error->code,
@@ -282,7 +282,7 @@ class Request {
 			throw new Request_Exception( $message );
 		}
 
-		// Return the response in the desired format
+		// Return the response in the desired format.
 		return $json ? $response_decoded : $response['body'];
 	}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -332,8 +332,10 @@ class Apple_News {
 	 */
 	public function migrate_api_settings() {
 
-		// Use the value of api_autosync_update for api_autosync_delete if not set
-		// since that was the previous value used to determine this behavior.
+		/**
+		 * Use the value of api_autosync_update for api_autosync_delete if not set
+		 * since that was the previous value used to determine this behavior.
+		 */
 		$wp_settings = get_option( self::$option_name );
 		if ( empty( $wp_settings['api_autosync_delete'] )
 		     && ! empty( $wp_settings['api_autosync_update'] )

--- a/index.php
+++ b/index.php
@@ -1,1 +1,1 @@
-<?php // Silence is golden
+<?php // Silence is golden.


### PR DESCRIPTION
* Ensure all single-line comments end in punctuation.
* Ensure multiple rows of single-line comments are converted to `/** */` comment blocks.
* Fix a few stray typos and misspellings in comments.