### PR TITLE
Add the option to exclude individual posts when the site is in auto-sync mode.

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -136,6 +136,13 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		// Check the nonce.
 		check_admin_referer( self::PUBLISH_ACTION, 'apple_news_nonce' );
 
+		if ( ! empty( $_POST['apple_news_is_excluded'] ) && 1 === intval( $_POST['apple_news_is_excluded'] ) ) {
+			$is_excluded = true;
+		} else {
+			$is_excluded = false;
+		}
+		update_post_meta( $post_id, 'apple_news_is_excluded', $is_excluded );
+
 		// Determine whether to save sections.
 		if ( empty( $_POST['apple_news_sections_by_taxonomy'] ) ) {
 			$sections = array();
@@ -237,6 +244,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		$api_id             = get_post_meta( $post->ID, 'apple_news_api_id', true );
 		$deleted            = get_post_meta( $post->ID, 'apple_news_api_deleted', true );
 		$pending            = get_post_meta( $post->ID, 'apple_news_api_pending', true );
+		$is_excluded        = get_post_meta( $post->ID, 'apple_news_is_excluded', true );
 		$is_preview         = get_post_meta( $post->ID, 'apple_news_is_preview', true );
 		$is_hidden          = get_post_meta( $post->ID, 'apple_news_is_hidden', true );
 		$maturity_rating    = get_post_meta( $post->ID, 'apple_news_maturity_rating', true );

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -86,6 +86,11 @@ class Admin_Apple_Post_Sync {
 			return;
 		}
 
+		// Check if the post has been marked for exclusion from auto-publication.
+		// @fixme When Gutenberg is active, sometimes this is not set at the right time.
+		// @see https://github.com/alleyinteractive/apple-news/issues/590
+		$excluded = (bool) get_post_meta( $id, 'apple_news_is_excluded', true );
+
 		/**
 		 * Ability to override the autopublishing of posts on a per-post level.
 		 *
@@ -93,7 +98,7 @@ class Admin_Apple_Post_Sync {
 		 * @param int     $post_id Post ID.
 		 * @param WP_Post $post Post object.
 		 */
-		$should_autopublish = (bool) apply_filters( 'apple_news_should_post_autopublish', true, $id, $post );
+		$should_autopublish = (bool) apply_filters( 'apple_news_should_post_autopublish', ! $excluded, $id, $post );
 
 		// Bail if the filter returns false.
 		if ( ! $should_autopublish ) {

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -20,6 +20,28 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 <?php endif;  // phpcs:ignore Squiz.PHP.NonExecutableCode.Unreachable ?>
 <div id="apple-news-publish">
 	<?php wp_nonce_field( $publish_action, 'apple_news_nonce' ); ?>
+	<?php
+	// Show the exclusion option if set for autosync and not already published to Apple News.
+	global $current_screen;
+	if (
+		'yes' === $this->settings->get( 'api_autosync' )
+		&& ! get_post_meta( $post->ID, 'apple_news_api_id', true )
+		// @todo Remove Gutenberg exclusion once the metadata timing bug is fixed.
+		// @see https://github.com/alleyinteractive/apple-news/issues/590
+		&& ! ( function_exists( 'is_gutenberg_page' ) && is_gutenberg_page() )
+		&& ! ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() )
+	) :
+	?>
+		<div id="apple-news-metabox-exclude" class="apple-news-metabox-section">
+			<h3><?php esc_html_e( 'Exclude from Apple News', 'apple-news' ); ?></h3>
+			<label for="apple-news-is-excluded">
+				<input id="apple-news-is-excluded" name="apple_news_is_excluded" type="checkbox" value="1" <?php checked( $is_excluded ); ?>>
+				<?php esc_html_e( 'Check this to exclude this article from Apple News entirely.', 'apple-news' ); ?>
+			</label>
+		</div>
+	<?php
+	endif;
+	?>
 	<div id="apple-news-metabox-sections" class="apple-news-metabox-section">
 		<h3><?php esc_html_e( 'Sections', 'apple-news' ); ?></h3>
 		<?php Admin_Apple_Meta_Boxes::build_sections_override( $post->ID ); ?>

--- a/assets/js/meta-boxes.js
+++ b/assets/js/meta-boxes.js
@@ -2,6 +2,7 @@
 	'use strict';
 
 	var $assign_by_taxonomy = $( '#apple-news-sections-by-taxonomy' );
+	var $exclude_post = $( '#apple-news-is-excluded' );
 
 	// Listen for clicks on the submit button.
 	$( '#apple-news-publish-submit' ).click(function ( e ) {
@@ -53,4 +54,15 @@
 			.addClass( 'apple-news-metabox-section-collapsed' )
 			.removeClass( 'apple-news-metabox-section-visible' );
 	} );
+
+	// Listen for changes to the "exclude post" checkbox.
+	if ( $exclude_post.length ) {
+		$exclude_post.on( 'change', function () {
+			if ( $( this ).is( ':checked' ) ) {
+				$( '.apple-news-metabox-section:not(#apple-news-metabox-exclude,.apple-news-metabox-section-collapsable),#apple-news-publish > h3,#apple-news-publish > p' ).hide();
+			} else {
+				$( '.apple-news-metabox-section:not(.apple-news-metabox-section-collapsable),#apple-news-publish > h3,#apple-news-publish > p' ).show();
+			}
+		} ).change();
+	}
 })( jQuery, window );


### PR DESCRIPTION
This adds an interface element to prevent the auto-sync of individual posts when auto-sync has been enabled for a site. When selected, it will hide the rest of the UI elements which are made irrelevant. Once a post has been published to Apple News, the exclude option no longer appears and the pre-existing interface options must be used instead to delete or update the post.

![exclude-example](https://user-images.githubusercontent.com/152539/49887477-73c1aa00-fe0a-11e8-8413-71a6aa8b3f5f.png)
