### PR TITLE
Updated section selection description to reflect current behavior.

### DIFF
--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -25,7 +25,7 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		<?php Admin_Apple_Meta_Boxes::build_sections_override( $post->ID ); ?>
 		<div class="apple-news-sections">
 			<?php Admin_Apple_Meta_Boxes::build_sections_field( $post->ID ); ?>
-			<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. Uncheck them all for a standalone article.', 'apple-news' ); ?></p>
+			<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. If none are selected, it will be published to the default section.', 'apple-news' ); ?></p>
 		</div>
 	</div>
 	<div id="apple-news-metabox-is-preview" class="apple-news-metabox-section">

--- a/admin/partials/page-single-push.php
+++ b/admin/partials/page-single-push.php
@@ -27,7 +27,7 @@
 					<?php \Admin_Apple_Meta_Boxes::build_sections_override( $post->ID ); ?>
 					<div class="apple-news-sections">
 						<?php \Admin_Apple_Meta_Boxes::build_sections_field( $post->ID ); ?>
-						<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. Uncheck them all for a standalone article.', 'apple-news' ); ?></p>
+						<p class="description"><?php esc_html_e( 'Select the sections in which to publish this article. If none are selected, it will be published to the default section.', 'apple-news' ); ?></p>
 					</div>
 				</td>
 			</tr>


### PR DESCRIPTION
This updates the description that appears below the section selection checkboxes to more accurately explain the current behavior -- "If none are selected, it will be published to the default section."
![screen shot 2018-11-29 at 5 37 09 pm](https://user-images.githubusercontent.com/152539/49256691-dcb62480-f3fd-11e8-8746-c2076f0b482d.png)
