### PR TITLE
Bugfix: Tie the `save_post` action only to registered PTAN post types

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -41,9 +41,6 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Register hooks if enabled.
 		if ( 'yes' === $settings->get( 'show_metabox' ) ) {
-			// Handle a publish action and saving fields.
-			add_action( 'save_post', array( $this, 'do_publish' ), 10, 2 );
-
 			// Add the custom meta boxes to each post type.
 			$post_types = $settings->get( 'post_types' );
 			if ( ! is_array( $post_types ) ) {
@@ -52,6 +49,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 			foreach ( $post_types as $post_type ) {
 				add_action( 'add_meta_boxes_' . $post_type, array( $this, 'add_meta_boxes' ) );
+				add_action( 'save_post_' . $post_type, array( $this, 'do_publish' ), 10, 2 );
 			}
 
 			// Register assets used by the meta box.


### PR DESCRIPTION
The `save_post` action was being used to perform a publish action on
all post types, without regard to whether the post type was registered
with Publish to Apple News or not. Therefore, when a `save_post` action
triggered for a post type that was not registered to PTAN, the nonce
verification check failed, since the metabox was not being displayed
and therefore the nonce was not being generated. This commit modifies
the behavior of the `save_post` action to register separate `save_post`
action hooks for each supported post type.