### PR TITLE
Replace contentInset with padding in quote layout

### DIFF
--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -105,12 +105,7 @@ class Quote extends Component {
 			'blockquote-layout',
 			__( 'Blockquote Layout', 'apple-news' ),
 			array(
-				'contentInset' => array(
-					'bottom' => true,
-					'left'   => true,
-					'right'  => true,
-					'top'    => true,
-				),
+				'padding' => 20
 			)
 		);
 


### PR DESCRIPTION
Per https://developer.apple.com/documentation/apple_news/contentinset, contentInset is now deprecated - updating blockquote layout to use padding instead.