### PR TITLE
AN-147 publish to multiple sections

### DIFF
--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -192,7 +192,7 @@ class Sidebar extends React.PureComponent {
     const selectedSectionsArray = Array.isArray(selectedSectionsRaw)
       ? selectedSectionsRaw
       : [];
-    const parsedCoverArt = JSON.parse(coverArt) || '{}';
+    const parsedCoverArt = '' !== coverArt ? JSON.parse(coverArt) : {};
     const coverArtOrientation = parsedCoverArt.orientation || 'landscape';
     const coverArtSizes = [
       {
@@ -229,7 +229,7 @@ class Sidebar extends React.PureComponent {
           <h3>Sections</h3>
           <CheckboxControl
             label={__('Assign sections by category', 'apple-news')}
-            checked
+            checked={'' === sections || ! sections.length}
           />
           <hr />
           {! someKey && [

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -121,6 +121,9 @@ class Sidebar extends React.PureComponent {
       .catch((error) => console.error(error)); /* eslint-disable-line no-console */
   }
 
+  /**
+   * Fetch published state.
+   */
   fetchPublishState() {
     const {
       post,
@@ -132,6 +135,12 @@ class Sidebar extends React.PureComponent {
       .catch((error) => console.error(error)); /* eslint-disable-line no-console */
   }
 
+  /**
+   * Select Cover Art Image
+   *
+   * @param   {string}  metaKey  metakey name
+   * @param   {string}  value    meta key value
+   */
   updateSelectCoverArtImage(metaKey, value) {
     const {
       onUpdate,
@@ -157,6 +166,14 @@ class Sidebar extends React.PureComponent {
     );
   }
 
+  /**
+   * Update which sections are selected.
+   *
+   * @param   {boolean} checked  is selected
+   * @param   {string}  name     name of item selected
+   *
+   * @return void.
+   */
   updateSelectedSections(checked, name) {
     const {
       onUpdate,
@@ -165,14 +182,19 @@ class Sidebar extends React.PureComponent {
       },
     } = this.props;
     // Need to default to [], else JSON parse fails
-    const selectedSectionsArray = JSON.parse(selectedSections) || '[]';
+    const selectedSectionsArray = JSON.parse(selectedSections) || null;
+
+    const arrayFilter = selectedSectionsArray.filter(
+      (section) => section !== name
+    );
+    const selectedArrayFilter = 0 < arrayFilter.length ? arrayFilter : null;
 
     onUpdate(
       'apple_news_sections',
       JSON.stringify(
         checked
           ? [...selectedSectionsArray, name]
-          : selectedSectionsArray.filter((section) => section !== name)
+          : selectedArrayFilter
       )
     );
   }

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -64,7 +64,7 @@ class Sidebar extends React.PureComponent {
     this.state = {
       autoAssignCategories: false,
       sections: [],
-      selectedSectionsPrev: JSON.stringify('[]'),
+      selectedSectionsPrev: null,
       settings: {
         enableCoverArt: false,
         adminUrl: '',
@@ -182,20 +182,23 @@ class Sidebar extends React.PureComponent {
       },
     } = this.props;
     // Need to default to [], else JSON parse fails
-    const selectedSectionsArray = JSON.parse(selectedSections) || null;
+    const selectedSectionsArray = JSON.parse(selectedSections) || [];
+
+    const selectedArrayDefault = Array.isArray(selectedSectionsArray)
+      ? JSON.stringify([...selectedSectionsArray, name]) : null;
 
     const arrayFilter = selectedSectionsArray.filter(
       (section) => section !== name
     );
-    const selectedArrayFilter = 0 < arrayFilter.length ? arrayFilter : null;
+
+    const selectedArrayFilter = 0 < arrayFilter.length
+      ? JSON.stringify(arrayFilter) : null;
 
     onUpdate(
       'apple_news_sections',
-      JSON.stringify(
-        checked
-          ? [...selectedSectionsArray, name]
-          : selectedArrayFilter
-      )
+      checked
+        ? selectedArrayDefault
+        : selectedArrayFilter
     );
   }
 
@@ -284,7 +287,7 @@ class Sidebar extends React.PureComponent {
                 });
                 if (checked) {
                   this.setState({
-                    selectedSectionsPrev: selectedSections,
+                    selectedSectionsPrev: selectedSections || null,
                   });
                   onUpdate(
                     'apple_news_sections',
@@ -296,7 +299,7 @@ class Sidebar extends React.PureComponent {
                     selectedSectionsPrev
                   );
                   this.setState({
-                    selectedSectionsPrev: '',
+                    selectedSectionsPrev: null,
                   });
                 }
               }

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -143,7 +143,7 @@ class Sidebar extends React.PureComponent {
       },
     } = this.props;
     // Need to default to [], else JSON parse fails
-    const selectedSectionsArray = JSON.parse(selectedSections || '[]');
+    const selectedSectionsArray = JSON.parse(selectedSections) || '[]';
 
     onUpdate(
       'apple_news_sections',

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -278,7 +278,7 @@ class Sidebar extends React.PureComponent {
         >
           <Notifications />
           <h3>Sections</h3>
-          {automaticAssignment && (
+          {automaticAssignment && [
             <CheckboxControl
               label={__('Assign sections by category', 'apple-news')}
               checked={autoAssignCategories}
@@ -306,10 +306,10 @@ class Sidebar extends React.PureComponent {
                   }
                 }
               }
-            />
-          )}
-          <hr />
-          {! autoAssignCategories && [
+            />,
+            <hr />,
+          ]}
+          {(! autoAssignCategories || ! automaticAssignment) && [
             <h4>Manual Section Selection</h4>,
             Array.isArray(sections) && (
               <ul className="apple-news-sections">

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -174,6 +174,7 @@ class Sidebar extends React.PureComponent {
         dateCreated = '',
         dateModified = '',
         shareUrl = '',
+        someKey = false,
         revision = '',
       },
       onUpdate,
@@ -226,21 +227,29 @@ class Sidebar extends React.PureComponent {
         >
           <Notifications />
           <h3>Sections</h3>
-          {Array.isArray(sections) && (
-            <ul className="apple-news-sections">
-              {sections.map(({ id, name }) => (
-                <li key={id}>
-                  <CheckboxControl
-                    label={name}
-                    checked={- 1 !== selectedSectionsArray.indexOf(id)}
-                    onChange={
-                      (checked) => this.updateSelectedSections(checked, id)
-                    }
-                  />
-                </li>
-              ))}
-            </ul>
-          )}
+          <CheckboxControl
+            label={__('Assign sections by category', 'apple-news')}
+            checked
+          />
+          <hr />
+          {! someKey && [
+            <h4>Manual Section Selection</h4>,
+            Array.isArray(sections) && (
+              <ul className="apple-news-sections">
+                {sections.map(({ id, name }) => (
+                  <li key={id}>
+                    <CheckboxControl
+                      label={name}
+                      checked={- 1 !== selectedSectionsArray.indexOf(id)}
+                      onChange={
+                        (checked) => this.updateSelectedSections(checked, id)
+                      }
+                    />
+                  </li>
+                ))}
+              </ul>
+            ),
+          ]}
           <p>
             <em>
               {

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -60,6 +60,7 @@ class Sidebar extends React.PureComponent {
     super(props);
 
     this.state = {
+      autoAssignCategories: false,
       sections: [],
       settings: {
         enableCoverArt: false,
@@ -174,13 +175,13 @@ class Sidebar extends React.PureComponent {
         dateCreated = '',
         dateModified = '',
         shareUrl = '',
-        someKey = false,
         revision = '',
       },
       onUpdate,
     } = this.props;
 
     const {
+      autoAssignCategories,
       sections,
       settings: {
         enableCoverArt,
@@ -229,10 +230,23 @@ class Sidebar extends React.PureComponent {
           <h3>Sections</h3>
           <CheckboxControl
             label={__('Assign sections by category', 'apple-news')}
-            checked={'' === sections || ! sections.length}
+            checked={autoAssignCategories}
+            onChange={
+              (checked) => {
+                this.setState({
+                  autoAssignCategories: checked,
+                });
+                onUpdate(
+                  'apple_news_sections',
+                  JSON.stringify(
+                    [],
+                  )
+                );
+              }
+            }
           />
           <hr />
-          {! someKey && [
+          {! autoAssignCategories && [
             <h4>Manual Section Selection</h4>,
             Array.isArray(sections) && (
               <ul className="apple-news-sections">

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -191,7 +191,7 @@ class Sidebar extends React.PureComponent {
     const selectedSectionsArray = Array.isArray(selectedSectionsRaw)
       ? selectedSectionsRaw
       : [];
-    const parsedCoverArt = JSON.parse(coverArt || '{}');
+    const parsedCoverArt = JSON.parse(coverArt) || '{}';
     const coverArtOrientation = parsedCoverArt.orientation || 'landscape';
     const coverArtSizes = [
       {

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -1,5 +1,7 @@
 /* global React, wp */
 
+/* eslint-disable react/no-unused-state */
+
 import PropTypes from 'prop-types';
 import ImagePicker from '../imagePicker';
 import Notifications from '../notifications';
@@ -62,6 +64,7 @@ class Sidebar extends React.PureComponent {
     this.state = {
       autoAssignCategories: false,
       sections: [],
+      selectedSectionsPrev: [],
       settings: {
         enableCoverArt: false,
         adminUrl: '',
@@ -187,6 +190,7 @@ class Sidebar extends React.PureComponent {
         enableCoverArt,
         adminUrl,
       },
+      selectedSectionsPrev,
       publishState,
     } = this.state;
     const selectedSectionsRaw = '' !== selectedSections
@@ -238,12 +242,23 @@ class Sidebar extends React.PureComponent {
                 this.setState({
                   autoAssignCategories: checked,
                 });
-                onUpdate(
-                  'apple_news_sections',
-                  JSON.stringify(
-                    [],
-                  )
-                );
+                if (checked) {
+                  this.setState({
+                    selectedSectionsPrev: selectedSections,
+                  });
+                  onUpdate(
+                    'apple_news_sections',
+                    null
+                  );
+                } else {
+                  onUpdate(
+                    'apple_news_sections',
+                    selectedSectionsPrev
+                  );
+                  this.setState({
+                    selectedSectionsPrev: [],
+                  });
+                }
               }
             }
           />

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -64,7 +64,7 @@ class Sidebar extends React.PureComponent {
     this.state = {
       autoAssignCategories: false,
       sections: [],
-      selectedSectionsPrev: [],
+      selectedSectionsPrev: JSON.stringify('[]'),
       settings: {
         enableCoverArt: false,
         adminUrl: '',
@@ -79,6 +79,24 @@ class Sidebar extends React.PureComponent {
     this.fetchSections();
     this.fetchSettings();
     this.fetchPublishState();
+    this.setAutoCategoryState();
+  }
+
+  /**
+   * Set initial checkbox state for category auto.
+   *
+   * @return  {boolean}  state for autoAssignCategories
+   */
+  setAutoCategoryState() {
+    const {
+      meta: {
+        selectedSections,
+      },
+    } = this.props;
+
+    this.setState({
+      autoAssignCategories: 'null' === selectedSections,
+    });
   }
 
   /**
@@ -193,7 +211,7 @@ class Sidebar extends React.PureComponent {
       selectedSectionsPrev,
       publishState,
     } = this.state;
-    const selectedSectionsRaw = '' !== selectedSections
+    const selectedSectionsRaw = 'null' !== selectedSections
       ? JSON.parse(selectedSections)
       : '';
     const selectedSectionsArray = Array.isArray(selectedSectionsRaw)
@@ -256,7 +274,7 @@ class Sidebar extends React.PureComponent {
                     selectedSectionsPrev
                   );
                   this.setState({
-                    selectedSectionsPrev: [],
+                    selectedSectionsPrev: '',
                   });
                 }
               }

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -189,7 +189,9 @@ class Sidebar extends React.PureComponent {
       },
       publishState,
     } = this.state;
-    const selectedSectionsRaw = JSON.parse(selectedSections);
+    const selectedSectionsRaw = '' !== selectedSections
+      ? JSON.parse(selectedSections)
+      : '';
     const selectedSectionsArray = Array.isArray(selectedSectionsRaw)
       ? selectedSectionsRaw
       : [];

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -243,7 +243,8 @@ class Sidebar extends React.PureComponent {
     const selectedSectionsArray = Array.isArray(selectedSectionsRaw)
       ? selectedSectionsRaw
       : [];
-    const parsedCoverArt = '' !== coverArt ? JSON.parse(coverArt) : {};
+    const parsedCoverArt = '' !== coverArt && 'null' !== coverArt
+      ? JSON.parse(coverArt) : {};
     const coverArtOrientation = parsedCoverArt.orientation || 'landscape';
     const coverArtSizes = [
       {

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -230,6 +230,7 @@ class Sidebar extends React.PureComponent {
       autoAssignCategories,
       sections,
       settings: {
+        automaticAssignment,
         enableCoverArt,
         adminUrl,
       },
@@ -277,34 +278,36 @@ class Sidebar extends React.PureComponent {
         >
           <Notifications />
           <h3>Sections</h3>
-          <CheckboxControl
-            label={__('Assign sections by category', 'apple-news')}
-            checked={autoAssignCategories}
-            onChange={
-              (checked) => {
-                this.setState({
-                  autoAssignCategories: checked,
-                });
-                if (checked) {
+          {automaticAssignment && (
+            <CheckboxControl
+              label={__('Assign sections by category', 'apple-news')}
+              checked={autoAssignCategories}
+              onChange={
+                (checked) => {
                   this.setState({
-                    selectedSectionsPrev: selectedSections || null,
+                    autoAssignCategories: checked,
                   });
-                  onUpdate(
-                    'apple_news_sections',
-                    null
-                  );
-                } else {
-                  onUpdate(
-                    'apple_news_sections',
-                    selectedSectionsPrev
-                  );
-                  this.setState({
-                    selectedSectionsPrev: null,
-                  });
+                  if (checked) {
+                    this.setState({
+                      selectedSectionsPrev: selectedSections || null,
+                    });
+                    onUpdate(
+                      'apple_news_sections',
+                      null
+                    );
+                  } else {
+                    onUpdate(
+                      'apple_news_sections',
+                      selectedSectionsPrev
+                    );
+                    this.setState({
+                      selectedSectionsPrev: null,
+                    });
+                  }
                 }
               }
-            }
-          />
+            />
+          )}
           <hr />
           {! autoAssignCategories && [
             <h4>Manual Section Selection</h4>,

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -18,6 +18,7 @@ function get_settings_response( $data ) {
 		// Get admin settings
 		$admin_settings = new \Admin_Apple_Settings();
 		$settings = $admin_settings->fetch_settings();
+		$response['automaticAssignment'] = ! empty( get_option( 'apple_news_section_taxonomy_mappings' ) );
 		$response['enableCoverArt'] = 'no' !== $settings->enable_cover_art;
 		$response['adminUrl'] = esc_url( admin_url( 'admin.php?page=apple-news-options' ) );
 	}


### PR DESCRIPTION
Closes: #614 
Completes: https://alleyinteractive.atlassian.net/browse/AN-147

- Adds "Assign sections by category" checkbox, and assigned/removes data as necessary.
- Fixes several `string`/`JSON.parse`-related errors.
- Allows "sections" post meta to be `null` instead of an empty array to appease the PHP side of the plugin/publishing.
- Updates the "settings" endpoint to include a boolean based on the value of (or not of) `apple_news_section_taxonomy_mappings`. If true, there are sections saved in post meta and the default is not to "Assign sections by category".