### PR TITLE
AN-132 Miscellaneous WordPress phpcs Error Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,10 @@ before_script:
   # For debugging.
   - which phpunit
   - phpunit --version
+  - which phpcs
+  - phpcs --version
   - pwd
+  - echo $PATH
 
 # Run test script commands.
 # Default is specific to project language.

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
 
   # Install Composer dependencies.
   - composer install
-  - export PATH=$PATH:${og_dir}/vendor/bin/
+  - export PATH=$PATH:`pwd`/vendor/bin/
   - phpenv rehash
 
   # For debugging.

--- a/admin/apple-actions/index/class-delete.php
+++ b/admin/apple-actions/index/class-delete.php
@@ -18,7 +18,7 @@ use Apple_Actions\API_Action as API_Action;
  * @package Apple_News
  * @subpackage Apple_Actions\Index
  */
-class Delete extends API_Action {
+class Delete extends API_Action { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_delete
 
 	/**
 	 * ID of the post to be deleted.

--- a/admin/apple-actions/index/class-delete.php
+++ b/admin/apple-actions/index/class-delete.php
@@ -18,7 +18,7 @@ use Apple_Actions\API_Action as API_Action;
  * @package Apple_News
  * @subpackage Apple_Actions\Index
  */
-class Delete extends API_Action { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_delete
+class Delete extends API_Action { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_delete, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
 
 	/**
 	 * ID of the post to be deleted.

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -101,7 +101,7 @@ class Export extends Action {
 		 * Fetch WP_Post object, and all required post information to fill up the
 		 * Exporter_Content instance.
 		 */
-		$post = get_post( $this->id );
+		$post = get_post( $this->id ); // phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited
 
 		// Build the excerpt if required.
 		if ( empty( $post->post_excerpt ) ) {

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -112,7 +112,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 		check_ajax_referer( self::ACTION );
 
 		// Sanitize input data.
-		$id = absint( $_GET['id'] );
+		$id = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
 		// Ensure the post exists and that it's published.
 		$post = get_post( $id );

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -83,7 +83,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 	 * @access public
 	 */
 	public function build_page() {
-		$ids = isset( $_GET['ids'] ) ? sanitize_text_field( $_GET['ids'] ) : null;
+		$ids = isset( $_GET['ids'] ) ? sanitize_text_field( wp_unslash( $_GET['ids'] ) ) : null;
 		if ( ! $ids ) {
 			wp_safe_redirect( esc_url_raw( menu_page_url( $this->plugin_slug . '_index', false ) ) );
 			if ( ! defined( 'APPLE_NEWS_UNIT_TESTS' ) || ! APPLE_NEWS_UNIT_TESTS ) {

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -365,9 +365,6 @@ class Admin_Apple_Index_Page extends Apple_News {
 			return;
 		}
 
-		// Check the nonce.
-		check_admin_referer( 'publish', 'apple_news_nonce' );
-
 		// Save fields.
 		\Admin_Apple_Meta_Boxes::save_post_meta( $id );
 

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -266,7 +266,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Type: application/json' );
 		header( 'Content-Disposition: attachment; filename="article-' . absint( $id ) . '.json"' );
-		echo $json;
+		echo wp_json_encode( json_decode( $json ) );
 		die();
 	}
 
@@ -366,13 +366,10 @@ class Admin_Apple_Index_Page extends Apple_News {
 		}
 
 		// Check the nonce.
-		// If it isn't set, this isn't a form submission so we need to just display the form.
-		if ( ! isset( $_POST['apple_news_nonce'] ) ) {
-			return;
-		}
-
-		// If invalid, we need to display an error.
-		if ( ! wp_verify_nonce( $_POST['apple_news_nonce'], 'publish' ) ) {
+		$nonce = isset( $_REQUEST['apple_news_nonce'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['apple_news_nonce'] ) )
+			: '';
+		if ( ! wp_verify_nonce( $nonce, 'publish' ) ) {
 			$this->notice_error( __( 'Invalid nonce.', 'apple-news' ) );
 		}
 

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -93,7 +93,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 */
 	public function admin_page() {
 		$id     = isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : null;
-		$action = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : null;
+		$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
 
 		switch ( $action ) {
 			case self::namespace_action( 'push' ):
@@ -127,9 +127,9 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 * @return mixed The result of the requested action.
 	 */
 	public function page_router() {
-		$id             = isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : null;
-		$action     = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : null;
-		$action2    = isset( $_GET['action2'] ) ? sanitize_text_field( $_GET['action2'] ) : null;
+		$id      = isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : null;
+		$action  = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null;
+		$action2 = isset( $_GET['action2'] ) ? sanitize_text_field( wp_unslash( $_GET['action2'] ) ) : null;
 
 		// Allow for bulk actions from top or bottom.
 		if ( ( empty( $action ) || '-1' === $action ) && ! empty( $action2 ) ) {
@@ -234,7 +234,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		// Add the other params.
 		foreach ( $keys as $key ) {
 			if ( ! empty( $_GET[ $key ] ) ) {
-				$params[ $key ] = urlencode( sanitize_text_field( $_GET[ $key ] ) );
+				$params[ $key ] = urlencode( sanitize_text_field( wp_unslash( $_GET[ $key ] ) ) );
 			}
 		}
 

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -366,12 +366,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 		}
 
 		// Check the nonce.
-		$nonce = isset( $_REQUEST['apple_news_nonce'] )
-			? sanitize_text_field( wp_unslash( $_REQUEST['apple_news_nonce'] ) )
-			: '';
-		if ( ! wp_verify_nonce( $nonce, 'publish' ) ) {
-			$this->notice_error( __( 'Invalid nonce.', 'apple-news' ) );
-		}
+		check_admin_referer( 'publish', 'apple_news_nonce' );
 
 		// Save fields.
 		\Admin_Apple_Meta_Boxes::save_post_meta( $id );

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -106,7 +106,9 @@ class Admin_Apple_JSON extends Apple_News {
 		}
 
 		// Call the callback for the action for further processing.
-		if ( isset( $this->valid_actions[ $action ]['callback'] ) ) {
+		if ( isset( $this->valid_actions[ $action ]['callback'] )
+			&& is_callable( $this->valid_actions[ $action ]['callback'] )
+		) {
 			call_user_func( $this->valid_actions[ $action ]['callback'] );
 		}
 	}

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -80,21 +80,16 @@ class Admin_Apple_JSON extends Apple_News {
 	 */
 	public function action_router() {
 
-		// Determine if we got an action.
-		if ( empty( $_REQUEST['apple_news_action'] ) ) {
+		// Check for a valid action.
+		$action = isset( $_REQUEST['apple_news_action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['apple_news_action'] ) )
+			: null;
+		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
 			return;
 		}
 
 		// Check the nonce.
 		check_admin_referer( 'apple_news_json' );
-
-		// Check for a valid action.
-		$action = isset( $_POST['apple_news_action'] )
-			? sanitize_text_field( wp_unslash( $_POST['apple_news_action'] ) )
-			: null;
-		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
-			return;
-		}
 
 		// Store the selected component value for use later.
 		$this->selected_component = isset( $_POST['apple_news_component'] )

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -27,6 +27,24 @@ class Admin_Apple_JSON extends Apple_News {
 	private $namespace = '\\Apple_Exporter\\Components\\';
 
 	/**
+	 * Holds the selected component from the request.
+	 *
+	 * @since 1.4.0
+	 * @var string
+	 * @access private
+	 */
+	private $selected_component = '';
+
+	/**
+	 * Holds the selected theme from the request.
+	 *
+	 * @since 1.4.0
+	 * @var string
+	 * @access private
+	 */
+	private $selected_theme = '';
+
+	/**
 	 * Valid actions handled by this class and their callback functions.
 	 *
 	 * @var array
@@ -61,6 +79,15 @@ class Admin_Apple_JSON extends Apple_News {
 	 * @access public
 	 */
 	public function action_router() {
+
+		// Determine if we got an action.
+		if ( empty( $_REQUEST['apple_news_action'] ) ) {
+			return;
+		}
+
+		// Check the nonce.
+		check_admin_referer( 'apple_news_json' );
+
 		// Check for a valid action.
 		$action = isset( $_POST['apple_news_action'] )
 			? sanitize_text_field( wp_unslash( $_POST['apple_news_action'] ) )
@@ -69,8 +96,18 @@ class Admin_Apple_JSON extends Apple_News {
 			return;
 		}
 
-		// Check the nonce.
-		check_admin_referer( 'apple_news_json' );
+		// Store the selected component value for use later.
+		$this->selected_component = isset( $_POST['apple_news_component'] )
+			? sanitize_text_field( wp_unslash( $_POST['apple_news_component'] ) )
+			: '';
+		if ( ! array_key_exists( $this->selected_component, $this->list_components() ) ) {
+			$this->selected_component = '';
+		}
+
+		// Store the selected theme for use later.
+		if ( ! empty( $_POST['apple_news_theme'] ) ) {
+			$this->selected_theme = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
+		}
 
 		// Call the callback for the action for further processing.
 		call_user_func( $this->valid_actions[ $action ]['callback'] );
@@ -137,12 +174,7 @@ class Admin_Apple_JSON extends Apple_News {
 		$all_themes = \Apple_Exporter\Theme::get_registry();
 
 		// Negotiate selected theme.
-		$selected_theme = '';
-		if ( ! empty( $_POST['apple_news_theme'] ) ) {
-			$selected_theme = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
-		} elseif ( ! empty( $_GET['theme'] ) ) {
-			$selected_theme = sanitize_text_field( wp_unslash( $_GET['theme'] ) );
-		}
+		$selected_theme = $this->get_selected_theme();
 
 		// Check if there is a valid selected component.
 		$selected_component = ( ! empty( $selected_theme ) )
@@ -198,6 +230,9 @@ class Admin_Apple_JSON extends Apple_News {
 	 */
 	private function reset_json() {
 
+		// Check the nonce.
+		check_admin_referer( 'apple_news_json' );
+
 		// Ensure a theme was selected.
 		if ( empty( $_POST['apple_news_theme'] ) ) {
 			\Admin_Apple_Notice::error(
@@ -251,6 +286,9 @@ class Admin_Apple_JSON extends Apple_News {
 	 * @access private
 	 */
 	private function save_json() {
+
+		// Check the nonce.
+		check_admin_referer( 'apple_news_json' );
 
 		// Ensure a theme was selected.
 		if ( empty( $_POST['apple_news_theme'] ) ) {
@@ -367,16 +405,29 @@ class Admin_Apple_JSON extends Apple_News {
 	 * @access public
 	 */
 	public function get_selected_component() {
-		$selected_component = '';
+		return $this->selected_component;
+	}
 
-		if ( isset( $_POST['apple_news_component'] ) ) {
-			$selected_component = sanitize_text_field( wp_unslash( $_POST['apple_news_component'] ) );
-			if ( ! array_key_exists( $selected_component, $this->list_components() ) ) {
-				$selected_component = '';
-			}
+	/**
+	 * Checks for a valid selected theme.
+	 *
+	 * @since 1.4.0
+	 * @access public
+	 * @return string
+	 */
+	public function get_selected_theme() {
+
+		// First, check for a theme loaded in from postmeta.
+		if ( ! empty( $this->selected_theme ) ) {
+			return $this->selected_theme;
 		}
 
-		return $selected_component;
+		// Next, check for a theme loaded in from the query string.
+		if ( ! empty( $_GET['theme'] ) ) {
+			return sanitize_text_field( wp_unslash( $_GET['theme'] ) );
+		}
+
+		return '';
 	}
 
 	/**

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -59,6 +59,7 @@ class Admin_Apple_JSON extends Apple_News {
 		$this->json_page_name = $this->plugin_domain . '-json';
 
 		$this->valid_actions = array(
+			'apple_news_get_json' => array(),
 			'apple_news_reset_json' => array(
 				'callback' => array( $this, 'reset_json' ),
 			),
@@ -105,7 +106,9 @@ class Admin_Apple_JSON extends Apple_News {
 		}
 
 		// Call the callback for the action for further processing.
-		call_user_func( $this->valid_actions[ $action ]['callback'] );
+		if ( isset( $this->valid_actions[ $action ]['callback'] ) ) {
+			call_user_func( $this->valid_actions[ $action ]['callback'] );
+		}
 	}
 
 	/**
@@ -263,7 +266,7 @@ class Admin_Apple_JSON extends Apple_News {
 
 		// Iterate over the specs and reset each one.
 		foreach ( $specs as $spec ) {
-			$spec->delete();
+			$spec->delete( $this->selected_theme );
 		}
 
 		\Admin_Apple_Notice::success(
@@ -412,7 +415,7 @@ class Admin_Apple_JSON extends Apple_News {
 	 */
 	public function get_selected_theme() {
 
-		// First, check for a theme loaded in from postmeta.
+		// First, check for a theme loaded in from postdata.
 		if ( ! empty( $this->selected_theme ) ) {
 			return $this->selected_theme;
 		}

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -62,7 +62,9 @@ class Admin_Apple_JSON extends Apple_News {
 	 */
 	public function action_router() {
 		// Check for a valid action.
-		$action = isset( $_POST['apple_news_action'] ) ? sanitize_text_field( $_POST['apple_news_action'] ) : null;
+		$action = isset( $_POST['apple_news_action'] )
+			? sanitize_text_field( wp_unslash( $_POST['apple_news_action'] ) )
+			: null;
 		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
 			return;
 		}
@@ -137,9 +139,9 @@ class Admin_Apple_JSON extends Apple_News {
 		// Negotiate selected theme.
 		$selected_theme = '';
 		if ( ! empty( $_POST['apple_news_theme'] ) ) {
-			$selected_theme = sanitize_text_field( $_POST['apple_news_theme'] );
+			$selected_theme = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
 		} elseif ( ! empty( $_GET['theme'] ) ) {
-			$selected_theme = sanitize_text_field( $_GET['theme'] );
+			$selected_theme = sanitize_text_field( wp_unslash( $_GET['theme'] ) );
 		}
 
 		// Check if there is a valid selected component.
@@ -270,7 +272,7 @@ class Admin_Apple_JSON extends Apple_News {
 		}
 
 		// Get the specs for the component and theme.
-		$theme = stripslashes( sanitize_text_field( $_POST['apple_news_theme'] ) );
+		$theme = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
 		$specs = $this->get_specs( $component, $theme );
 		if ( empty( $specs ) ) {
 			\Admin_Apple_Notice::error(
@@ -291,7 +293,7 @@ class Admin_Apple_JSON extends Apple_News {
 			// Ensure the value exists.
 			$key = 'apple_news_json_' . $spec->key_from_name( $spec->name );
 			if ( isset( $_POST[ $key ] ) ) {
-				$custom_spec = stripslashes( sanitize_text_field( $_POST[ $key ] ) );
+				$custom_spec = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
 				$result = $spec->save( $custom_spec, $theme );
 				if ( true === $result ) {
 					$updates[] = $spec->label;
@@ -368,7 +370,7 @@ class Admin_Apple_JSON extends Apple_News {
 		$selected_component = '';
 
 		if ( isset( $_POST['apple_news_component'] ) ) {
-			$selected_component = sanitize_text_field( $_POST['apple_news_component'] );
+			$selected_component = sanitize_text_field( wp_unslash( $_POST['apple_news_component'] ) );
 			if ( ! array_key_exists( $selected_component, $this->list_components() ) ) {
 				$selected_component = '';
 			}

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -69,19 +69,16 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 */
 	public function do_publish( $post_id, $post ) {
 
-		// If there is no post ID, bail.
-		if ( empty( $_REQUEST['post_ID'] ) ) {
+		// Check the post ID.
+		$post_id = isset( $_REQUEST['post_ID'] )
+			? absint( $_REQUEST['post_ID'] )
+			: 0;
+		if ( empty( $post_id ) ) {
 			return;
 		}
 
 		// Check the nonce.
 		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );
-
-		// Check the post ID.
-		$post_id = isset( $_POST['post_ID'] ) ? absint( $_POST['post_ID'] ) : 0;
-		if ( empty( $post_id ) ) {
-			return;
-		}
 
 		// Save meta box fields.
 		self::save_post_meta( $post_id );
@@ -117,6 +114,11 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access public
 	 */
 	public static function save_post_meta( $post_id ) {
+
+		// If there is no postdata, bail.
+		if ( empty( $_POST ) ) {
+			return;
+		}
 
 		// Check the nonce.
 		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -69,6 +69,11 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 */
 	public function do_publish( $post_id, $post ) {
 
+		// If there is no post ID, bail.
+		if ( empty( $_REQUEST['post_ID'] ) ) {
+			return;
+		}
+
 		// Check the nonce.
 		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );
 

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -69,19 +69,22 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access public
 	 */
 	public function do_publish( $post_id, $post ) {
-		// Check if the values we want are present in $_REQUEST params.
-		if ( empty( $_POST['apple_news_nonce'] )
-			|| empty( $_POST['post_ID'] ) ) {
+
+		// Check the nonce.
+		$nonce = isset( $_REQUEST['apple_news_nonce'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['apple_news_nonce'] ) )
+			: '';
+		if ( ! wp_verify_nonce( $nonce, $this->publish_action ) ) {
 			return;
 		}
 
-		// Check the nonce.
-		if ( ! wp_verify_nonce( $_POST['apple_news_nonce'], $this->publish_action ) ) {
+		// Check the post ID.
+		$post_id = isset( $_POST['post_ID'] ) ? absint( $_POST['post_ID'] ) : 0;
+		if ( empty( $post_id ) ) {
 			return;
 		}
 
 		// Save meta box fields.
-		$post_id = absint( $_POST['post_ID'] );
 		self::save_post_meta( $post_id );
 
 		// If this is set to autosync or no action is set, we're done here.

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -127,7 +127,10 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			) {
 				$sections = array_map(
 					'sanitize_text_field',
-					$_POST['apple_news_sections']
+					array_map(
+						'wp_unslash',
+						$_POST['apple_news_sections'] // phpcs:ignore WordPress.VIP.ValidatedSanitizedInput.MissingUnslash, WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized
+					)
 				);
 			}
 			update_post_meta( $post_id, 'apple_news_sections', $sections );
@@ -157,7 +160,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		update_post_meta( $post_id, 'apple_news_is_sponsored', $is_sponsored );
 
 		if ( ! empty( $_POST['apple_news_maturity_rating'] ) ) {
-			$maturity_rating = sanitize_text_field( $_POST['apple_news_maturity_rating'] );
+			$maturity_rating = sanitize_text_field( wp_unslash( $_POST['apple_news_maturity_rating'] ) );
 			if ( ! in_array( $maturity_rating, self::$maturity_ratings, true ) ) {
 				$maturity_rating = '';
 			}
@@ -167,14 +170,14 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		}
 
 		if ( ! empty( $_POST['apple_news_pullquote'] ) ) {
-			$pullquote = sanitize_text_field( $_POST['apple_news_pullquote'] );
+			$pullquote = sanitize_text_field( wp_unslash( $_POST['apple_news_pullquote'] ) );
 		} else {
 			$pullquote = '';
 		}
 		update_post_meta( $post_id, 'apple_news_pullquote', $pullquote );
 
 		if ( ! empty( $_POST['apple_news_pullquote_position'] ) ) {
-			$pullquote_position = sanitize_text_field( $_POST['apple_news_pullquote_position'] );
+			$pullquote_position = sanitize_text_field( wp_unslash( $_POST['apple_news_pullquote_position'] ) );
 		} else {
 			$pullquote_position = 'middle';
 		}
@@ -374,7 +377,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Start building cover art meta using the orientation.
 		$meta_value = array(
-			'orientation' => sanitize_text_field( $_POST['apple-news-coverart-orientation'] ),
+			'orientation' => sanitize_text_field( wp_unslash( $_POST['apple-news-coverart-orientation'] ) ),
 		);
 
 		// Iterate through image sizes and add each that is set for the orientation.

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -13,6 +13,14 @@
 class Admin_Apple_Meta_Boxes extends Apple_News {
 
 	/**
+	 * Publish action.
+	 *
+	 * @since 0.9.0
+	 * @var array
+	 */
+	const PUBLISH_ACTION = 'apple_news_publish';
+
+	/**
 	 * Current settings.
 	 *
 	 * @since 0.9.0
@@ -20,15 +28,6 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access private
 	 */
 	private $settings;
-
-	/**
-	 * Publish action.
-	 *
-	 * @since 0.9.0
-	 * @var array
-	 * @access private
-	 */
-	private $publish_action = 'apple_news_publish';
 
 	/**
 	 * Constructor.
@@ -71,12 +70,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	public function do_publish( $post_id, $post ) {
 
 		// Check the nonce.
-		$nonce = isset( $_REQUEST['apple_news_nonce'] )
-			? sanitize_text_field( wp_unslash( $_REQUEST['apple_news_nonce'] ) )
-			: '';
-		if ( ! wp_verify_nonce( $nonce, $this->publish_action ) ) {
-			return;
-		}
+		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );
 
 		// Check the post ID.
 		$post_id = isset( $_POST['post_ID'] ) ? absint( $_POST['post_ID'] ) : 0;
@@ -91,7 +85,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		if ( 'yes' === $this->settings->get( 'api_autosync' )
 			|| 'publish' !== $post->post_status
 			|| empty( $_POST['apple_news_publish_action'] )
-			|| $this->publish_action !== $_POST['apple_news_publish_action'] ) {
+			|| self::PUBLISH_ACTION !== $_POST['apple_news_publish_action'] ) {
 			return;
 		}
 
@@ -118,6 +112,9 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access public
 	 */
 	public static function save_post_meta( $post_id ) {
+
+		// Check the nonce.
+		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );
 
 		// Determine whether to save sections.
 		if ( empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
@@ -233,7 +230,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		}
 
 		// Create local copies of values to pass into the partial.
-		$publish_action = $this->publish_action;
+		$publish_action = self::PUBLISH_ACTION;
 
 		include plugin_dir_path( __FILE__ ) . 'partials/metabox-publish.php';
 	}
@@ -356,7 +353,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		// Localize the JS file for meta boxes.
 		wp_localize_script(
 			$this->plugin_slug . '_meta_boxes_js', 'apple_news_meta_boxes', array(
-				'publish_action' => $this->publish_action,
+				'publish_action' => self::PUBLISH_ACTION,
 			)
 		);
 	}
@@ -369,6 +366,9 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 * @access private
 	 */
 	private static function _save_coverart_meta( $post_id ) {
+
+		// Check the nonce.
+		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );
 
 		// Ensure there is an orientation.
 		if ( empty( $_POST['apple-news-coverart-orientation'] ) ) {

--- a/admin/class-admin-apple-news-list-table.php
+++ b/admin/class-admin-apple-news-list-table.php
@@ -447,7 +447,9 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access protected
 	 */
 	protected function get_publish_status_filter() {
-		return ( empty( $_GET['apple_news_publish_status'] ) ) ? '' : sanitize_text_field( $_GET['apple_news_publish_status'] );
+		return ( ! empty( $_GET['apple_news_publish_status'] ) )
+			? sanitize_text_field( wp_unslash( $_GET['apple_news_publish_status'] ) )
+			: '';
 	}
 
 	/**
@@ -457,7 +459,9 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access protected
 	 */
 	protected function get_date_from_filter() {
-		return ( empty( $_GET['apple_news_date_from'] ) ) ? '' : sanitize_text_field( $_GET['apple_news_date_from'] );
+		return ( ! empty( $_GET['apple_news_date_from'] ) )
+			? sanitize_text_field( wp_unslash( $_GET['apple_news_date_from'] ) )
+			: '';
 	}
 
 	/**
@@ -467,7 +471,9 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access protected
 	 */
 	protected function get_date_to_filter() {
-		return ( empty( $_GET['apple_news_date_to'] ) ) ? '' : sanitize_text_field( $_GET['apple_news_date_to'] );
+		return ( ! empty( $_GET['apple_news_date_to'] ) )
+			? sanitize_text_field( wp_unslash( $_GET['apple_news_date_to'] ) )
+			: '';
 	}
 
 	/**
@@ -477,7 +483,9 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 	 * @access protected
 	 */
 	protected function get_search_filter() {
-		return ( empty( $_GET['s'] ) ) ? '' : sanitize_text_field( $_GET['s'] );
+		return ( ! empty( $_GET['s'] ) )
+			? sanitize_text_field( wp_unslash( $_GET['s'] ) )
+			: '';
 	}
 
 	/**

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -178,10 +178,11 @@ class Admin_Apple_Notice {
 	 */
 	public static function wp_ajax_dismiss_notice() {
 
-		// Verify nonce.
-		if ( ! isset( $_POST['nonce'] )
-			|| ! wp_verify_nonce( $_POST['nonce'], 'apple_news_dismiss_notice' )
-		) {
+		// Check the nonce.
+		$nonce = isset( $_REQUEST['nonce'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) )
+			: '';
+		if ( ! wp_verify_nonce( $nonce, 'apple_news_dismiss_notice' ) ) {
 			return;
 		}
 
@@ -237,7 +238,7 @@ class Admin_Apple_Notice {
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
 			return update_user_attribute( $user_id, self::KEY, $values );
 		} else {
-			return update_user_meta( $user_id, self::KEY, $values );
+			return update_user_meta( $user_id, self::KEY, $values ); // phpcs:ignore WordPress.VIP.RestrictedFunctions.user_meta_update_user_meta
 		}
 	}
 
@@ -252,7 +253,7 @@ class Admin_Apple_Notice {
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
 			return delete_user_attribute( $user_id, self::KEY );
 		} else {
-			return delete_user_meta( $user_id, self::KEY );
+			return delete_user_meta( $user_id, self::KEY ); // phpcs:ignore WordPress.VIP.RestrictedFunctions.user_meta_delete_user_meta
 		}
 	}
 
@@ -269,7 +270,7 @@ class Admin_Apple_Notice {
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
 			$meta_value = get_user_attribute( $user_id, self::KEY );
 		} else {
-			$meta_value = get_user_meta( $user_id, self::KEY, true );
+			$meta_value = get_user_meta( $user_id, self::KEY, true ); // phpcs:ignore WordPress.VIP.RestrictedFunctions.user_meta_get_user_meta
 		}
 
 		return ( ! empty( $meta_value ) ) ? $meta_value : array();
@@ -340,7 +341,7 @@ class Admin_Apple_Notice {
 			if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
 				return update_user_attribute( $user_id, self::KEY, $values );
 			} else {
-				return update_user_meta( $user_id, self::KEY, $values );
+				return update_user_meta( $user_id, self::KEY, $values ); // phpcs:ignore WordPress.VIP.RestrictedFunctions.user_meta_update_user_meta
 			}
 		}
 

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -179,12 +179,7 @@ class Admin_Apple_Notice {
 	public static function wp_ajax_dismiss_notice() {
 
 		// Check the nonce.
-		$nonce = isset( $_REQUEST['nonce'] )
-			? sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) )
-			: '';
-		if ( ! wp_verify_nonce( $nonce, 'apple_news_dismiss_notice' ) ) {
-			return;
-		}
+		check_admin_referer( 'apple_news_dismiss_notice', 'nonce' );
 
 		// Safely extract message and type for comparison.
 		$message = isset( $_POST['message'] )

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -236,7 +236,7 @@ class Admin_Apple_Sections extends Apple_News {
 	public function action_router() {
 
 		// Check for a valid action.
-		$action = isset( $_POST['action'] ) ? sanitize_text_field( $_POST['action'] ) : null;
+		$action = isset( $_POST['action'] ) ? sanitize_text_field( wp_unslash( $_POST['action'] ) ) : null;
 		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
 			return;
 		}
@@ -274,7 +274,7 @@ class Admin_Apple_Sections extends Apple_News {
 				'fields' => 'names',
 				'hide_empty' => false,
 				'number' => 10,
-				'search' => sanitize_text_field( $_GET['term'] ),
+				'search' => sanitize_text_field( wp_unslash( $_GET['term'] ) ),
 				'taxonomy' => $taxonomy->name,
 			)
 		);
@@ -446,7 +446,13 @@ class Admin_Apple_Sections extends Apple_News {
 			$taxonomy_key = 'taxonomy-mapping-' . $section_id;
 			if ( ! empty( $_POST[ $taxonomy_key ] ) && is_array( $_POST[ $taxonomy_key ] ) ) {
 				// Loop over terms and convert to term IDs for save.
-				$values = array_map( 'sanitize_text_field', $_POST[ $taxonomy_key ] );
+				$values = array_map(
+					'sanitize_text_field',
+					array_map(
+						'wp_unslash',
+						$_POST[ $taxonomy_key ] // phpcs:ignore WordPress.VIP.ValidatedSanitizedInput.MissingUnslash, WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized
+					)
+				);
 				foreach ( $values as $value ) {
 					$term = get_term_by( 'name', $value, $taxonomy->name );
 					if ( ! empty( $term ) && ! is_wp_error( $term ) ) {
@@ -459,7 +465,7 @@ class Admin_Apple_Sections extends Apple_News {
 			// Determine if there is theme data for this section.
 			$theme_key = 'theme-mapping-' . $section_id;
 			if ( ! empty( $_POST[ $theme_key ] ) ) {
-				$theme_mappings[ $section_id ] = sanitize_text_field( $_POST[ $theme_key ] );
+				$theme_mappings[ $section_id ] = sanitize_text_field( wp_unslash( $_POST[ $theme_key ] ) );
 			}
 		}
 

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -235,19 +235,16 @@ class Admin_Apple_Sections extends Apple_News {
 	 */
 	public function action_router() {
 
-		// Ensure an action was set.
-		if ( ! isset( $_REQUEST['action'] ) ) {
+		// Check for a valid action.
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
+		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
 			return;
 		}
 
 		// Check the nonce.
 		check_admin_referer( 'apple_news_sections' );
-
-		// Check for a valid action.
-		$action = isset( $_POST['action'] ) ? sanitize_text_field( wp_unslash( $_POST['action'] ) ) : null;
-		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
-			return;
-		}
 
 		// Call the callback for the action for further processing.
 		call_user_func( $this->valid_actions[ $action ] );

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -235,14 +235,19 @@ class Admin_Apple_Sections extends Apple_News {
 	 */
 	public function action_router() {
 
-		// Check for a valid action.
-		$action = isset( $_POST['action'] ) ? sanitize_text_field( wp_unslash( $_POST['action'] ) ) : null;
-		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
+		// Ensure an action was set.
+		if ( ! isset( $_REQUEST['action'] ) ) {
 			return;
 		}
 
 		// Check the nonce.
 		check_admin_referer( 'apple_news_sections' );
+
+		// Check for a valid action.
+		$action = isset( $_POST['action'] ) ? sanitize_text_field( wp_unslash( $_POST['action'] ) ) : null;
+		if ( ( empty( $action ) || ! array_key_exists( $action, $this->valid_actions ) ) ) {
+			return;
+		}
 
 		// Call the callback for the action for further processing.
 		call_user_func( $this->valid_actions[ $action ] );
@@ -421,6 +426,9 @@ class Admin_Apple_Sections extends Apple_News {
 	 * @access private
 	 */
 	private function set_section_mappings() {
+
+		// Check the nonce.
+		check_admin_referer( 'apple_news_sections' );
 
 		// Ensure we got POST data.
 		if ( empty( $_POST ) || ! is_array( $_POST ) ) {

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -199,21 +199,17 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	public function action_router() {
 
-		// Determine if an action was specified.
-		if ( ! isset( $_REQUEST['action'] ) ) {
+		// Determine if a valid action was specified.
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
+		if ( ( empty( $action ) || ! array_key_exists( $action, $this->_valid_actions ) ) ) {
 			return;
 		}
 
 		// Check the nonce.
 		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
-
-		// Determine if a valid action was specified.
-		if ( ( empty( $action )
-			|| ! array_key_exists( $action, $this->_valid_actions ) )
-		) {
-			return;
-		}
 
 		// Call the callback for the action for further processing.
 		call_user_func( $this->_valid_actions[ $action ]['callback'] );

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -205,7 +205,7 @@ class Admin_Apple_Themes extends Apple_News {
 		}
 
 		// Determine if a valid action was specified.
-		$action = sanitize_text_field( $_POST['action'] );
+		$action = sanitize_text_field( wp_unslash( $_POST['action'] ) );
 		if ( ( empty( $action )
 			|| ! array_key_exists( $action, $this->_valid_actions ) )
 		) {
@@ -271,7 +271,7 @@ class Admin_Apple_Themes extends Apple_News {
 		$error = '';
 		$theme = new \Apple_Exporter\Theme();
 		if ( isset( $_GET['theme'] ) ) {
-			$theme_name = sanitize_text_field( $_GET['theme'] );
+			$theme_name = sanitize_text_field( wp_unslash( $_GET['theme'] ) );
 			$theme->set_name( $theme_name );
 			if ( false === $theme->load() ) {
 				$error = sprintf(
@@ -556,7 +556,7 @@ class Admin_Apple_Themes extends Apple_News {
 
 		// Attempt to get the name of the theme from postdata.
 		if ( empty( $name ) && ! empty( $_POST['apple_news_theme'] ) ) {
-			$name = sanitize_text_field( $_POST['apple_news_theme'] );
+			$name = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
 		}
 
 		// Ensure a name was provided.
@@ -591,7 +591,7 @@ class Admin_Apple_Themes extends Apple_News {
 
 		// Get the theme name from POST data.
 		if ( ! empty( $_POST['apple_news_theme'] ) ) {
-			$name = sanitize_text_field( $_POST['apple_news_theme'] );
+			$name = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
 		}
 
 		// Ensure we got a theme name.
@@ -660,7 +660,7 @@ class Admin_Apple_Themes extends Apple_News {
 		}
 
 		// Ensure the theme name is valid.
-		$name = sanitize_text_field( $_POST['apple_news_theme_name'] );
+		$name = sanitize_text_field( wp_unslash( $_POST['apple_news_theme_name'] ) );
 		if ( empty( $name ) ) {
 			\Admin_Apple_Notice::error(
 				__( 'The theme name was empty', 'apple-news' )
@@ -671,7 +671,7 @@ class Admin_Apple_Themes extends Apple_News {
 
 		// Negotiate previous theme name.
 		$previous_name = ( ! empty( $_POST['apple_news_theme_name_previous'] ) )
-			? sanitize_text_field( $_POST['apple_news_theme_name_previous'] )
+			? sanitize_text_field( wp_unslash( $_POST['apple_news_theme_name_previous'] ) )
 			: '';
 
 		// Determine whether this theme is new, is an update, or is being renamed.
@@ -748,7 +748,7 @@ class Admin_Apple_Themes extends Apple_News {
 
 		// Get the theme name from postdata.
 		if ( ! empty( $_POST['apple_news_active_theme'] ) ) {
-			$name = sanitize_text_field( $_POST['apple_news_active_theme'] );
+			$name = sanitize_text_field( wp_unslash( $_POST['apple_news_active_theme'] ) );
 		}
 
 		// Ensure we have a theme name.

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -208,7 +208,6 @@ class Admin_Apple_Themes extends Apple_News {
 		}
 
 		// Check the nonce.
-		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Call the callback for the action for further processing.
@@ -550,13 +549,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function _delete_theme() {
 
-		// Ensure an action was specified.
-		if ( empty( $_REQUEST['action'] ) ) {
-			return;
-		}
-
 		// Check the nonce.
-		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Attempt to get the name of the theme from postdata.
@@ -594,13 +590,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function _export_theme() {
 
-		// Ensure an action was specified.
-		if ( empty( $_REQUEST['action'] ) ) {
-			return;
-		}
-
 		// Check the nonce.
-		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Get the theme name from POST data.
@@ -661,13 +654,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function _save_edit_theme() {
 
-		// Ensure an action was specified.
-		if ( empty( $_REQUEST['action'] ) ) {
-			return;
-		}
-
 		// Check the nonce.
-		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Create a theme object.
@@ -769,13 +759,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function _set_theme() {
 
-		// Ensure an action was specified.
-		if ( empty( $_REQUEST['action'] ) ) {
-			return;
-		}
-
 		// Check the nonce.
-		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Get the theme name from postdata.

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -204,16 +204,16 @@ class Admin_Apple_Themes extends Apple_News {
 			return;
 		}
 
+		// Check the nonce.
+		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
+
 		// Determine if a valid action was specified.
-		$action = sanitize_text_field( wp_unslash( $_POST['action'] ) );
 		if ( ( empty( $action )
 			|| ! array_key_exists( $action, $this->_valid_actions ) )
 		) {
 			return;
 		}
-
-		// Check the nonce.
-		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Call the callback for the action for further processing.
 		call_user_func( $this->_valid_actions[ $action ]['callback'] );
@@ -554,6 +554,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function _delete_theme() {
 
+		// Check the nonce.
+		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
+
 		// Attempt to get the name of the theme from postdata.
 		if ( empty( $name ) && ! empty( $_POST['apple_news_theme'] ) ) {
 			$name = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
@@ -588,6 +592,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access private
 	 */
 	private function _export_theme() {
+
+		// Check the nonce.
+		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Get the theme name from POST data.
 		if ( ! empty( $_POST['apple_news_theme'] ) ) {
@@ -646,6 +654,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access private
 	 */
 	private function _save_edit_theme() {
+
+		// Check the nonce.
+		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Create a theme object.
 		$theme = new \Apple_Exporter\Theme();
@@ -745,6 +757,10 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access private
 	 */
 	private function _set_theme() {
+
+		// Check the nonce.
+		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
+		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Get the theme name from postdata.
 		if ( ! empty( $_POST['apple_news_active_theme'] ) ) {

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -65,7 +65,7 @@ class Admin_Apple_Themes extends Apple_News {
 		}
 
 		// If the field has its own render callback, use that instead.
-		if ( ! empty( $option['callback'] ) ) {
+		if ( ! empty( $option['callback'] ) && is_callable( $option['callback'] ) ) {
 			return call_user_func( $option['callback'], $theme );
 		}
 
@@ -211,7 +211,11 @@ class Admin_Apple_Themes extends Apple_News {
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
 
 		// Call the callback for the action for further processing.
-		call_user_func( $this->_valid_actions[ $action ]['callback'] );
+		if ( isset( $this->_valid_actions[ $action ]['callback'] )
+			&& is_callable( $this->_valid_actions[ $action ]['callback'] )
+		) {
+			call_user_func( $this->_valid_actions[ $action ]['callback'] );
+		}
 	}
 
 	/**

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -200,7 +200,7 @@ class Admin_Apple_Themes extends Apple_News {
 	public function action_router() {
 
 		// Determine if an action was specified.
-		if ( ! isset( $_POST['action'] ) ) {
+		if ( ! isset( $_REQUEST['action'] ) ) {
 			return;
 		}
 
@@ -554,6 +554,11 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	private function _delete_theme() {
 
+		// Ensure an action was specified.
+		if ( empty( $_REQUEST['action'] ) ) {
+			return;
+		}
+
 		// Check the nonce.
 		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
 		check_admin_referer( $this->_valid_actions[ $action ]['nonce'] );
@@ -592,6 +597,11 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access private
 	 */
 	private function _export_theme() {
+
+		// Ensure an action was specified.
+		if ( empty( $_REQUEST['action'] ) ) {
+			return;
+		}
 
 		// Check the nonce.
 		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
@@ -654,6 +664,11 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access private
 	 */
 	private function _save_edit_theme() {
+
+		// Ensure an action was specified.
+		if ( empty( $_REQUEST['action'] ) ) {
+			return;
+		}
 
 		// Check the nonce.
 		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );
@@ -757,6 +772,11 @@ class Admin_Apple_Themes extends Apple_News {
 	 * @access private
 	 */
 	private function _set_theme() {
+
+		// Ensure an action was specified.
+		if ( empty( $_REQUEST['action'] ) ) {
+			return;
+		}
 
 		// Check the nonce.
 		$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) );

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -496,15 +496,21 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 * @access public
 	 */
 	public function save_settings() {
+
+		// If there isn't an action, bail.
+		if ( ! isset( $_REQUEST['action'] ) ) {
+			return;
+		}
+
+		// Form nonce check.
+		check_admin_referer( $this->save_action );
+
 		// Check if we're saving options and that there are settings to save.
 		if ( empty( $_POST['action'] )
 			|| $this->save_action !== $_POST['action']
 			|| empty( $this->settings ) ) {
 			return;
 		}
-
-		// Form nonce check.
-		check_admin_referer( $this->save_action );
 
 		// Get the current Apple News settings.
 		$settings = get_option( self::$section_option_name, array() );

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -497,20 +497,16 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 */
 	public function save_settings() {
 
-		// If there isn't an action, bail.
-		if ( ! isset( $_REQUEST['action'] ) ) {
+		// Check if we're saving options and that there are settings to save.
+		$action = isset( $_REQUEST['action'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			: null;
+		if ( empty( $action ) || $this->save_action !== $action || empty( $this->settings ) ) {
 			return;
 		}
 
 		// Form nonce check.
 		check_admin_referer( $this->save_action );
-
-		// Check if we're saving options and that there are settings to save.
-		if ( empty( $_POST['action'] )
-			|| $this->save_action !== $_POST['action']
-			|| empty( $this->settings ) ) {
-			return;
-		}
 
 		// Get the current Apple News settings.
 		$settings = get_option( self::$section_option_name, array() );

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -515,17 +515,15 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		 */
 		$default_settings = new Settings();
 		foreach ( $this->settings as $key => $attributes ) {
-			if ( ! empty( $_POST[ $key ] )
-				|| ( isset( $_POST[ $key ] )
-					&& in_array( $_POST[ $key ], array( 0, '0' ), true )
-				)
-			) {
-				// Sanitize the value.
+
+			// Negotiate the value.
+			$value = $default_settings->$key;
+			if ( isset( $_POST[ $key ] ) ) {
 				$sanitize = ( empty( $attributes['sanitize'] ) || ! is_callable( $attributes['sanitize'] ) ) ? 'sanitize_text_field' : $attributes['sanitize'];
-				$value = call_user_func( $sanitize, $_POST[ $key ] );
-			} else {
-				// Use the default value.
-				$value = $default_settings->$key;
+				$sanitized_value = call_user_func( $sanitize, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized
+				if ( ! empty( $sanitized_value ) || in_array( $sanitized_value, array( 0, '0' ), true ) ) {
+					$value = $sanitized_value;
+				}
 			}
 
 			// Add to the array.

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -180,7 +180,7 @@ class Components extends Builder {
 			// Try to get the original URL for the image.
 			$original_url = '';
 			foreach ( $bundles as $bundle_url ) {
-				if ( $bundle_basename === Apple_News::get_filename( $bundle_url ) ) {
+				if ( Apple_News::get_filename( $bundle_url ) === $bundle_basename ) {
 					$original_url = $bundle_url;
 					break;
 				}

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -77,9 +77,9 @@ class Settings {
 
 			// Log a deprecated notice, since this is no longer preferred.
 			_deprecated_function(
-				__( 'Getting formatting settings through the \\Apple_Exporter\\Settings object', 'apple-news' ),
+				esc_html__( 'Getting formatting settings through the \\Apple_Exporter\\Settings object', 'apple-news' ),
 				'1.3.0',
-				__( 'the \\Apple_Exporter\\Theme object', 'apple-news' )
+				esc_html__( 'the \\Apple_Exporter\\Theme object', 'apple-news' )
 			);
 
 			return $value;
@@ -91,9 +91,9 @@ class Settings {
 
 			// Log a deprecated notice, since this is no longer preferred.
 			_deprecated_function(
-				__( 'Getting formatting settings through the \\Apple_Exporter\\Settings object', 'apple-news' ),
+				esc_html__( 'Getting formatting settings through the \\Apple_Exporter\\Settings object', 'apple-news' ),
 				'1.3.0',
-				__( 'the \\Apple_Exporter\\Theme object', 'apple-news' )
+				esc_html__( 'the \\Apple_Exporter\\Theme object', 'apple-news' )
 			);
 
 			return $value;

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1391,6 +1391,9 @@ class Theme {
 	 */
 	public function load_postdata() {
 
+		// Check the nonce.
+		check_admin_referer( 'apple_news_save_edit_theme' );
+
 		// Remove all configured values except for JSON templates.
 		if ( ! empty( $this->_values['json_templates'] )
 			&& is_array( $this->_values['json_templates'] )

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1423,7 +1423,7 @@ class Theme {
 							'sanitize_text_field',
 							array_map(
 								'wp_unslash',
-								$_POST[ $option_key ]
+								$_POST[ $option_key ] // phpcs:ignore WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized, WordPress.VIP.ValidatedSanitizedInput.MissingUnslash
 							)
 						);
 					}

--- a/includes/apple-exporter/components/class-tweet.php
+++ b/includes/apple-exporter/components/class-tweet.php
@@ -25,7 +25,7 @@ class Tweet extends Component {
 	 */
 	public static function node_matches( $node ) {
 		// Check if the body of a node is solely a tweet URL.
-		$is_twitter_url = $node->nodeName === 'p' && preg_match( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+		$is_twitter_url = 'p' === $node->nodeName && preg_match( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			'#https?://(www\.)?twitter\.com/.+?/status(es)?/.*#i',
 			trim( $node->nodeValue ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		);

--- a/tests/admin/test-class-admin-apple-meta-boxes.php
+++ b/tests/admin/test-class-admin-apple-meta-boxes.php
@@ -28,6 +28,8 @@ class Admin_Apple_Meta_Boxes_Test extends WP_UnitTestCase {
 		$_POST['apple_news_pullquote_position'] = 'middle';
 		$_POST['apple_news_nonce'] = wp_create_nonce( 'apple_news_publish' );
 		$_POST['apple_news_publish_action'] = 'apple_news_publish';
+		$_REQUEST['post_ID'] = $_POST['post_ID'];
+		$_REQUEST['apple_news_nonce'] = $_POST['apple_news_nonce'];
 
 		// Create the meta box class and simulate a save
 		$meta_box = new Admin_Apple_Meta_Boxes( $this->settings );
@@ -62,6 +64,8 @@ class Admin_Apple_Meta_Boxes_Test extends WP_UnitTestCase {
 		$_POST['apple_news_pullquote_position'] = 'middle';
 		$_POST['apple_news_nonce'] = wp_create_nonce( 'apple_news_publish' );
 		$_POST['apple_news_publish_action'] = 'apple_news_publish';
+		$_REQUEST['post_ID'] = $_POST['post_ID'];
+		$_REQUEST['apple_news_nonce'] = $_POST['apple_news_nonce'];
 
 		// Create the meta box class and simulate a save
 		$meta_box = new Admin_Apple_Meta_Boxes( $this->settings );

--- a/tests/admin/test-class-admin-apple-sections.php
+++ b/tests/admin/test-class-admin-apple-sections.php
@@ -86,6 +86,7 @@ class Admin_Apple_Sections_Test extends WP_UnitTestCase {
 		$_REQUEST = array(
 			'_wp_http_referer' => '/wp-admin/admin.php?page=apple-news-sections',
 			'_wpnonce' => wp_create_nonce( 'apple_news_sections' ),
+			'action' => 'apple_news_set_section_mappings',
 		);
 
 		// Run the request to set up taxonomy mappings.

--- a/tests/admin/test-class-admin-apple-themes.php
+++ b/tests/admin/test-class-admin-apple-themes.php
@@ -54,6 +54,7 @@ class Admin_Apple_Themes_Test extends WP_UnitTestCase {
 		$_POST['redirect'] = false;
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-theme-edit';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['action'] = $_POST['action'];
 
 		// Merge any provided settings with default settings.
 		$default_theme = new \Apple_Exporter\Theme;
@@ -193,6 +194,7 @@ class Admin_Apple_Themes_Test extends WP_UnitTestCase {
 		$_POST['page'] = 'apple-news-themes';
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-themes';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['action'] = $_POST['action'];
 		$this->themes->action_router();
 
 		// Ensure that the test theme does not exist after deletion.
@@ -360,6 +362,7 @@ JSON;
 		$_POST['redirect'] = false;
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-json';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['apple_news_action'] = $_POST['apple_news_action'];
 
 		// Trigger the save operation.
 		$admin_json = new \Admin_Apple_JSON();
@@ -401,6 +404,7 @@ JSON;
 		$_POST['redirect'] = false;
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-json';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['apple_news_action'] = $_POST['apple_news_action'];
 
 		// Trigger the save operation.
 		$admin_json = new \Admin_Apple_JSON();
@@ -441,6 +445,7 @@ JSON;
 		$_POST['redirect'] = false;
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-json';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['apple_news_action'] = $_POST['apple_news_action'];
 
 		// Trigger the spec save.
 		$admin_json = new \Admin_Apple_JSON();
@@ -488,6 +493,7 @@ JSON;
 		$_POST['redirect'] = false;
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-json';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['apple_news_action'] = $_POST['apple_news_action'];
 
 		// Trigger the spec save.
 		$admin_json = new \Admin_Apple_JSON();
@@ -540,6 +546,7 @@ JSON;
 		$_POST['redirect'] = false;
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-json';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['apple_news_action'] = $_POST['apple_news_action'];
 
 		// Trigger the spec save.
 		$admin_json = new \Admin_Apple_JSON();
@@ -582,6 +589,7 @@ JSON;
 		$_POST['page'] = 'apple-news-themes';
 		$_REQUEST['_wp_http_referer'] = '/wp-admin/admin.php?page=apple-news-themes';
 		$_REQUEST['_wpnonce'] = $nonce;
+		$_REQUEST['action'] = $_POST['action'];
 		$this->themes->action_router();
 
 		// Check that the theme got set.


### PR DESCRIPTION
* Addresses `WordPress.CSRF.NonceVerification.NoNonceVerification`.
* Addresses `WordPress.VIP.ValidatedSanitizedInput.MissingUnslash`.
* Addresses `WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized`.
* Addresses `WordPress.XSS.EscapeOutput.OutputNotEscaped`.
* Addresses `WordPress.PHP.YodaConditions.NotYoda`.
* Addresses `WordPress.VIP.RestrictedFunctions.user_meta_update_user_meta`.
* Addresses `WordPress.VIP.ValidatedSanitizedInput.InputNotValidated`.
* Addresses `WordPress.VIP.RestrictedFunctions.user_meta_delete_user_meta`.
* Addresses `WordPress.VIP.RestrictedFunctions.user_meta_get_user_meta`.
* Addresses `WordPress.VIP.FileSystemWritesDisallow.file_ops_delete`.
* Addresses `WordPress.Variables.GlobalVariables.OverrideProhibited`.

Fixes #96