### PR TITLE
An 146 unicode character support

### DIFF
--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -342,7 +342,7 @@ class Exporter {
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
 			// Strip hidden white space.
-			$data = mb_ereg_replace( '/\h+(\/d+)/', ' ', $data );
+			$data = mb_ereg_replace( '/(\h+)<([a-z0-9]+)[^>]*>\s*<\/\1>(\d+)/', ' ', $data );
 
 			return;
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -368,7 +368,7 @@ class Exporter {
 
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
-			// Strip separaters/white space.
+			// Strip separators/white space.
 			$data = str_replace( $this->separators, ' ', $data );
 
 			// Convert all characters into HTML readable entities.

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -341,11 +341,8 @@ class Exporter {
 
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
-			// Convert all characters into HTML readable entities.
-			$data = mb_convert_encoding( $data, 'HTML-ENTITIES', "UTF-8");
-
 			// Strip hidden white space.
-			$data = preg_replace( '/\h+/', ' ', $data );
+			$data = mb_ereg_replace( '/\h+(\/d+)/', ' ', $data );
 
 			return;
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -342,7 +342,7 @@ class Exporter {
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
 			// Strip hidden white space.
-			$data = mb_ereg_replace( '/(\h+)<([a-z0-9]+)[^>]*>\s*<\/\1>(\d+)/', ' ', $data );
+			$data = mb_ereg_replace( '/(\h+)(\x00-\x1F\x7F-\xFF)<([a-z0-9]+)[^>]*>\s*<\/\1>(\d+)/', ' ', $data );
 
 			return;
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -59,6 +59,14 @@ class Exporter {
 	private $builders;
 
 	/**
+	 * A list of Unicode separator characters for use in filtering.
+	 *
+	 * @access private
+	 * @var array
+	 */
+	private $separators;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Exporter_Content $content   The content to export.
@@ -71,6 +79,25 @@ class Exporter {
 		$this->workspace  = $workspace ?: new Workspace( $this->content_id() );
 		$this->settings   = $settings ?: new Settings();
 		$this->builders   = array();
+		$this->separators = array(
+			json_decode( '"\u0020"' ),
+			json_decode( '"\u00a0"' ),
+			json_decode( '"\u1680"' ),
+			json_decode( '"\u2000"' ),
+			json_decode( '"\u2001"' ),
+			json_decode( '"\u2002"' ),
+			json_decode( '"\u2003"' ),
+			json_decode( '"\u2004"' ),
+			json_decode( '"\u2005"' ),
+			json_decode( '"\u2006"' ),
+			json_decode( '"\u2007"' ),
+			json_decode( '"\u2008"' ),
+			json_decode( '"\u2009"' ),
+			json_decode( '"\u200a"' ),
+			json_decode( '"\u202f"' ),
+			json_decode( '"\u205f"' ),
+			json_decode( '"\u3000"' ),
+		);
 	}
 
 	/**
@@ -341,7 +368,8 @@ class Exporter {
 
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
-			$data = mb_ereg_replace( '/\h+/', ' ', $data );
+			$data = str_replace( $this->separators, ' ', $data );
+			$data = preg_replace( '/\h+/', ' ', $data );
 
 			return;
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -342,7 +342,7 @@ class Exporter {
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
 			// Strip hidden white space.
-			$data = mb_ereg_replace( '/(\h+)(\x00-\x1F\x7F-\xFF)<([a-z0-9]+)[^>]*>\s*<\/\1>(\d+)/', ' ', $data );
+			$data = preg_replace( '/\h/u', ' ', $data );
 
 			return;
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -222,7 +222,7 @@ class Exporter {
 		$json = apply_filters( 'apple_news_generate_json', $json, $this->content_id() );
 
 		// Clean up the data array and convert to JSON format.
-		$this->prepare_for_encoding( $json );
+		self::prepare_for_encoding( $json );
 		$json = wp_json_encode( $json );
 
 		return $json;
@@ -330,12 +330,12 @@ class Exporter {
 	 *
 	 * @access private
 	 */
-	public function prepare_for_encoding( &$data ) {
+	public static function prepare_for_encoding( &$data ) {
 
 		// If the value is an array, loop through it and process each element.
 		if ( is_array( $data ) ) {
 			foreach ( $data as &$datum ) {
-				$this->prepare_for_encoding( $datum );
+				self::prepare_for_encoding( $datum );
 			}
 		}
 

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -59,14 +59,6 @@ class Exporter {
 	private $builders;
 
 	/**
-	 * A list of Unicode separator characters for use in filtering.
-	 *
-	 * @access private
-	 * @var array
-	 */
-	private $separators;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param Exporter_Content $content   The content to export.
@@ -79,25 +71,6 @@ class Exporter {
 		$this->workspace  = $workspace ?: new Workspace( $this->content_id() );
 		$this->settings   = $settings ?: new Settings();
 		$this->builders   = array();
-		$this->separators = array(
-			json_decode( '"\u0020"' ),
-			json_decode( '"\u00a0"' ),
-			json_decode( '"\u1680"' ),
-			json_decode( '"\u2000"' ),
-			json_decode( '"\u2001"' ),
-			json_decode( '"\u2002"' ),
-			json_decode( '"\u2003"' ),
-			json_decode( '"\u2004"' ),
-			json_decode( '"\u2005"' ),
-			json_decode( '"\u2006"' ),
-			json_decode( '"\u2007"' ),
-			json_decode( '"\u2008"' ),
-			json_decode( '"\u2009"' ),
-			json_decode( '"\u200a"' ),
-			json_decode( '"\u202f"' ),
-			json_decode( '"\u205f"' ),
-			json_decode( '"\u3000"' ),
-		);
 	}
 
 	/**
@@ -368,9 +341,6 @@ class Exporter {
 
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
-			// Strip separators/white space.
-			$data = str_replace( $this->separators, ' ', $data );
-
 			// Convert all characters into HTML readable entities.
 			$data = mb_convert_encoding( $data, 'HTML-ENTITIES', "UTF-8");
 

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -59,14 +59,6 @@ class Exporter {
 	private $builders;
 
 	/**
-	 * A list of Unicode separator characters for use in filtering.
-	 *
-	 * @access private
-	 * @var array
-	 */
-	private $separators;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param Exporter_Content $content   The content to export.
@@ -79,25 +71,6 @@ class Exporter {
 		$this->workspace  = $workspace ?: new Workspace( $this->content_id() );
 		$this->settings   = $settings ?: new Settings();
 		$this->builders   = array();
-		$this->separators = array(
-			json_decode( '"\u0020"' ),
-			json_decode( '"\u00a0"' ),
-			json_decode( '"\u1680"' ),
-			json_decode( '"\u2000"' ),
-			json_decode( '"\u2001"' ),
-			json_decode( '"\u2002"' ),
-			json_decode( '"\u2003"' ),
-			json_decode( '"\u2004"' ),
-			json_decode( '"\u2005"' ),
-			json_decode( '"\u2006"' ),
-			json_decode( '"\u2007"' ),
-			json_decode( '"\u2008"' ),
-			json_decode( '"\u2009"' ),
-			json_decode( '"\u200a"' ),
-			json_decode( '"\u202f"' ),
-			json_decode( '"\u205f"' ),
-			json_decode( '"\u3000"' ),
-		);
 	}
 
 	/**
@@ -368,8 +341,7 @@ class Exporter {
 
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
-			$data = str_replace( $this->separators, ' ', $data );
-			$data = preg_replace( '/\h+/', ' ', $data );
+			$data = mb_ereg_replace( '/\h+/', ' ', $data );
 
 			return;
 		}

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -368,7 +368,13 @@ class Exporter {
 
 		// If the value is a string, clean it up.
 		if ( is_string( $data ) ) {
+			// Strip separaters/white space.
 			$data = str_replace( $this->separators, ' ', $data );
+
+			// Convert all characters into HTML readable entities.
+			$data = mb_convert_encoding( $data, 'HTML-ENTITIES', "UTF-8");
+
+			// Strip hidden white space.
 			$data = preg_replace( '/\h+/', ' ', $data );
 
 			return;

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -330,7 +330,7 @@ class Exporter {
 	 *
 	 * @access private
 	 */
-	private function prepare_for_encoding( &$data ) {
+	public function prepare_for_encoding( &$data ) {
 
 		// If the value is an array, loop through it and process each element.
 		if ( is_array( $data ) ) {

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -74,11 +74,9 @@ class HTML {
 		$html = wp_kses( $html, $this->_allowed_html );
 
 		// Replace non-breaking spaces with regular spaces.
-		$html = str_ireplace( '&nbsp;', ' ', $html );
-		$html = str_replace( '&#160;', ' ', $html );
-		$html = str_replace( chr( 160 ), ' ', $html );
+		$html = mb_ereg_replace( '/\h+/', ' ', $html );
 
-		// Replace the "null" character with a blank string.
+		// // Replace the "null" character with a blank string.
 		$html = str_replace( chr( 194 ), '', $html );
 
 		// Remove any empty tags.

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -70,6 +70,9 @@ class HTML {
 		// Since wp_kses has an issue with some <script> tags, proactively strip them.
 		$html = preg_replace( '/<script[^>]*?>.*?<\/script>/', '', $html );
 
+		// Remove any tempty tags.
+		$html = preg_replace( '/<([a-z0-9]+)[^>]*>\s*<\/\1>/', '', $html );
+
 		// Strip out all tags and attributes other than what is allowed.
 		$html = wp_kses( $html, $this->_allowed_html );
 

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -73,15 +73,8 @@ class HTML {
 		// Strip out all tags and attributes other than what is allowed.
 		$html = wp_kses( $html, $this->_allowed_html );
 
-		// Replace non-breaking spaces with regular spaces.
-		// Handles chr(160) and &nbsp; characters among many others.
-		$html = mb_ereg_replace( '/\h+/', ' ', $html );
-
 		// // Replace the "null" character with a blank string.
 		$html = str_replace( chr( 194 ), '', $html );
-
-		// Remove any empty tags.
-		$html = preg_replace( '/<([a-z0-9]+)[^>]*>\s*<\/\1>/', '', $html );
 
 		return $html;
 	}

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -73,9 +73,6 @@ class HTML {
 		// Strip out all tags and attributes other than what is allowed.
 		$html = wp_kses( $html, $this->_allowed_html );
 
-		// // Replace the "null" character with a blank string.
-		$html = str_replace( chr( 194 ), '', $html );
-
 		return $html;
 	}
 }

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -70,11 +70,11 @@ class HTML {
 		// Since wp_kses has an issue with some <script> tags, proactively strip them.
 		$html = preg_replace( '/<script[^>]*?>.*?<\/script>/', '', $html );
 
-		// Remove any tempty tags.
-		$html = preg_replace( '/<([a-z0-9]+)[^>]*>\s*<\/\1>/', '', $html );
-
 		// Strip out all tags and attributes other than what is allowed.
 		$html = wp_kses( $html, $this->_allowed_html );
+
+		// Remove any tempty tags.
+		$html = preg_replace( '/<([a-z0-9]+)[^>]*>\s*<\/\1>/', '', $html );
 
 		return $html;
 	}

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -74,6 +74,7 @@ class HTML {
 		$html = wp_kses( $html, $this->_allowed_html );
 
 		// Replace non-breaking spaces with regular spaces.
+		// Handles chr(160) and &nbsp; characters among many others.
 		$html = mb_ereg_replace( '/\h+/', ' ', $html );
 
 		// // Replace the "null" character with a blank string.

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -94,7 +94,7 @@ class Body_Test extends Component_TestCase {
 		$this->assertEquals(
 			array(
 				'role'      => 'body',
-				'text'      => '<p>a</p><p> </p><p>b</p>',
+				'text'      => '<p>a</p><p>b</p>',
 				'format'    => 'html',
 				'textStyle' => 'dropcapBodyStyle',
 				'layout'    => 'body-layout',

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -94,7 +94,7 @@ class Body_Test extends Component_TestCase {
 		$this->assertEquals(
 			array(
 				'role'      => 'body',
-				'text'      => '<p>a</p><p>b</p>',
+				'text'      => '<p>a</p><p> </p><p>b</p>',
 				'format'    => 'html',
 				'textStyle' => 'dropcapBodyStyle',
 				'layout'    => 'body-layout',

--- a/tests/apple-exporter/test-class-exporter.php
+++ b/tests/apple-exporter/test-class-exporter.php
@@ -32,8 +32,9 @@ class Exporter_Test extends WP_UnitTestCase {
 			->get_json()
 			->shouldBeCalled();
 
-		$content  = new Apple_Exporter\Exporter_Content( 3, 'Title', '<p>Example content</p>' );
+		$content  = new Apple_Exporter\Exporter_Content( 3, 'Title', '<p>Example content</p><p>Pondant à Noël — aÀâÂèÈéÉêÊëËîÎïÏôÔùÙûÛüÜÿŸçÇœŒ€æÆ</p>' );
 		$exporter = new Exporter( $content, $workspace->reveal() );
+		$exporter->prepare_for_encoding( $exporter );
 		$exporter->export();
 	}
 
@@ -80,6 +81,5 @@ class Exporter_Test extends WP_UnitTestCase {
 		) );
 		$exporter->export();
 	}
-
 }
 

--- a/tests/apple-exporter/test-class-exporter.php
+++ b/tests/apple-exporter/test-class-exporter.php
@@ -32,9 +32,8 @@ class Exporter_Test extends WP_UnitTestCase {
 			->get_json()
 			->shouldBeCalled();
 
-		$content  = new Apple_Exporter\Exporter_Content( 3, 'Title', '<p>Example content</p><p>Pondant à Noël — aÀâÂèÈéÉêÊëËîÎïÏôÔùÙûÛüÜÿŸçÇœŒ€æÆ</p>' );
+		$content  = new Apple_Exporter\Exporter_Content( 3, 'Title', '<p>Example content</p>' );
 		$exporter = new Exporter( $content, $workspace->reveal() );
-		$exporter->prepare_for_encoding( $exporter );
 		$exporter->export();
 	}
 
@@ -80,6 +79,40 @@ class Exporter_Test extends WP_UnitTestCase {
 			'componentStyles'     => $builder3->reveal(),
 		) );
 		$exporter->export();
+	}
+
+	/**
+	 * Tests the functionality of the prepare_for_encoding function to ensure
+	 * that unwanted characters are stripped.
+	 */
+	public function testPrepareForEncoding() {
+		// Test UTF-8 characters with accents common in French.
+		$test_content = 'Pondant à Noël — aÀâÂèÈéÉêÊëËîÎïÏôÔùÙûÛüÜÿŸçÇœŒ€æÆ';
+		Exporter::prepare_for_encoding( $test_content );
+		$this->assertEquals( 'Pondant à Noël — aÀâÂèÈéÉêÊëËîÎïÏôÔùÙûÛüÜÿŸçÇœŒ€æÆ', $test_content );
+
+		// Test Unicode whitespace character removal.
+		$test_content = json_decode( '"\u0020"' )
+			. json_decode( '"\u00a0"' )
+			. json_decode( '"\u2000"' )
+			. json_decode( '"\u2001"' )
+			. json_decode( '"\u2002"' )
+			. json_decode( '"\u2003"' )
+			. json_decode( '"\u2004"' )
+			. json_decode( '"\u2005"' )
+			. json_decode( '"\u2006"' )
+			. json_decode( '"\u2007"' )
+			. json_decode( '"\u2008"' )
+			. json_decode( '"\u2009"' )
+			. json_decode( '"\u200a"' )
+			. json_decode( '"\u202f"' )
+			. json_decode( '"\u205f"' )
+			. json_decode( '"\u3000"' );
+		Exporter::prepare_for_encoding( $test_content );
+		$this->assertEquals(
+			str_repeat( ' ', strlen( $test_content ) ),
+			$test_content
+		);
 	}
 }
 


### PR DESCRIPTION
Closes: https://alleyinteractive.atlassian.net/browse/AN-146
Potentially closes: #615, #561, #585, #604

- Adds support or the `à` character, and french characters showng below #615:

`Les naïfs ægithales hâtifs pondant a Noël où il gèle sont sûrs d'être déçus en voyant leurs drôles d'œufs abîmés. aÀâÂèÈéÉêÊëËîÎïÏôÔùÙûÛüÜÿŸçÇœŒ€æÆ
`

- Prevents elements in the Classic Editor or Gutenberg editor with the `à` character from throwing an undefined index error #561, and provides output instead of an empty array for those elements #585.
- Fixes issues with non-escaped Unicode characters like `&` #604 causing issues with JSON output.
- Renders French and English characters in Apple News reader:

<img width="396" alt="Screen Shot 2019-04-15 at 3 42 42 PM" src="https://user-images.githubusercontent.com/5230729/56167676-067b7c80-5f96-11e9-8dfa-51ba950a39e9.png">
<img width="396" alt="Screen Shot 2019-04-15 at 3 42 55 PM" src="https://user-images.githubusercontent.com/5230729/56167677-067b7c80-5f96-11e9-8489-2b8ba74bc9d0.png">

