### PR TITLE
AN-132 Fix i18n phpcs errors

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -282,6 +282,7 @@ class Push extends API_Action {
 		if ( $remote_id ) {
 			Admin_Apple_Notice::success(
 				sprintf(
+					// translators: token is the post title.
 					__( 'Article %s has been successfully updated on Apple News!', 'apple-news' ),
 					$post->post_title
 				),
@@ -290,6 +291,7 @@ class Push extends API_Action {
 		} else {
 			Admin_Apple_Notice::success(
 				sprintf(
+					// translators: token is the post title.
 					__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
 					$post->post_title
 				),
@@ -327,11 +329,13 @@ class Push extends API_Action {
 
 			if ( 'warn' === $component_alerts ) {
 				$alert_message .= sprintf(
+					// translators: token is a list of component names.
 					__( 'The following components are unsupported by Apple News and were removed: %s', 'apple-news' ),
 					$component_names
 				);
 			} elseif ( 'fail' === $component_alerts ) {
 				$alert_message .= sprintf(
+					// translators: token is a list of component names.
 					__( 'The following components are unsupported by Apple News and prevented publishing: %s', 'apple-news' ),
 					$component_names
 				);
@@ -350,11 +354,13 @@ class Push extends API_Action {
 			// Add these to the message.
 			if ( 'warn' === $json_alerts ) {
 				$alert_message .= sprintf(
+					// translators: token is a list of errors.
 					__( 'The following JSON errors were detected: %s', 'apple-news' ),
 					$json_errors
 				);
 			} elseif ( 'fail' === $json_alerts ) {
 				$alert_message .= sprintf(
+					// translators: token is a list of errors.
 					__( 'The following JSON errors were detected and prevented publishing: %s', 'apple-news' ),
 					$json_errors
 				);

--- a/admin/class-admin-apple-async.php
+++ b/admin/class-admin-apple-async.php
@@ -79,6 +79,7 @@ class Admin_Apple_Async extends Apple_News {
 		if ( 'publish' !== $post->post_status ) {
 			Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is the post title.
 					__( 'Article %s is no longer published and cannot be pushed to Apple News.', 'apple-news' ),
 					$post->post_title
 				), $user_id

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -142,6 +142,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 				array(
 					'success' => false,
 					'error'   => sprintf(
+						// translators: token is a post ID.
 						__( 'Article %s is not published and cannot be pushed to Apple News.', 'apple-news' ),
 						$id
 					),

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -71,7 +71,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 	public function set_title( $admin_title ) {
 		$screen = get_current_screen();
 		if ( 'admin_page_apple_news_bulk_export' === $screen->base ) {
-			$admin_title = __( 'Bulk Export' ) . $admin_title;
+			$admin_title = __( 'Bulk Export', 'apple-news' ) . $admin_title;
 		}
 
 		return $admin_title;

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -358,6 +358,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		if ( 'publish' !== get_post_status( $id ) ) {
 			$this->notice_error(
 				sprintf(
+					// translators: token is the post ID.
 					__( 'Article %s is not published and cannot be pushed to Apple News.', 'apple-news' ),
 					$id
 				)

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -85,6 +85,7 @@ class Admin_Apple_JSON extends Apple_News {
 		$screen = get_current_screen();
 		if ( 'admin_page_' . $this->json_page_name === $screen->base ) {
 			$admin_title = sprintf(
+				// translators: token is the admin page title.
 				__( 'Customize JSON %s', 'apple-news' ),
 				trim( $admin_title )
 			);
@@ -219,6 +220,7 @@ class Admin_Apple_JSON extends Apple_News {
 		if ( empty( $specs ) ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is component name.
 					__( 'The component %s has no specs and cannot be reset', 'apple-news' ),
 					$component
 				)
@@ -234,6 +236,7 @@ class Admin_Apple_JSON extends Apple_News {
 
 		\Admin_Apple_Notice::success(
 			sprintf(
+				// translators: token is component name.
 				__( 'Reset the custom specs for %s.', 'apple-news' ),
 				$component
 			)
@@ -272,6 +275,7 @@ class Admin_Apple_JSON extends Apple_News {
 		if ( empty( $specs ) ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is component name.
 					__( 'The component %s has no specs and cannot be saved', 'apple-news' ),
 					$component
 				)
@@ -298,6 +302,7 @@ class Admin_Apple_JSON extends Apple_News {
 		if ( empty( $updates ) ) {
 			\Admin_Apple_Notice::info(
 				sprintf(
+					// translators: token is component name.
 					__( 'No spec updates were found for %s', 'apple-news' ),
 					$component
 				)
@@ -305,6 +310,7 @@ class Admin_Apple_JSON extends Apple_News {
 		} else {
 			\Admin_Apple_Notice::success(
 				sprintf(
+					// translators: first token is the component name, second is spec names.
 					__( 'Saved the following custom specs for %1$s: %2$s', 'apple-news' ),
 					$component,
 					implode( ', ', $updates )

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -243,6 +243,7 @@ class Admin_Apple_Themes extends Apple_News {
 		$theme->set_name( $name );
 		if ( ! $theme->load( $settings ) || ! $theme->save() ) {
 			return sprintf(
+				// translators: token is an error message.
 				__(
 					'The theme file was invalid and cannot be imported: %s',
 					'apple-news'
@@ -274,6 +275,7 @@ class Admin_Apple_Themes extends Apple_News {
 			$theme->set_name( $theme_name );
 			if ( false === $theme->load() ) {
 				$error = sprintf(
+					// translators: token is a theme name.
 					__( 'The theme %s does not exist', 'apple-news' ),
 					$theme_name
 				);
@@ -395,6 +397,7 @@ class Admin_Apple_Themes extends Apple_News {
 		$screen = get_current_screen();
 		if ( 'admin_page_' . $this->theme_edit_page_name === $screen->base ) {
 			$admin_title = sprintf(
+				// translators: token is a theme name.
 				__( 'Edit Theme %s', 'apple-news' ),
 				trim( $admin_title )
 			);
@@ -572,6 +575,7 @@ class Admin_Apple_Themes extends Apple_News {
 		// Indicate success.
 		\Admin_Apple_Notice::success(
 			sprintf(
+				// translators: token is a theme name.
 				__( 'Successfully deleted theme %s', 'apple-news' ),
 				$name
 			)
@@ -607,6 +611,7 @@ class Admin_Apple_Themes extends Apple_News {
 		if ( ! $theme->load() ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a theme name.
 					__( 'The theme %s could not be found', 'apple-news' ),
 					$name
 				)
@@ -683,6 +688,7 @@ class Admin_Apple_Themes extends Apple_News {
 		) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a theme name.
 					__( 'Theme name %s is already in use.', 'apple-news' ),
 					$name
 				)
@@ -708,6 +714,7 @@ class Admin_Apple_Themes extends Apple_News {
 		if ( ! $theme->save() ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: first token is a theme name, second is an error message.
 					__( 'Could not save theme %1$s: %2$s', 'apple-news' ),
 					$name,
 					$theme->get_last_error()
@@ -725,6 +732,7 @@ class Admin_Apple_Themes extends Apple_News {
 		// Indicate success.
 		\Admin_Apple_Notice::success(
 			sprintf(
+				// translators: token is a theme name.
 				__( 'The theme %s was saved successfully', 'apple-news' ),
 				$name
 			)
@@ -760,6 +768,7 @@ class Admin_Apple_Themes extends Apple_News {
 		// Indicate success.
 		\Admin_Apple_Notice::success(
 			sprintf(
+				// translators: token is a theme name.
 				__( 'Successfully switched to theme %s', 'apple-news' ),
 				$name
 			)
@@ -796,8 +805,9 @@ class Admin_Apple_Themes extends Apple_News {
 			wp_import_cleanup( $this->file_id );
 			\Admin_Apple_Notice::error(
 				sprintf(
-					__( 'The export file could not be found at <code>%s</code>. It is likely that this was caused by a permissions problem.', 'apple-news' ),
-					esc_html( $file['file'] )
+					// translators: token is a filepath wrapped in <code>.
+					__( 'The export file could not be found at %s. It is likely that this was caused by a permissions problem.', 'apple-news' ),
+					'<code>' . esc_html( $file['file'] ) . '</code>'
 				)
 			);
 			return;
@@ -833,6 +843,7 @@ class Admin_Apple_Themes extends Apple_News {
 		// Indicate success.
 		\Admin_Apple_Notice::success(
 			sprintf(
+				// translators: token is the theme name.
 				__( 'Successfully uploaded theme %s', 'apple-news' ),
 				$name
 			)

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -796,7 +796,7 @@ class Admin_Apple_Themes extends Apple_News {
 			wp_import_cleanup( $this->file_id );
 			\Admin_Apple_Notice::error(
 				sprintf(
-					__( 'The export file could not be found at <code>%s</code>. It is likely that this was caused by a permissions problem.', 'wp-options-importer' ),
+					__( 'The export file could not be found at <code>%s</code>. It is likely that this was caused by a permissions problem.', 'apple-news' ),
 					esc_html( $file['file'] )
 				)
 			);

--- a/admin/partials/cover-art.php
+++ b/admin/partials/cover-art.php
@@ -15,11 +15,10 @@ $orientations = array(
 <p class="description">
 	<?php
 	printf(
-		wp_kses(
-			__( '<a href="%s">Cover art</a> will represent your article if editorially chosen for Featured Stories. Cover Art must include your channel logo with text at 24 pt minimum that is related to the headline. The image provided must match the dimensions listed. Limit submissions to 1-3 articles per day.', 'apple-news' ),
-			array( 'a' => array( 'href' => array() ) )
-		),
-		'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html'
+		// translators: first token is an opening <a> tag, second is </a>.
+		esc_html__( '%1$sCover art%2$s will represent your article if editorially chosen for Featured Stories. Cover Art must include your channel logo with text at 24 pt minimum that is related to the headline. The image provided must match the dimensions listed. Limit submissions to 1-3 articles per day.', 'apple-news' ),
+		'<a href="https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html">',
+		'</a>'
 	);
 	?>
 </p>

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -20,8 +20,10 @@
 			<?php
 			echo wp_kses(
 				sprintf(
-					__( 'Select a component to customize any of the specs for its JSON snippets. This will enable to you create advanced templates beyond what is supported by <a href="%s">themes</a>.', 'apple-news' ),
-					esc_url( $theme_admin_url )
+					// translators: first token is an opening <a> tag, second is </a>.
+					__( 'Select a component to customize any of the specs for its JSON snippets. This will enable to you create advanced templates beyond what is supported by %1$sthemes%2$s.', 'apple-news' ),
+					'<a href="' . esc_url( $theme_admin_url ) . '">',
+					'</a>'
 				),
 				array(
 					'a' => array(
@@ -47,8 +49,10 @@
 			<?php
 			echo wp_kses(
 				sprintf(
-					__( 'For more information on the Apple News format options for each component, please read the <a href="%s">Apple News Format Reference</a>.', 'apple-news' ),
-					'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/Component.html#//apple_ref/doc/uid/TP40015408-CH5-SW1'
+					// translators: first argument is an opening <a> tag, second argument is </a>.
+					__( 'For more information on the Apple News format options for each component, please read the %1$sApple News Format Reference%2$s.', 'apple-news' ),
+					'<a href="https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/Component.html#//apple_ref/doc/uid/TP40015408-CH5-SW1">',
+					'</a>'
 				),
 				array(
 					'a' => array(

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -13,6 +13,7 @@
 	<?php
 	echo esc_html(
 		sprintf(
+			// translators: placeholder is a taxonomy label, plural form, e.g., "categories".
 			__( 'To enable automatic section assignment, choose the %s that you would like to be associated with each section.', 'apple-news' ),
 			strtolower( $taxonomy->label )
 		)
@@ -23,8 +24,10 @@
 	<?php
 	echo wp_kses_post(
 		sprintf(
-			__( 'You can also map a theme to automatically be used for posts with a specific Apple News section, if you want to use something other than the <a href="%s">active theme</a>. This will only work for posts with precisely one Apple News section to avoid conflicts.', 'apple-news' ),
-			esc_url( $theme_admin_url )
+			// translators: first argument is an opening <a> tag, second argument is </a>.
+			__( 'You can also map a theme to automatically be used for posts with a specific Apple News section, if you want to use something other than the %1$sactive theme%2$s. This will only work for posts with precisely one Apple News section to avoid conflicts.', 'apple-news' ),
+			'<a href="' . esc_url( $theme_admin_url ) . '">',
+			'</a>'
 		)
 	);
 		?>

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -103,7 +103,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		}
 
 		return sprintf(
-			__( 'This will cause publishing to happen asynchronously using %s.', 'apple_news' ),
+			__( 'This will cause publishing to happen asynchronously using %s.', 'apple-news' ),
 			$system
 		);
 	}

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -97,15 +97,9 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 	 */
 	private function get_async_description() {
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
-			$system = __( 'the WordPress VIP jobs system', 'apple-news' );
-		} else {
-			$system = __( 'a single scheduled event', 'apple-news' );
+			return __( 'This will cause publishing to happen asynchronously using the WordPress VIP jobs system.', 'apple-news' );
 		}
 
-		return sprintf(
-			__( 'This will cause publishing to happen asynchronously using %s.', 'apple-news' ),
-			$system
-		);
+		return __( 'This will cause publishing to happen asynchronously using a single scheduled event.', 'apple-news' );
 	}
-
 }

--- a/includes/apple-exporter/class-component-spec.php
+++ b/includes/apple-exporter/class-component-spec.php
@@ -233,6 +233,7 @@ class Component_Spec {
 		if ( empty( $json ) ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a spec label.
 					__( 'The spec for %s was invalid and cannot be saved', 'apple-news' ),
 					$this->label
 				)
@@ -256,6 +257,7 @@ class Component_Spec {
 		if ( false === $result ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a spec label.
 					__(
 						'The spec for %s had invalid tokens and cannot be saved',
 						'apple-news'
@@ -278,6 +280,7 @@ class Component_Spec {
 		if ( ! $theme->load() ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a theme name.
 					__( 'Unable to load theme %s to save spec', 'apple-news' ),
 					$theme_name
 				)
@@ -300,6 +303,7 @@ class Component_Spec {
 		if ( ! $theme->load( $theme_settings ) ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a spec label.
 					__( 'The spec for %s could not be loaded into the theme', 'apple-news' ),
 					$this->label
 				)
@@ -312,6 +316,7 @@ class Component_Spec {
 		if ( ! $theme->save() ) {
 			\Admin_Apple_Notice::error(
 				sprintf(
+					// translators: token is a spec label.
 					__( 'The spec for %s could not be saved to the theme', 'apple-news' ),
 					$this->label
 				)

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1473,6 +1473,7 @@ class Theme {
 		if ( self::theme_exists( $name ) ) {
 			$this->_log_error(
 				sprintf(
+					// translators: token is the theme name.
 					__( 'Theme name %s is already in use.', 'apple-news' ),
 					$name
 				)
@@ -1622,6 +1623,7 @@ class Theme {
 			if ( ! isset( $options[ $key ] ) ) {
 				$this->_log_error(
 					sprintf(
+						// translators: token is a setting key.
 						__( 'An invalid setting was encountered: %s', 'apple-news' ),
 						$key
 					)
@@ -1642,6 +1644,7 @@ class Theme {
 					if ( ! is_array( $value ) ) {
 						$this->_log_error(
 							sprintf(
+								// translators: first token is the setting key, second token is the value type.
 								__(
 									'Array expected for setting %1$s, %2$s provided',
 									'apple-news'
@@ -1667,6 +1670,7 @@ class Theme {
 					if ( false === preg_match( '/#([a-f0-9]{3}){1,2}\b/i', $value ) ) {
 						$this->_log_error(
 							sprintf(
+								// translators: first token is a value, second token is the setting key.
 								__(
 									'Invalid color value %1$s specified for setting %2$s',
 									'apple-news'
@@ -1694,6 +1698,7 @@ class Theme {
 					if ( ! in_array( $value, self::get_fonts(), true ) ) {
 						$this->_log_error(
 							sprintf(
+								// translators: first token is the value, second is the setting key.
 								__(
 									'Invalid font value %1$s specified for setting %2$s',
 									'apple-news'
@@ -1721,6 +1726,7 @@ class Theme {
 					if ( ! in_array( $value, $options[ $key ]['options'] ) ) {
 						$this->_log_error(
 							sprintf(
+								// translators: first token is the value, second token is the setting key.
 								__( 'Invalid value %1$s specified for setting %2$s', 'apple-news' ),
 								$value,
 								$key
@@ -2088,6 +2094,7 @@ class Theme {
 				if ( ! $spec->validate( $current_component[ $spec_key ] ) ) {
 					$this->_log_error(
 						sprintf(
+							// translators: token is a combination of a component key and a spec key.
 							__(
 								'The spec for %s had invalid tokens and cannot be saved',
 								'apple-news'

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -82,6 +82,7 @@ class Heading extends Component {
 			$this->register_spec(
 				'default-heading-' . $level,
 				sprintf(
+					// translators: token is the heading level.
 					__( 'Level %s Style', 'apple-news' ),
 					$level
 				),

--- a/includes/apple-push-api/class-mime-builder.php
+++ b/includes/apple-push-api/class-mime-builder.php
@@ -207,6 +207,7 @@ class MIME_Builder {
 		if ( empty( $content ) ) {
 			throw new Request_Exception(
 				sprintf(
+					// translators: token is an attachment filename.
 					__( 'The attachment %s could not be included in the request because it was empty.', 'apple-news' ),
 					esc_html( $filename )
 				)
@@ -217,6 +218,7 @@ class MIME_Builder {
 		if ( 0 >= intval( $size ) ) {
 			throw new Request_Exception(
 				sprintf(
+					// translators: first token is the filename, second is the file size.
 					__( 'The attachment %1$s could not be included in the request because its size was %2$s.', 'apple-news' ),
 					esc_html( $filename ),
 					esc_html( $size )


### PR DESCRIPTION
* Addresses `WordPress.WP.I18n.MissingTranslatorsComment`.
* Addresses `WordPress.WP.I18n.TextDomainMismatch`.
* Addresses `WordPress.WP.I18n.MissingArgDomain`.