### PR TITLE
AN-132 Fix remaining phpcs errors not specific to WordPress

### DIFF
--- a/admin/apple-actions/class-action.php
+++ b/admin/apple-actions/class-action.php
@@ -16,12 +16,21 @@ namespace Apple_Actions;
  */
 abstract class Action {
 
+	/**
+	 * The settings in use when this action is called.
+	 *
+	 * @var \Apple_Exporter\Settings
+	 * @access protected
+	 */
 	protected $settings;
 
 	/**
 	 * Constructor.
+	 *
+	 * @param \Apple_Exporter\Settings $settings The settings to load.
+	 * @access public
 	 */
-	function __construct( $settings ) {
+	public function __construct( $settings ) {
 		$this->settings = $settings;
 	}
 
@@ -34,6 +43,9 @@ abstract class Action {
 	 * Gets a setting by name which was loaded from WordPress options.
 	 *
 	 * @since 0.4.0
+	 * @param string $name The name of the setting to get.
+	 * @access protected
+	 * @return mixed The value for the setting.
 	 */
 	protected function get_setting( $name ) {
 		return $this->settings->get( $name );

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -90,6 +90,7 @@ class Push extends API_Action {
 	 *
 	 * @access private
 	 * @return boolean
+	 * @throws \Apple_Actions\Action_Exception If the post could not be found.
 	 */
 	private function is_post_in_sync() {
 		$post = get_post( $this->id );
@@ -112,6 +113,7 @@ class Push extends API_Action {
 	 * Updates the current relevant metadata stored for the post.
 	 *
 	 * @access private
+	 * @throws \Apple_Actions\Action_Exception If there was an error getting the article from the API.
 	 */
 	private function get() {
 		// Ensure we have a valid ID.

--- a/admin/apple-actions/index/class-section.php
+++ b/admin/apple-actions/index/class-section.php
@@ -79,7 +79,8 @@ class Section extends API_Action {
 	 * @return array
 	 */
 	public function get_sections() {
-		if ( false === ( $sections = get_transient( 'apple_news_sections' ) ) ) {
+		$sections = get_transient( 'apple_news_sections' );
+		if ( false === $sections ) {
 			$sections = array();
 			$channel = $this->get_setting( 'api_channel' );
 			if ( ! empty( $channel ) ) {

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -94,7 +94,8 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 		// Populate $articles array with a set of valid posts.
 		$articles = array();
 		foreach ( explode( '.', $ids ) as $id ) {
-			if ( $post = get_post( absint( $id ) ) ) {
+			$post = get_post( absint( $id ) );
+			if ( ! empty( $post ) ) {
 				$articles[] = $post;
 			}
 		}

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -142,7 +142,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 				return $this->export_action( $id );
 			case self::namespace_action( 'reset' ):
 				return $this->reset_action( $id );
-			case self::namespace_action( 'push' ):
+			case self::namespace_action( 'push' ): // phpcs:ignore PSR2.ControlStructures.SwitchDeclaration.TerminatingComment
 				if ( ! $id ) {
 					$url = menu_page_url( $this->plugin_slug . '_bulk_export', false );
 					if ( isset( $_GET['article'] ) ) {
@@ -186,7 +186,6 @@ class Admin_Apple_Index_Page extends Apple_News {
 	/**
 	 * Performs the redirect after an action is complete.
 	 *
-	 * @param string $message The message to show.
 	 * @access public
 	 */
 	private function do_redirect() {

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -37,7 +37,7 @@ class Admin_Apple_JSON extends Apple_News {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->json_page_name = $this->plugin_domain . '-json';
 
 		$this->valid_actions = array(

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -35,7 +35,7 @@ class Admin_Apple_News extends Apple_News {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		// Register hooks.
 		add_action( 'admin_print_styles-toplevel_page_apple_news_index', array( $this, 'plugin_styles' ) );
 		add_action( 'init', array( $this, 'action_init' ) );
@@ -250,9 +250,10 @@ class Admin_Apple_News extends Apple_News {
 	 */
 	public static function get_post_status( $post_id ) {
 		$key = 'apple_news_post_state_' . $post_id;
-		if ( false === ( $state = get_transient( $key ) ) ) {
-				// Get the state from the API.
-				// If this causes an error, display that message instead of the state.
+		$state = get_transient( $key );
+		if ( false === $state ) {
+			// Get the state from the API.
+			// If this causes an error, display that message instead of the state.
 			try {
 				$action = new Apple_Actions\Index\Get( self::$settings, $post_id );
 				$state = $action->get_data( 'state', __( 'N/A', 'apple-news' ) );
@@ -260,8 +261,8 @@ class Admin_Apple_News extends Apple_News {
 				$state = $e->getMessage();
 			}
 
-				$cache_expiration = ( 'LIVE' === $state || 'TAKEN_DOWN' === $state ) ? 3600 : 60;
-				set_transient( $key, $state, apply_filters( 'apple_news_post_status_cache_expiration', $cache_expiration, $state ) );
+			$cache_expiration = ( 'LIVE' === $state || 'TAKEN_DOWN' === $state ) ? 3600 : 60;
+			set_transient( $key, $state, apply_filters( 'apple_news_post_status_cache_expiration', $cache_expiration, $state ) );
 		}
 
 		return $state;

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -81,7 +81,8 @@ class Admin_Apple_Sections extends Apple_News {
 	public static function get_sections() {
 
 		// Try to load from cache.
-		if ( false !== ( $sections = get_transient( 'apple_news_sections' ) ) ) {
+		$sections = get_transient( 'apple_news_sections' );
+		if ( false !== $sections ) {
 			return $sections;
 		}
 
@@ -186,8 +187,7 @@ class Admin_Apple_Sections extends Apple_News {
 	/**
 	 * Given a section ID, check for a custom theme mapping.
 	 *
-	 * @param string $section_id The Apple News section ID
-	 *
+	 * @param string $section_id The Apple News section ID.
 	 * @access public
 	 * @return string The name of the theme, or null if not found.
 	 */
@@ -205,7 +205,7 @@ class Admin_Apple_Sections extends Apple_News {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		// Initialize class variables.
 		$this->page_name = $this->plugin_domain . '-sections';
@@ -252,7 +252,6 @@ class Admin_Apple_Sections extends Apple_News {
 	 * AJAX endpoint for section/taxonomy mapping autocomplete fields.
 	 *
 	 * @access public
-	 * @return array An array of values matching the query.
 	 */
 	public function ajax_apple_news_section_taxonomy_autocomplete() {
 
@@ -437,7 +436,8 @@ class Admin_Apple_Sections extends Apple_News {
 		}
 
 		// Loop through sections and look for mappings in POST data.
-		$taxonomy_mappings = $theme_mappings = array();
+		$taxonomy_mappings = array();
+		$theme_mappings = array();
 		$taxonomy = self::get_mapping_taxonomy();
 		$section_ids = wp_list_pluck( $sections_raw, 'id' );
 		foreach ( $section_ids as $section_id ) {

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -54,7 +54,7 @@
 						<ul class="apple-news-section-taxonomy-mapping-list">
 						<?php if ( ! empty( $taxonomy_mappings[ $section_id ] ) ) : ?>
 							<?php foreach ( $taxonomy_mappings[ $section_id ] as $term ) : ?>
-								<?php $taxonomy_id = 'apple-news-section-mapping-' . ++ $count; ?>
+								<?php $taxonomy_id = 'apple-news-section-mapping-' . ( ++ $count ); ?>
 								<li>
 									<label for="<?php echo esc_attr( $taxonomy_id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
 									<input name="taxonomy-mapping-<?php echo esc_attr( $section_id ); ?>[]" id="<?php echo esc_attr( $taxonomy_id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
@@ -67,7 +67,7 @@
 					</td>
 					<td>
 						<?php
-							$theme_id = 'apple-news-theme-mapping-' . ++ $count;
+							$theme_id = 'apple-news-theme-mapping-' . ( ++ $count );
 							$selected_theme = ( isset( $theme_mappings[ $section_id ] ) ) ? $theme_mappings[ $section_id ] : '';
 						?>
 						<select name="theme-mapping-<?php echo esc_attr( $section_id ); ?>" id="<?php echo esc_attr( $theme_id ); ?>">

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -255,7 +255,8 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		 */
 		if ( is_array( $type ) ) {
 			// Check if this is a multiple select.
-			$multiple_name = $multiple_attr = '';
+			$multiple_name = '';
+			$multiple_attr = '';
 			if ( $this->is_multiple( $name ) ) {
 				$multiple_name = '[]';
 				$multiple_attr = 'multiple="multiple"';

--- a/includes/apple-exporter/builders/class-component-layouts.php
+++ b/includes/apple-exporter/builders/class-component-layouts.php
@@ -28,8 +28,12 @@ class Component_Layouts extends Builder {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param \Apple_Exporter\Exporter_Content          $content The content object to load.
+	 * @param \Apple_Exporter\Exporter_Content_Settings $settings The settings object to load.
+	 * @access public
 	 */
-	function __construct( $content, $settings ) {
+	public function __construct( $content, $settings ) {
 		parent::__construct( $content, $settings );
 		$this->layouts  = array();
 	}

--- a/includes/apple-exporter/builders/class-component-text-styles.php
+++ b/includes/apple-exporter/builders/class-component-text-styles.php
@@ -26,8 +26,12 @@ class Component_Text_Styles extends Builder {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param \Apple_Exporter\Exporter_Content          $content The content object to load.
+	 * @param \Apple_Exporter\Exporter_Content_Settings $settings The settings object to load.
+	 * @access public
 	 */
-	function __construct( $content, $settings ) {
+	public function __construct( $content, $settings ) {
 		parent::__construct( $content, $settings );
 		$this->styles = array();
 	}

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -72,8 +72,7 @@ class Components extends Builder {
 	/**
 	 * Add a pullquote component if needed.
 	 *
-	 * @param array &$components An array of Component objects to analyze.
-	 *
+	 * @param array $components An array of Component objects to analyze.
 	 * @access private
 	 */
 	private function _add_pullquote_if_needed( &$components ) {
@@ -126,8 +125,7 @@ class Components extends Builder {
 	/**
 	 * Add a thumbnail if needed.
 	 *
-	 * @param array &$components An array of Component objects to analyze.
-	 *
+	 * @param array $components An array of Component objects to analyze.
 	 * @access private
 	 */
 	private function _add_thumbnail_if_needed( &$components ) {
@@ -208,8 +206,7 @@ class Components extends Builder {
 	/**
 	 * Anchor components that are marked as can_be_anchor_target.
 	 *
-	 * @param array &$components An array of Component objects to process.
-	 *
+	 * @param array $components An array of Component objects to process.
 	 * @access private
 	 */
 	private function _anchor_components( &$components ) {
@@ -404,10 +401,8 @@ class Components extends Builder {
 	/**
 	 * Performs additional processing on 'body' nodes to clean up data.
 	 *
-	 * @param Component &$component The component to clean up.
-	 *
 	 * @since 1.2.1
-	 *
+	 * @param Component $component The component to clean up.
 	 * @access private
 	 */
 	private function _clean_up_components( &$component ) {
@@ -692,9 +687,13 @@ class Components extends Builder {
 
 			// Determine if component is loadable.
 			$method = 'content_' . $component;
-			if ( ! method_exists( $this, $method )
-				 || ! ( $content = $this->$method() )
-			) {
+			if ( ! method_exists( $this, $method ) ) {
+				continue;
+			}
+
+			// Determine if component has content.
+			$content = $this->$method();
+			if ( empty( $content ) ) {
 				continue;
 			}
 

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -102,7 +102,7 @@ class Metadata extends Builder {
 	/**
 	 * Adds metadata for cover art.
 	 *
-	 * @param array &$meta The metadata array to augment.
+	 * @param array $meta The metadata array to augment.
 	 *
 	 * @access private
 	 */

--- a/includes/apple-exporter/class-component-spec.php
+++ b/includes/apple-exporter/class-component-spec.php
@@ -164,7 +164,8 @@ class Component_Spec {
 
 		// Iterate recursively over the built-in spec and get all the tokens.
 		// Do the same for the provided spec.
-		$new_tokens = $default_tokens = array();
+		$new_tokens = array();
+		$default_tokens = array();
 		$this->find_tokens( $spec, $new_tokens );
 		$this->find_tokens( $this->spec, $default_tokens );
 

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -477,6 +477,7 @@ class Theme {
 	/**
 	 * Renders the meta component order field.
 	 *
+	 * @param \Apple_Exporter\Theme $theme The theme for which to render the order.
 	 * @access public
 	 */
 	public static function render_meta_component_order( $theme ) {

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -383,10 +383,9 @@ abstract class Component {
 	 * Maybe bundles the source based on current settings.
 	 * Returns the URL to use based on current setings.
 	 *
-	 * @param string $source    The path or URL of the resource which is going to
-	 *                          be bundled
-	 * @param string $filename  The name of the file to be created
-	 * @return string                   The URL to use for this asset in the JSON
+	 * @param string $source   The path or URL of the resource which is going to be bundled.
+	 * @param string $filename The name of the file to be created.
+	 * @return string The URL to use for this asset in the JSON.
 	 */
 	protected function maybe_bundle_source( $source, $filename = null ) {
 		if ( 'yes' === $this->get_setting( 'use_remote_images' ) ) {
@@ -404,9 +403,8 @@ abstract class Component {
 	 * Calls the current workspace bundle_source method to allow for
 	 * different implementations of the bundling technique.
 	 *
-	 * @param string $filename  The name of the file to be created
-	 * @param string $source    The path or URL of the resource which is going to
-	 *                          be bundled
+	 * @param string $filename The name of the file to be created.
+	 * @param string $source   The path or URL of the resource which is going to be bundled.
 	 */
 	protected function bundle_source( $filename, $source ) {
 		$this->workspace->bundle_source( $filename, $source );
@@ -502,8 +500,8 @@ abstract class Component {
 	 * Set the JSON for the component.
 	 *
 	 * @since 1.2.4
-	 * @param string $spec_name The spec to use for defining the JSON
-	 * @param array  $values Values to substitute for placeholders in the spec
+	 * @param string $spec_name The spec to use for defining the JSON.
+	 * @param array  $values    Values to substitute for placeholders in the spec.
 	 * @access protected
 	 */
 	protected function register_json( $spec_name, $values = array() ) {
@@ -520,10 +518,10 @@ abstract class Component {
 	 * Using the style service, register a new style.
 	 *
 	 * @since 0.4.0
-	 * @param string $name The name of the style
-	 * @param string $spec_name The spec to use for defining the JSON
-	 * @param array  $values Values to substitute for placeholders in the spec
-	 * @param array  $property The JSON property to set with the style
+	 * @param string $name      The name of the style.
+	 * @param string $spec_name The spec to use for defining the JSON.
+	 * @param array  $values    Values to substitute for placeholders in the spec.
+	 * @param array  $property  The JSON property to set with the style.
 	 * @access protected
 	 */
 	protected function register_style( $name, $spec_name, $values = array(), $property = null ) {
@@ -542,10 +540,10 @@ abstract class Component {
 	 * Using the layouts service, register a new layout.
 	 *
 	 * @since 0.4.0
-	 * @param string $name The name of the layout
-	 * @param string $spec_name The spec to use for defining the JSON
-	 * @param array  $values Values to substitute for placeholders in the spec
-	 * @param array  $property The JSON property to set with the layout
+	 * @param string $name      The name of the layout.
+	 * @param string $spec_name The spec to use for defining the JSON.
+	 * @param array  $values    Values to substitute for placeholders in the spec.
+	 * @param array  $property  The JSON property to set with the layout.
 	 * @access protected
 	 */
 	protected function register_layout( $name, $spec_name, $values = array(), $property = null ) {
@@ -566,10 +564,10 @@ abstract class Component {
 	 * because when the body is centered, the full-width layout spans the same
 	 * columns as the body.
 	 *
-	 * @param string $name The name of the layout
-	 * @param string $spec_name The spec to use for defining the JSON
-	 * @param array  $values Values to substitute for placeholders in the spec
-	 * @param array  $property The JSON property to set with the layout
+	 * @param string $name      The name of the layout.
+	 * @param string $spec_name The spec to use for defining the JSON.
+	 * @param array  $values    Values to substitute for placeholders in the spec.
+	 * @param array  $property  The JSON property to set with the layout.
 	 * @access protected
 	 */
 	protected function register_full_width_layout( $name, $spec_name, $values = array(), $property = null ) {
@@ -624,8 +622,8 @@ abstract class Component {
 	/**
 	 * Check if a node has a class.
 	 *
-	 * @param \DOMElement $node The node to examine for matches.
-	 * @param string $classname The name of the class to look up.
+	 * @param \DOMElement $node      The node to examine for matches.
+	 * @param string      $classname The name of the class to look up.
 	 * @access protected
 	 * @return boolean True if the node has the class, false if it does not.
 	 */

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -115,6 +115,7 @@ class Apple_News {
 	 * This functionality is used in a number of classes that do not have a common
 	 * ancestor.
 	 *
+	 * @param string $path The path to analyze for a filename.
 	 * @access public
 	 * @return string The filename for an asset to be bundled.
 	 */
@@ -789,13 +790,8 @@ class Apple_News {
 	 * Accepts an array of settings and a settings map to clone settings from one
 	 * key to another.
 	 *
-	 * @param array $wp_settings An array of settings to modify.
+	 * @param array $wp_settings  An array of settings to modify.
 	 * @param array $settings_map A settings map in the format $to => $from.
-	 *   Example:
-	 *   $settings_map = array(
-	 *       'blockquote_color' => 'pullquote_color',
-	 *   );
-	 *
 	 * @access private
 	 * @return array The modified settings array.
 	 */


### PR DESCRIPTION
Addresses `PSR2.ControlStructures.SwitchDeclaration.TerminatingComment`.
Addresses `Squiz.Commenting.FunctionComment.ExtraParamComment`.
Addresses `Squiz.Commenting.FunctionComment.InvalidNoReturn`.
Addresses `Squiz.Commenting.FunctionComment.MissingParamTag`.
Addresses `Squiz.Commenting.FunctionComment.ParamCommentFullStop`.
Addresses `Squiz.Commenting.FunctionComment.ParamNameNoMatch`.
Addresses `Squiz.Commenting.FunctionComment.SpacingAfterParamType`.
Addresses `Squiz.Commenting.FunctionCommentThrowTag.Missing`.
Addresses `Squiz.Commenting.VariableComment.Missing`.
Addresses `Squiz.Operators.IncrementDecrementUsage.NoBrackets`.
Addresses `Squiz.PHP.DisallowMultipleAssignments.Found`.
Addresses `Squiz.Scope.MethodScope.Missing`.