### PR TITLE
Refreshing meta box nonce after re-authenticating following a wp_auth_check()

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -54,6 +54,9 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 			// Register assets used by the meta box.
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_assets' ) );
+
+			// Refresh the nonce after the user re-authenticates due to a wp_auth_check() to avoid failing check_admin_referrer()
+			add_action( 'wp_refresh_nonces', array( $this, 'refresh_nonce' ), 20, 1 );
 		}
 	}
 
@@ -202,6 +205,19 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Save cover art.
 		self::save_coverart_meta( $post_id );
+	}
+
+	/**
+	 * Filters the Heartbeat response to refresh the apple_news_nonce
+	 *
+	 * @param $response array Heartbeat response
+	 * @return array Filtered Heartbeat $response
+	 * @access public
+	 */
+	public function refresh_nonce( $response ) {
+		$response['wp-refresh-post-nonces']['replace']['apple_news_nonce'] = wp_create_nonce( self::PUBLISH_ACTION );
+
+		return $response;
 	}
 
 	/**

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -55,7 +55,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			// Register assets used by the meta box.
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_assets' ) );
 
-			// Refresh the nonce after the user re-authenticates due to a wp_auth_check() to avoid failing check_admin_referrer()
+			// Refresh the nonce after the user re-authenticates due to a wp_auth_check() to avoid failing check_admin_referrer().
 			add_action( 'wp_refresh_nonces', array( $this, 'refresh_nonce' ), 20, 1 );
 		}
 	}
@@ -210,8 +210,8 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	/**
 	 * Filters the Heartbeat response to refresh the apple_news_nonce
 	 *
-	 * @param $response array Heartbeat response
-	 * @return array Filtered Heartbeat $response
+	 * @param array $response Heartbeat response.
+	 * @return array Filtered Heartbeat $response.
 	 * @access public
 	 */
 	public function refresh_nonce( $response ) {


### PR DESCRIPTION
Fixes #622 

Filters wp_refresh_nonces to refresh the apple_news_nonce to prevent data loss after re-authenticating an expired session.