### PR TITLE
AN-154 fix embeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 vendor
 npm-debug.log
 .idea
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ composer.lock
 vendor
 npm-debug.log
 .idea
-/.vscode
+
+## IDE
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ tags
 composer.lock
 vendor
 npm-debug.log
-.idea
 
 ## IDE
+.idea
 .vscode

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -103,12 +103,8 @@ class Export extends Action {
 		 */
 		$post = get_post( $this->id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 
-		// Build the excerpt if required.
-		if ( empty( $post->post_excerpt ) ) {
-			$excerpt = wp_trim_words( wp_strip_all_tags( $this->remove_tags( strip_shortcodes( $post->post_content ) ) ), 55, '...' );
-		} else {
-			$excerpt = wp_strip_all_tags( $post->post_excerpt );
-		}
+		// Only include excerpt if exists.
+		$excerpt = has_excerpt( $post ) ? wp_strip_all_tags( $post->post_excerpt ) : '';
 
 		// Get the post thumbnail.
 		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) ) ?: null;

--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -93,8 +93,8 @@ class Component_Factory {
 		self::register_component( 'facebook', '\\Apple_Exporter\\Components\\Facebook' );
 		self::register_component( 'instagram', '\\Apple_Exporter\\Components\\Instagram' );
 		self::register_component( 'table', '\\Apple_Exporter\\Components\\Table' );
-		self::register_component( 'img', '\\Apple_Exporter\\Components\\Image' );
 		self::register_component( 'iframe', '\\Apple_Exporter\\Components\\Embed_Web_Video' );
+		self::register_component( 'img', '\\Apple_Exporter\\Components\\Image' );
 		self::register_component( 'video', '\\Apple_Exporter\\Components\\Video' );
 		self::register_component( 'audio', '\\Apple_Exporter\\Components\\Audio' );
 		self::register_component( 'heading', '\\Apple_Exporter\\Components\\Heading' );
@@ -145,6 +145,7 @@ class Component_Factory {
 	 * @return \Apple_Exporter\Components\Component A component class matching the shortname.
 	 */
 	public static function get_component( $shortname, $html ) {
+
 		$class = self::$components[ $shortname ];
 
 		if ( is_null( $class ) || ! class_exists( $class ) ) {
@@ -174,6 +175,7 @@ class Component_Factory {
 		$result = array();
 
 		foreach ( self::$components as $shortname => $class ) {
+
 			$matched_node = $class::node_matches( $node );
 
 			// Nothing matched? Skip to next match.
@@ -190,7 +192,6 @@ class Component_Factory {
 				foreach ( $matched_node as $base_component ) {
 					$result[] = self::get_component( $base_component['name'], $base_component['value'] );
 				}
-
 				return $result;
 			}
 
@@ -199,7 +200,6 @@ class Component_Factory {
 			$result[] = self::get_component( $shortname, $html );
 			return $result;
 		}
-
 		// Nothing found. Maybe it's a container element?
 		if ( $node->hasChildNodes() ) {
 			foreach ( $node->childNodes as $child ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
@@ -221,5 +221,4 @@ class Component_Factory {
 
 		return $result;
 	}
-
 }

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -790,7 +790,7 @@ abstract class Component {
 	 * @param [mixed] $node $node object
 	 * @return boolean $has_figure_iframe
 	 */
-	public static function is_gutenberg_embed_figure( $node ) {
+	public static function is_embed_figure( $node ) {
 
 		// Set default.
 		$has_figure_iframe = false;

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -783,4 +783,41 @@ abstract class Component {
 
 		return '';
 	}
+
+	/**
+	 * Get iframe/embed node
+	 *
+	 * @param [mixed] $node $node object
+	 * @return boolean $has_figure_iframe
+	 */
+	public static function is_gutenberg_embed_figure( $node ) {
+
+		// Set default.
+		$has_figure_iframe = false;
+
+		// Return false if we don't have any child nodes.
+		if ( ! $node->hasChildNodes() ) {
+			return $has_figure_iframe;
+		}
+
+		// Loop those child nodes.
+		foreach ( $node->childNodes as $child ) {
+
+			// Return false if we don't have children, or if is an image.
+			if ( ! $child->hasChildNodes() || 'img' === $child->nodeName ) {
+				return $has_figure_iframe;
+			}
+
+			// Loop subchildren.
+			foreach ( $child->childNodes as $c ) {
+
+				// Return true if we're seeing an iframe.
+				if ( 'iframe' === $c->nodeName ) {
+					return true;
+				}
+			}
+		}
+
+		return $has_figure_iframe;
+	}
 }

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -9,6 +9,8 @@
 
 namespace Apple_Exporter\Components;
 
+use Apple_Exporter\Components\Component;
+
 /**
  * An embedded video from Youtube or Vimeo, for example. For now, assume
  * any iframe is an embedded video.
@@ -39,6 +41,7 @@ class Embed_Web_Video extends Component {
 		return (
 			( 'p' === $node->nodeName && preg_match( $pattern, trim( $node->nodeValue ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			|| ( 'iframe' === $node->nodeName && preg_match( $pattern, trim( $node->getAttribute( 'src' ) ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			|| ( 'figure' === $node->nodeName && Component::is_gutenberg_embed_figure( $node ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		);
 	}
 

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -41,7 +41,7 @@ class Embed_Web_Video extends Component {
 		return (
 			( 'p' === $node->nodeName && preg_match( $pattern, trim( $node->nodeValue ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			|| ( 'iframe' === $node->nodeName && preg_match( $pattern, trim( $node->getAttribute( 'src' ) ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
-			|| ( 'figure' === $node->nodeName && Component::is_gutenberg_embed_figure( $node ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			|| ( 'figure' === $node->nodeName && Component::is_embed_figure( $node ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		);
 	}
 

--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -22,17 +22,9 @@ class Facebook extends Component {
 	 * A list of regular expression patterns for whitelisted Facebook oEmbed formats.
 	 *
 	 * @see https://developer.apple.com/library/prerelease/content/documentation/General/Conceptual/Apple_News_Format_Ref/FacebookPost.html#//apple_ref/doc/uid/TP40015408-CH106-SW1
-	 *
-	 * @access private
-	 * @var array
+	 * @see https://developers.facebook.com/docs/plugins/oembed-endpoints/
 	 */
-	private static $_formats = array(
-		'/^https:\/\/www\.facebook\.com\/[^\/]+\/posts\/[^\/]+\/?$/',
-		'/^https:\/\/www\.facebook\.com\/[^\/]+\/activity\/[^\/]+\/?$/',
-		'/^https:\/\/www\.facebook\.com\/photo.php\?fbid=.+$/',
-		'/^https:\/\/www\.facebook\.com\/photos\/[^\/]+\/?$/',
-		'/^https:\/\/www\.facebook\.com\/permalink\.php\?story_fbid=.+$/',
-	);
+	const FACEBOOK_MATCH = '/(?:https?:\/\/)?(?:www\.)?(?:facebook|fb|m\.facebook)\.(?:com|me)\/(?:(?:\w)*#!\/)?(?:pages\/)?(?:[\w\-]*\/)*([\w\-\.]+)(?:\/)?/i';
 
 	/**
 	 * Regular expressions for extracting post URLs from HTML markup.
@@ -150,11 +142,8 @@ class Facebook extends Component {
 	 */
 	private static function get_facebook_url( $text ) {
 
-		// Loop through whitelisted formats looking for matches.
-		foreach ( self::$_formats as $format ) {
-			if ( preg_match( $format, $text ) ) {
-				return untrailingslashit( $text );
-			}
+		if ( preg_match( self::FACEBOOK_MATCH, $text ) ) {
+			return untrailingslashit( $text );
 		}
 
 		return false;

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -27,7 +27,7 @@ class Image extends Component {
 	public static function node_matches( $node ) {
 		// Is this an image node?
 		if (
-			( 'img' === $node->nodeName || ( 'figure' === $node->nodeName && Component::is_gutenberg_embed_figure( $node ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			( 'img' === $node->nodeName || ( 'figure' === $node->nodeName && Component::is_embed_figure( $node ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			&& self::remote_file_exists( $node )
 		) {
 			return $node;

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -8,6 +8,8 @@
 
 namespace Apple_Exporter\Components;
 
+use Apple_Exporter\Components\Component;
+
 /**
  * Represents a simple image.
  *
@@ -25,7 +27,7 @@ class Image extends Component {
 	public static function node_matches( $node ) {
 		// Is this an image node?
 		if (
-			( 'img' === $node->nodeName || 'figure' === $node->nodeName ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			( 'img' === $node->nodeName || ( 'figure' === $node->nodeName && Component::is_gutenberg_embed_figure( $node ) ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			&& self::remote_file_exists( $node )
 		) {
 			return $node;

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -19,7 +19,24 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		return apple_news_is_exporting() ? 'is exporting' : 'is not exporting';
 	}
 
-	public function testAutoExcerpt() {
+	public function testHasExcerpt() {
+		$title = 'My Title';
+		$excerpt = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue...';
+
+		$post_id = $this->factory->post->create( array(
+			'post_title' => $title,
+			'post_content' => '',
+			'post_excerpt' => $excerpt,
+		) );
+
+		$export = new Export( $this->settings, $post_id );
+		$exporter = $export->fetch_exporter();
+		$exporter_content = $exporter->get_content();
+
+		$this->assertEquals( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue...', $exporter_content->intro() );
+	}
+
+	public function testNoExcerpt() {
 		$title = 'My Title';
 		$content = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue arcu. Curabitur lacus elit, venenatis a laoreet sit amet, imperdiet ac lorem. Curabitur sed leo sed ligula tempor feugiat. Cras in tellus et elit volutpat.</p>';
 
@@ -33,7 +50,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		$exporter = $export->fetch_exporter();
 		$exporter_content = $exporter->get_content();
 
-		$this->assertEquals( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue...', $exporter_content->intro() );
+		$this->assertEquals( '', $exporter_content->intro() );
 	}
 
 	public function testShortcodeInExcerpt() {
@@ -50,7 +67,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		$exporter = $export->fetch_exporter();
 		$exporter_content = $exporter->get_content();
 
-		$this->assertEquals( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue...', $exporter_content->intro() );
+		$this->assertEquals( '', $exporter_content->intro() );
 	}
 
 	public function testBylineFormat() {


### PR DESCRIPTION
Closes #599, #597, #596, #594
Also Closes: https://alleyinteractive.atlassian.net/browse/AN-154

- Fixes Facebook embeds, relies on WordPress to filter "success" embeds, and accommodate all mobile, short link and full facebook URLs. 
- Replaced multiple Facebook REGEX strings with single catch-all.
- Fixes YouTube embeds and new Gutenberg embed structure.
- Adds function to check for Gutenberg embed structure.
- Checks for excerpt before outputting the excerpt.

### Test With Apple News
Includes images and article.json for Gutenberg and the Classic Editor (rename article.json to test).
[apple-news-test.zip](https://github.com/alleyinteractive/apple-news/files/3153274/apple-news-test.zip)

NOTE: There will be image width warnings because the images used were small.