### PR TITLE
Decode HTML entities in URLs from src attributes

### DIFF
--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -89,6 +89,9 @@ class Exporter_Content {
 			$url = site_url( $url );
 		}
 
+		// Decode the HTML entities since the URL is from the src attribute.
+		$url = html_entity_decode( $url );
+
 		// Escape the URL and ensure it is valid.
 		$url = esc_url_raw( $url );
 		if ( empty( $url ) ) {

--- a/tests/apple-exporter/test-class-exporter-content.php
+++ b/tests/apple-exporter/test-class-exporter-content.php
@@ -32,6 +32,9 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'someurl.com', $content->cover() );
 	}
 
+	/**
+	 * Ensure we decode the HTML entities in URLs extracted from HTML attributes.[type]
+	 */
 	public function test_format_src_url() {
 		$this->assertEquals(
 			'https://example.com/some.mp3?one=two&query=arg',

--- a/tests/apple-exporter/test-class-exporter-content.php
+++ b/tests/apple-exporter/test-class-exporter-content.php
@@ -33,11 +33,9 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 	}
 
 	public function test_format_src_url() {
-		$content = new \Apple_Exporter\Exporter_Content( 13, 'Title', '<p>Example content</p>' );
-
 		$this->assertEquals(
 			'https://example.com/some.mp3?one=two&query=arg',
-			$content::format_src_url( 'https://example.com/some.mp3?one=two&amp;query=arg' )
+			\Apple_Exporter\Exporter_Content::format_src_url( 'https://example.com/some.mp3?one=two&amp;query=arg' )
 		);
 	}
 

--- a/tests/apple-exporter/test-class-exporter-content.php
+++ b/tests/apple-exporter/test-class-exporter-content.php
@@ -32,5 +32,13 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'someurl.com', $content->cover() );
 	}
 
-}
+	public function test_format_src_url() {
+		$content = new \Apple_Exporter\Exporter_Content( 13, 'Title', '<p>Example content</p>' );
 
+		$this->assertEquals(
+			'https://example.com/some.mp3?one=two&query=arg',
+			$content::format_src_url( 'https://example.com/some.mp3?one=two&amp;query=arg' )
+		);
+	}
+
+}


### PR DESCRIPTION
Fixes #559.

- Decode HTML entities in URLs extracted from HTML src attributes.