### PR TITLE
Trying to make adding a cover art filterable for devs that want to add custom urls from CDNs over WordPress attachments

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -38,7 +38,7 @@ class Admin_Apple_News extends Apple_News {
 	public function __construct() {
 		// Register hooks.
 		add_action( 'admin_print_styles-toplevel_page_apple_news_index', array( $this, 'plugin_styles' ) );
-		add_action( 'init', array( $this, 'action_init' ) );
+		add_action( 'init', array( $this, 'add_image_sizes' ) );
 
 		/**
 		 * Admin_Settings builds the settings page for the plugin. Besides setting
@@ -216,8 +216,7 @@ class Admin_Apple_News extends Apple_News {
 	 *
 	 * @access public
 	 */
-	public function action_init() {
-
+	public function add_image_sizes() {
 		// Register custom image crops.
 		if ( 'yes' === self::$settings->enable_cover_art ) {
 			$image_sizes = self::get_image_sizes();

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -38,7 +38,7 @@ class Admin_Apple_News extends Apple_News {
 	public function __construct() {
 		// Register hooks.
 		add_action( 'admin_print_styles-toplevel_page_apple_news_index', array( $this, 'plugin_styles' ) );
-		add_action( 'init', array( $this, 'add_image_sizes' ) );
+		add_action( 'after_setup_theme', array( $this, 'add_image_sizes' ) );
 
 		/**
 		 * Admin_Settings builds the settings page for the plugin. Besides setting

--- a/apple-news.php
+++ b/apple-news.php
@@ -81,7 +81,7 @@ function apple_news_get_plugin_data() {
 	return get_plugin_data( plugin_dir_path( __FILE__ ) . '/apple-news.php' );
 }
 
-new Admin_Apple_News();
+$Admin_Apple_News = new Admin_Apple_News();
 
 /**
  * Reports whether an export is currently happening.


### PR DESCRIPTION
### apple-news.php: 
- Wrapped new function call in a variable so it's easier to access in global scope for hook deregistering and general good practice.

### class-admin-apple-news.php: 
- Changed action to run after_theme_setup which aligns with better WordPress standards and changed the function to something more descriptive

### includes/apple-exporter/builders/class-metadata.php: 
- Added filter to allow url overwriting so you're not forced to only used WordPress attachments