### PR TITLE
AN-166 Add Publish, Update, and Delete Buttons

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -21,12 +21,14 @@ require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-themes.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-preview.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-json.php';
 // REST Includes
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-sections.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-clear-notifications.php';
+require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-delete.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-notifications.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-published-state.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-settings.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-publish.php';
+require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-sections.php';
+require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-update.php';
 
 /**
  * Entry-point class for the plugin.

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -29,6 +29,7 @@ require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-sett
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-publish.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-sections.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-update.php';
+require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-user-can-publish.php';
 
 /**
  * Entry-point class for the plugin.

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -26,6 +26,7 @@ require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-clear-no
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-notifications.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-published-state.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-settings.php';
+require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-publish.php';
 
 /**
  * Entry-point class for the plugin.

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -344,10 +344,10 @@ class Admin_Apple_Notice {
 	 * Handle getting user meta across potential hosting platforms.
 	 *
 	 * @param int $user_id The user ID for which to retrieve meta.
-	 * @access public
+	 * @access private
 	 * @return array An array of values for the key.
 	 */
-	public static function get_user_meta( $user_id ) {
+	private static function get_user_meta( $user_id ) {
 
 		// Negotiate meta value.
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV && function_exists( 'get_user_attribute' ) ) {

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -344,13 +344,13 @@ class Admin_Apple_Notice {
 	 * Handle getting user meta across potential hosting platforms.
 	 *
 	 * @param int $user_id The user ID for which to retrieve meta.
-	 * @access private
+	 * @access public
 	 * @return array An array of values for the key.
 	 */
-	private static function get_user_meta( $user_id ) {
+	public static function get_user_meta( $user_id ) {
 
 		// Negotiate meta value.
-		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
+		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV && function_exists( 'get_user_attribute' ) ) {
 			$meta_value = get_user_attribute( $user_id, self::KEY );
 		} else {
 			$meta_value = get_user_meta( $user_id, self::KEY, true ); // phpcs:ignore WordPress.VIP.RestrictedFunctions.user_meta_get_user_meta

--- a/apple-news.php
+++ b/apple-news.php
@@ -179,3 +179,14 @@ function apple_news_is_classic_editor_plugin_active() {
 
     return false;
 }
+
+/**
+ * Given a user ID, a post ID, and an action, determines whether a user can
+ * perform the action or not.
+ *
+ * @param int    $post_id The ID of the post to check.
+ * @param string $action  The action to check. One of 'publish', 'update', 'delete'.
+ * @param int    $user_id The user ID to check.
+ *
+ * @return bool True if the user can perform the action, false otherwise.
+ */

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -76,6 +76,7 @@ class Sidebar extends React.PureComponent {
     sections: [],
     selectedSectionsPrev: null,
     settings: {},
+    userCanPublish: false,
   };
 
   constructor(props) {
@@ -100,6 +101,7 @@ class Sidebar extends React.PureComponent {
     this.fetchSections();
     this.fetchSettings();
     this.fetchPublishState();
+    this.fetchUserCanPublish();
   }
 
   /**
@@ -198,6 +200,20 @@ class Sidebar extends React.PureComponent {
 
     apiFetch({ path })
       .then(({ publishState }) => (this.setState({ publishState })))
+      .catch((error) => console.error(error)); /* eslint-disable-line no-console */
+  }
+
+  /**
+   * Fetch whether the current user can publish to Apple News.
+   */
+  fetchUserCanPublish() {
+    const {
+      post,
+    } = this.props;
+    const path = `/apple-news/v1/user-can-publish/${post.id}`;
+
+    apiFetch({ path })
+      .then(({ userCanPublish }) => (this.setState({ userCanPublish })))
       .catch((error) => console.error(error)); /* eslint-disable-line no-console */
   }
 
@@ -384,6 +400,9 @@ class Sidebar extends React.PureComponent {
 
     const {
       onUpdate,
+      post: {
+        status = '',
+      } = {},
     } = this.props;
 
     const {
@@ -404,6 +423,7 @@ class Sidebar extends React.PureComponent {
         shareUrl = '',
         revision = '',
       },
+      publishState,
       sections,
       settings: {
         adminUrl,
@@ -414,7 +434,7 @@ class Sidebar extends React.PureComponent {
         enableCoverArt,
       },
       selectedSectionsPrev,
-      publishState,
+      userCanPublish,
     } = this.state;
 
     const selectedSectionsRaw = 'null' !== selectedSections
@@ -734,41 +754,45 @@ class Sidebar extends React.PureComponent {
               </Fragment>
             )}
           </PanelBody>
-          {loading ? (
-            <Spinner />
-          ) : (
+          {'publish' === status && userCanPublish && (
             <Fragment>
-              {'' !== publishState && 'N/A' !== publishState ? (
-                <Fragment>
-                  {! apiAutosyncUpdate && (
-                    <Button
-                      isPrimary
-                      onClick={this.updatePost}
-                      style={{ margin: '1em' }}
-                    >
-                      {__('Update', 'apple-news')}
-                    </Button>
-                  )}
-                  {! apiAutosyncDelete && (
-                    <Button
-                      isDefault
-                      onClick={this.deletePost}
-                      style={{ margin: '1em' }}
-                    >
-                      {__('Delete', 'apple-news')}
-                    </Button>
-                  )}
-                </Fragment>
+              {loading ? (
+                <Spinner />
               ) : (
                 <Fragment>
-                  {! apiAutosync && (
-                    <Button
-                      isPrimary
-                      onClick={this.publishPost}
-                      style={{ margin: '1em' }}
-                    >
-                      {__('Publish', 'apple-news')}
-                    </Button>
+                  {'' !== publishState && 'N/A' !== publishState ? (
+                    <Fragment>
+                      {! apiAutosyncUpdate && (
+                        <Button
+                          isPrimary
+                          onClick={this.updatePost}
+                          style={{ margin: '1em' }}
+                        >
+                          {__('Update', 'apple-news')}
+                        </Button>
+                      )}
+                      {! apiAutosyncDelete && (
+                        <Button
+                          isDefault
+                          onClick={this.deletePost}
+                          style={{ margin: '1em' }}
+                        >
+                          {__('Delete', 'apple-news')}
+                        </Button>
+                      )}
+                    </Fragment>
+                  ) : (
+                    <Fragment>
+                      {! apiAutosync && (
+                        <Button
+                          isPrimary
+                          onClick={this.publishPost}
+                          style={{ margin: '1em' }}
+                        >
+                          {__('Publish', 'apple-news')}
+                        </Button>
+                      )}
+                    </Fragment>
                   )}
                 </Fragment>
               )}

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -16,6 +16,7 @@ const {
     CheckboxControl,
     PanelBody,
     SelectControl,
+    Spinner,
     TextareaControl,
   },
   data: {
@@ -69,10 +70,12 @@ class Sidebar extends React.PureComponent {
    */
   state = {
     autoAssignCategories: false,
+    loading: false,
+    meta: {},
+    publishState: '',
     sections: [],
     selectedSectionsPrev: null,
     settings: {},
-    publishState: '',
   };
 
   constructor(props) {
@@ -85,6 +88,15 @@ class Sidebar extends React.PureComponent {
   }
 
   componentDidMount() {
+    const {
+      meta = {},
+    } = this.props;
+
+    // Save meta to state, because it can be updated via REST event handlers outside of Gutenberg.
+    this.setState({
+      meta,
+    });
+
     this.fetchSections();
     this.fetchSettings();
     this.fetchPublishState();
@@ -102,6 +114,10 @@ class Sidebar extends React.PureComponent {
 
     const path = '/apple-news/v1/delete';
 
+    this.setState({
+      loading: true,
+    });
+
     apiFetch({
       data: {
         id,
@@ -109,7 +125,33 @@ class Sidebar extends React.PureComponent {
       method: 'POST',
       path,
     })
-      .then((data) => console.log(data))
+      .then((data) => {
+        const {
+          apiId = '',
+          dateCreated = '',
+          dateModified = '',
+          publishState = '',
+          revision = '',
+          shareUrl = '',
+        } = data;
+
+        const {
+          meta,
+        } = this.state;
+
+        this.setState({
+          loading: false,
+          meta: {
+            ...meta,
+            apiId,
+            dateCreated,
+            dateModified,
+            revision,
+            shareUrl,
+          },
+          publishState,
+        });
+      })
       .catch((error) => console.log(error)); // eslint-disable-line no-console
   }
 
@@ -171,6 +213,10 @@ class Sidebar extends React.PureComponent {
 
     const path = '/apple-news/v1/publish';
 
+    this.setState({
+      loading: true,
+    });
+
     apiFetch({
       data: {
         id,
@@ -178,7 +224,33 @@ class Sidebar extends React.PureComponent {
       method: 'POST',
       path,
     })
-      .then((data) => console.log(data))
+      .then((data) => {
+        const {
+          apiId = '',
+          dateCreated = '',
+          dateModified = '',
+          publishState = '',
+          revision = '',
+          shareUrl = '',
+        } = data;
+
+        const {
+          meta,
+        } = this.state;
+
+        this.setState({
+          loading: false,
+          meta: {
+            ...meta,
+            apiId,
+            dateCreated,
+            dateModified,
+            revision,
+            shareUrl,
+          },
+          publishState,
+        });
+      })
       .catch((error) => console.log(error)); // eslint-disable-line no-console
   }
 
@@ -194,6 +266,10 @@ class Sidebar extends React.PureComponent {
 
     const path = '/apple-news/v1/update';
 
+    this.setState({
+      loading: true,
+    });
+
     apiFetch({
       data: {
         id,
@@ -201,7 +277,33 @@ class Sidebar extends React.PureComponent {
       method: 'POST',
       path,
     })
-      .then((data) => console.log(data))
+      .then((data) => {
+        const {
+          apiId = '',
+          dateCreated = '',
+          dateModified = '',
+          publishState = '',
+          revision = '',
+          shareUrl = '',
+        } = data;
+
+        const {
+          meta,
+        } = this.state;
+
+        this.setState({
+          loading: false,
+          meta: {
+            ...meta,
+            apiId,
+            dateCreated,
+            dateModified,
+            revision,
+            shareUrl,
+          },
+          publishState,
+        });
+      })
       .catch((error) => console.log(error)); // eslint-disable-line no-console
   }
 
@@ -281,6 +383,12 @@ class Sidebar extends React.PureComponent {
     const label = __('Apple News Options', 'apple-news');
 
     const {
+      onUpdate,
+    } = this.props;
+
+    const {
+      autoAssignCategories,
+      loading,
       meta: {
         isPreview = false,
         isHidden = false,
@@ -296,11 +404,6 @@ class Sidebar extends React.PureComponent {
         shareUrl = '',
         revision = '',
       },
-      onUpdate,
-    } = this.props;
-
-    const {
-      autoAssignCategories,
       sections,
       settings: {
         adminUrl,
@@ -315,6 +418,7 @@ class Sidebar extends React.PureComponent {
     } = this.state;
 
     const selectedSectionsRaw = 'null' !== selectedSections
+      && '' !== selectedSections
       ? JSON.parse(selectedSections)
       : '';
 
@@ -613,7 +717,7 @@ class Sidebar extends React.PureComponent {
             initialOpen={false}
             title={__('Apple News Publish Information', 'apple-news')}
           >
-            {'' !== publishState && 'N/A' !== publishState ? (
+            {'' !== publishState && 'N/A' !== publishState && (
               <Fragment>
                 <h4>{__('API Id', 'apple-news')}</h4>
                 <p>{apiId}</p>
@@ -627,27 +731,49 @@ class Sidebar extends React.PureComponent {
                 <p>{revision}</p>
                 <h4>{__('Publish State', 'apple-news')}</h4>
                 <p>{publishState}</p>
-                {! apiAutosyncUpdate && (
-                  <Button isPrimary onClick={this.updatePost}>
-                    {__('Update', 'apple-news')}
-                  </Button>
-                )}
-                {! apiAutosyncDelete && (
-                  <Button isDestructive onClick={this.deletePost}>
-                    {__('Delete', 'apple-news')}
-                  </Button>
-                )}
-              </Fragment>
-            ) : (
-              <Fragment>
-                {! apiAutosync && (
-                  <Button isPrimary onClick={this.publishPost}>
-                    {__('Publish', 'apple-news')}
-                  </Button>
-                )}
               </Fragment>
             )}
           </PanelBody>
+          {loading ? (
+            <Spinner />
+          ) : (
+            <Fragment>
+              {'' !== publishState && 'N/A' !== publishState ? (
+                <Fragment>
+                  {! apiAutosyncUpdate && (
+                    <Button
+                      isPrimary
+                      onClick={this.updatePost}
+                      style={{ margin: '1em' }}
+                    >
+                      {__('Update', 'apple-news')}
+                    </Button>
+                  )}
+                  {! apiAutosyncDelete && (
+                    <Button
+                      isDefault
+                      onClick={this.deletePost}
+                      style={{ margin: '1em' }}
+                    >
+                      {__('Delete', 'apple-news')}
+                    </Button>
+                  )}
+                </Fragment>
+              ) : (
+                <Fragment>
+                  {! apiAutosync && (
+                    <Button
+                      isPrimary
+                      onClick={this.publishPost}
+                      style={{ margin: '1em' }}
+                    >
+                      {__('Publish', 'apple-news')}
+                    </Button>
+                  )}
+                </Fragment>
+              )}
+            </Fragment>
+          )}
         </PluginSidebar>
       </Fragment>
     );

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -74,7 +74,9 @@ class Sidebar extends React.PureComponent {
   constructor(props) {
     super(props);
 
+    this.deletePost = this.deletePost.bind(this);
     this.publishPost = this.publishPost.bind(this);
+    this.updatePost = this.updatePost.bind(this);
     this.updateSelectedSections = this.updateSelectedSections.bind(this);
   }
 
@@ -82,6 +84,29 @@ class Sidebar extends React.PureComponent {
     this.fetchSections();
     this.fetchSettings();
     this.fetchPublishState();
+  }
+
+  /**
+   * Sends a request to the REST API to delete the post.
+   */
+  deletePost() {
+    const {
+      post: {
+        id = 0,
+      } = {},
+    } = this.props;
+
+    const path = '/apple-news/v1/delete';
+
+    apiFetch({
+      data: {
+        id,
+      },
+      method: 'POST',
+      path,
+    })
+      .then((data) => console.log(data))
+      .catch((error) => console.log(error)); // eslint-disable-line no-console
   }
 
   /**
@@ -141,6 +166,29 @@ class Sidebar extends React.PureComponent {
     } = this.props;
 
     const path = '/apple-news/v1/publish';
+
+    apiFetch({
+      data: {
+        id,
+      },
+      method: 'POST',
+      path,
+    })
+      .then((data) => console.log(data))
+      .catch((error) => console.log(error)); // eslint-disable-line no-console
+  }
+
+  /**
+   * Sends a request to the REST API to update the post.
+   */
+  updatePost() {
+    const {
+      post: {
+        id = 0,
+      } = {},
+    } = this.props;
+
+    const path = '/apple-news/v1/update';
 
     apiFetch({
       data: {
@@ -568,12 +616,12 @@ class Sidebar extends React.PureComponent {
               <h4>{__('Publish State', 'apple-news')}</h4>
               <p>{publishState}</p>
               {! apiAutosyncUpdate && (
-                <Button isPrimary>
+                <Button isPrimary onClick={this.updatePost}>
                   {__('Update', 'apple-news')}
                 </Button>
               )}
               {! apiAutosyncDelete && (
-                <Button isDestructive>
+                <Button isDestructive onClick={this.deletePost}>
                   {__('Delete', 'apple-news')}
                 </Button>
               )}

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -523,23 +523,27 @@ class Sidebar extends React.PureComponent {
             )
           }
         </PanelBody>
-        <PanelBody
-          initialOpen={false}
-          title={__('Apple News Publish Information', 'apple-news')}
-        >
-          <h4>{__('API Id', 'apple-news')}</h4>
-          <p>{apiId}</p>
-          <h4>{__('Created On', 'apple-news')}</h4>
-          <p>{dateCreated}</p>
-          <h4>{__('Last Updated On', 'apple-news')}</h4>
-          <p>{dateModified}</p>
-          <h4>{__('Share URL', 'apple-news')}</h4>
-          <p>{shareUrl}</p>
-          <h4>{__('Revision', 'apple-news')}</h4>
-          <p>{revision}</p>
-          <h4>{__('Publish State', 'apple-news')}</h4>
-          <p>{publishState}</p>
-        </PanelBody>
+        {'' !== publishState && 'N/A' !== publishState ? (
+          <PanelBody
+            initialOpen={false}
+            title={__('Apple News Publish Information', 'apple-news')}
+          >
+            <h4>{__('API Id', 'apple-news')}</h4>
+            <p>{apiId}</p>
+            <h4>{__('Created On', 'apple-news')}</h4>
+            <p>{dateCreated}</p>
+            <h4>{__('Last Updated On', 'apple-news')}</h4>
+            <p>{dateModified}</p>
+            <h4>{__('Share URL', 'apple-news')}</h4>
+            <p>{shareUrl}</p>
+            <h4>{__('Revision', 'apple-news')}</h4>
+            <p>{revision}</p>
+            <h4>{__('Publish State', 'apple-news')}</h4>
+            <p>{publishState}</p>
+          </PanelBody>
+        ) : (
+          <div>Publish Me!</div>
+        )}
       </PluginSidebar>
     );
   }

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -24,6 +24,10 @@ const {
   },
   editPost: {
     PluginSidebar,
+    PluginSidebarMoreMenuItem,
+  },
+  element: {
+    Fragment,
   },
   i18n: {
     __,
@@ -273,6 +277,9 @@ class Sidebar extends React.PureComponent {
    * @returns {object} JSX component markup.
    */
   render() {
+    const target = 'publish-to-apple-news';
+    const label = __('Apple News Options', 'apple-news');
+
     const {
       meta: {
         isPreview = false,
@@ -307,19 +314,19 @@ class Sidebar extends React.PureComponent {
       publishState,
     } = this.state;
 
-    const {
-      Fragment,
-    } = React;
-
     const selectedSectionsRaw = 'null' !== selectedSections
       ? JSON.parse(selectedSections)
       : '';
+
     const selectedSectionsArray = Array.isArray(selectedSectionsRaw)
       ? selectedSectionsRaw
       : [];
+
     const parsedCoverArt = '' !== coverArt && 'null' !== coverArt
       ? JSON.parse(coverArt) : {};
+
     const coverArtOrientation = parsedCoverArt.orientation || 'landscape';
+
     const coverArtSizes = [
       {
         title: __('iPad Pro (12.9 in): 1832 x 1374 px', 'apple-news'),
@@ -342,301 +349,307 @@ class Sidebar extends React.PureComponent {
         key: `apple_news_ca_${coverArtOrientation}_4_0`,
       },
     ];
+
     return (
-      <PluginSidebar
-        name="publish-to-apple-news"
-        title={__('Publish to Apple News Options', 'apple-news')}
-      >
-        <div
-          className="components-panel__body is-opened"
-          id="apple-news-publish"
+      <Fragment>
+        <PluginSidebarMoreMenuItem target={target}>
+          {label}
+        </PluginSidebarMoreMenuItem>
+        <PluginSidebar
+          name={target}
+          title={__('Publish to Apple News Options', 'apple-news')}
         >
-          <Notifications />
-          <h3>Sections</h3>
-          {automaticAssignment && [
-            <CheckboxControl
-              label={__('Assign sections by category', 'apple-news')}
-              checked={autoAssignCategories}
-              onChange={
-                (checked) => {
-                  this.setState({
-                    autoAssignCategories: checked,
-                  });
-                  if (checked) {
+          <div
+            className="components-panel__body is-opened"
+            id="apple-news-publish"
+          >
+            <Notifications />
+            <h3>Sections</h3>
+            {automaticAssignment && [
+              <CheckboxControl
+                label={__('Assign sections by category', 'apple-news')}
+                checked={autoAssignCategories}
+                onChange={
+                  (checked) => {
                     this.setState({
-                      selectedSectionsPrev: selectedSections || null,
+                      autoAssignCategories: checked,
                     });
-                    onUpdate(
-                      'apple_news_sections',
-                      null
-                    );
-                  } else {
-                    onUpdate(
-                      'apple_news_sections',
-                      selectedSectionsPrev
-                    );
-                    this.setState({
-                      selectedSectionsPrev: null,
-                    });
+                    if (checked) {
+                      this.setState({
+                        selectedSectionsPrev: selectedSections || null,
+                      });
+                      onUpdate(
+                        'apple_news_sections',
+                        null
+                      );
+                    } else {
+                      onUpdate(
+                        'apple_news_sections',
+                        selectedSectionsPrev
+                      );
+                      this.setState({
+                        selectedSectionsPrev: null,
+                      });
+                    }
                   }
                 }
-              }
-            />,
-            <hr />,
-          ]}
-          {(! autoAssignCategories || ! automaticAssignment) && [
-            <h4>Manual Section Selection</h4>,
-            Array.isArray(sections) && (
-              <ul className="apple-news-sections">
-                {sections.map(({ id, name }) => (
-                  <li key={id}>
-                    <CheckboxControl
-                      label={name}
-                      checked={- 1 !== selectedSectionsArray.indexOf(id)}
-                      onChange={
-                        (checked) => this.updateSelectedSections(checked, id)
-                      }
-                    />
-                  </li>
-                ))}
-              </ul>
-            ),
-          ]}
-          <p>
-            <em>
-              {
-                // eslint-disable-next-line max-len
-                __('Select the sections in which to publish this article. If none are selected, it will be published to the default section.', 'apple-news')
-              }
-            </em>
-          </p>
-          <h3>{__('Preview Article', 'apple-news')}</h3>
-          <CheckboxControl
-            // eslint-disable-next-line max-len
-            label={__('Check this to publish the article as a draft.', 'apple-news')}
-            onChange={(value) => onUpdate(
-              'apple_news_is_preview',
-              value
-            )}
-            checked={isPreview}
-          />
-          <h3>Hidden Article</h3>
-          <CheckboxControl
-            // eslint-disable-next-line max-len
-            label={__('Hidden articles are visible to users who have a link to the article, but do not appear in feeds.', 'apple-news')}
-            onChange={(value) => onUpdate(
-              'apple_news_is_hidden',
-              value
-            )}
-            checked={isHidden}
-          />
-          <h3>Sponsored Article</h3>
-          <CheckboxControl
-            // eslint-disable-next-line max-len
-            label={__('Check this to indicate this article is sponsored content.', 'apple-news')}
-            onChange={(value) => onUpdate(
-              'apple_news_is_sponsored',
-              value
-            )}
-            checked={isSponsored}
-          />
-        </div>
-        <PanelBody
-          initialOpen={false}
-          title={__('Maturity Rating', 'apple-news')}
-        >
-          <SelectControl
-            label={__('Select Maturity Rating', 'apple-news')}
-            value={maturityRating}
-            options={[
-              { label: '', value: '' },
-              { label: __('Kids', 'apple-news'), value: 'KIDS' },
-              { label: __('Mature', 'apple-news'), value: 'MATURE' },
-              { label: __('General', 'apple-news'), value: 'GENERAL' },
+              />,
+              <hr />,
             ]}
-            onChange={(value) => onUpdate(
-              'apple_news_maturity_rating',
-              value
-            )}
-          />
-          <p>
-            <em>
-              Select the optional maturity rating for this post.
-            </em>
-          </p>
-        </PanelBody>
-        <PanelBody
-          initialOpen={false}
-          title={__('Pull Quote', 'apple_news')}
-        >
-          <TextareaControl
-            label={__('Description', 'apple_news')}
-            value={pullquoteText}
-            onChange={(value) => onUpdate(
-              'apple_news_pullquote',
-              value
-            )}
-            // eslint-disable-next-line max-len
-            placeholder="A pull quote is a key phrase, quotation, or excerpt that has been pulled from an article and used as a graphic element, serving to entice readers into the article or to highlight a key topic."
-          />
-          <p>
-            <em>
-              This is optional and can be left blank.
-            </em>
-          </p>
-          <SelectControl
-            label={__('Pull Quote Position', 'apple-news')}
-            value={pullquotePosition || 'middle'}
-            options={[
-              { label: __('top', 'apple-news'), value: 'top' },
-              { label: __('middle', 'apple-news'), value: 'middle' },
-              { label: __('bottom', 'apple-news'), value: 'bottom' },
+            {(! autoAssignCategories || ! automaticAssignment) && [
+              <h4>Manual Section Selection</h4>,
+              Array.isArray(sections) && (
+                <ul className="apple-news-sections">
+                  {sections.map(({ id, name }) => (
+                    <li key={id}>
+                      <CheckboxControl
+                        label={name}
+                        checked={- 1 !== selectedSectionsArray.indexOf(id)}
+                        onChange={
+                          (checked) => this.updateSelectedSections(checked, id)
+                        }
+                      />
+                    </li>
+                  ))}
+                </ul>
+              ),
             ]}
-            onChange={(value) => onUpdate(
-              'apple_news_pullquote_position',
-              value
-            )}
-          />
-          <p>
-            <em>
-              {
-                // eslint-disable-next-line max-len
-                __('The position in the article where the pull quote will appear.', 'apple-news')
-              }
-            </em>
-          </p>
-        </PanelBody>
-        <PanelBody
-          initialOpen={false}
-          title={__('Cover Art', 'apple-news')}
-        >
-          {
-            enableCoverArt ? (
-              <div>
-                <p>
-                  <em>
-                    <a href="https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html">
-                      {__('Cover Art', 'apple-news')}
-                    </a>
-                    {
-                      // eslint-disable-next-line max-len
-                      __(' will represent your article if editorially chosen for Featured Stories. Cover Art must include your channel logo with text at 24 pt minimum that is related to the headline. The image provided must match the dimensions listed. Limit submissions to 1-3 articles per day.', 'apple-news')
-                    }
-                  </em>
-                </p>
-                <SelectControl
-                  label={__('Orientation', 'apple-news')}
-                  value={coverArtOrientation}
-                  options={[
-                    /* eslint-disable max-len */
-                    { label: __('Landscape (4:3)', 'apple-news'), value: 'landscape' },
-                    { label: __('Portrait (3:4)', 'apple-news'), value: 'portrait' },
-                    { label: __('Square (1:1)', 'apple-news'), value: 'square' },
-                    /* eslint-enable */
-                  ]}
-                  onChange={(value) => {
-                    const mediaKeys = Object
-                      .keys(parsedCoverArt)
-                      .filter((key) => 'orientation' !== key);
-                    const updatedOrientation = {
-                      orientation: value,
-                    };
-
-                    const updatedCoverArt = mediaKeys.reduce((acc, curr) => {
-                      const newKey = curr.replace(coverArtOrientation, value);
-                      return {
-                        [newKey]: parsedCoverArt[curr],
-                        ...acc,
-                      };
-                    }, updatedOrientation);
-
-                    onUpdate(
-                      'apple_news_coverart',
-                      JSON.stringify(updatedCoverArt)
-                    );
-                  }}
-                />
-                <p>
-                  <em>
-                    {
-                      // eslint-disable-next-line max-len
-                      __('Note: You must provide the largest size (iPad Pro 12.9 in) in order for your submission to be considered.', 'apple-news')
-                    }
-                  </em>
-
-                </p>
+            <p>
+              <em>
+                {
+                  // eslint-disable-next-line max-len
+                  __('Select the sections in which to publish this article. If none are selected, it will be published to the default section.', 'apple-news')
+                }
+              </em>
+            </p>
+            <h3>{__('Preview Article', 'apple-news')}</h3>
+            <CheckboxControl
+              // eslint-disable-next-line max-len
+              label={__('Check this to publish the article as a draft.', 'apple-news')}
+              onChange={(value) => onUpdate(
+                'apple_news_is_preview',
+                value
+              )}
+              checked={isPreview}
+            />
+            <h3>Hidden Article</h3>
+            <CheckboxControl
+              // eslint-disable-next-line max-len
+              label={__('Hidden articles are visible to users who have a link to the article, but do not appear in feeds.', 'apple-news')}
+              onChange={(value) => onUpdate(
+                'apple_news_is_hidden',
+                value
+              )}
+              checked={isHidden}
+            />
+            <h3>Sponsored Article</h3>
+            <CheckboxControl
+              // eslint-disable-next-line max-len
+              label={__('Check this to indicate this article is sponsored content.', 'apple-news')}
+              onChange={(value) => onUpdate(
+                'apple_news_is_sponsored',
+                value
+              )}
+              checked={isSponsored}
+            />
+          </div>
+          <PanelBody
+            initialOpen={false}
+            title={__('Maturity Rating', 'apple-news')}
+          >
+            <SelectControl
+              label={__('Select Maturity Rating', 'apple-news')}
+              value={maturityRating}
+              options={[
+                { label: '', value: '' },
+                { label: __('Kids', 'apple-news'), value: 'KIDS' },
+                { label: __('Mature', 'apple-news'), value: 'MATURE' },
+                { label: __('General', 'apple-news'), value: 'GENERAL' },
+              ]}
+              onChange={(value) => onUpdate(
+                'apple_news_maturity_rating',
+                value
+              )}
+            />
+            <p>
+              <em>
+                Select the optional maturity rating for this post.
+              </em>
+            </p>
+          </PanelBody>
+          <PanelBody
+            initialOpen={false}
+            title={__('Pull Quote', 'apple_news')}
+          >
+            <TextareaControl
+              label={__('Description', 'apple_news')}
+              value={pullquoteText}
+              onChange={(value) => onUpdate(
+                'apple_news_pullquote',
+                value
+              )}
+              // eslint-disable-next-line max-len
+              placeholder="A pull quote is a key phrase, quotation, or excerpt that has been pulled from an article and used as a graphic element, serving to entice readers into the article or to highlight a key topic."
+            />
+            <p>
+              <em>
+                This is optional and can be left blank.
+              </em>
+            </p>
+            <SelectControl
+              label={__('Pull Quote Position', 'apple-news')}
+              value={pullquotePosition || 'middle'}
+              options={[
+                { label: __('top', 'apple-news'), value: 'top' },
+                { label: __('middle', 'apple-news'), value: 'middle' },
+                { label: __('bottom', 'apple-news'), value: 'bottom' },
+              ]}
+              onChange={(value) => onUpdate(
+                'apple_news_pullquote_position',
+                value
+              )}
+            />
+            <p>
+              <em>
+                {
+                  // eslint-disable-next-line max-len
+                  __('The position in the article where the pull quote will appear.', 'apple-news')
+                }
+              </em>
+            </p>
+          </PanelBody>
+          <PanelBody
+            initialOpen={false}
+            title={__('Cover Art', 'apple-news')}
+          >
+            {
+              enableCoverArt ? (
                 <div>
-                  {
-                    coverArtSizes.map((item) => (
-                      <div>
-                        <h4>{item.title}</h4>
-                        <ImagePicker
-                          metaKey={item.key}
-                          onUpdate={
-                            (metaKey, value) => this.updateSelectCoverArtImage(
-                              metaKey,
-                              value
-                            )
-                          }
-                          value={parsedCoverArt[item.key]}
-                        />
-                      </div>
-                    ))
-                  }
+                  <p>
+                    <em>
+                      <a href="https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/CoverArt.html">
+                        {__('Cover Art', 'apple-news')}
+                      </a>
+                      {
+                        // eslint-disable-next-line max-len
+                        __(' will represent your article if editorially chosen for Featured Stories. Cover Art must include your channel logo with text at 24 pt minimum that is related to the headline. The image provided must match the dimensions listed. Limit submissions to 1-3 articles per day.', 'apple-news')
+                      }
+                    </em>
+                  </p>
+                  <SelectControl
+                    label={__('Orientation', 'apple-news')}
+                    value={coverArtOrientation}
+                    options={[
+                      /* eslint-disable max-len */
+                      { label: __('Landscape (4:3)', 'apple-news'), value: 'landscape' },
+                      { label: __('Portrait (3:4)', 'apple-news'), value: 'portrait' },
+                      { label: __('Square (1:1)', 'apple-news'), value: 'square' },
+                      /* eslint-enable */
+                    ]}
+                    onChange={(value) => {
+                      const mediaKeys = Object
+                        .keys(parsedCoverArt)
+                        .filter((key) => 'orientation' !== key);
+                      const updatedOrientation = {
+                        orientation: value,
+                      };
+
+                      const updatedCoverArt = mediaKeys.reduce((acc, curr) => {
+                        const newKey = curr.replace(coverArtOrientation, value);
+                        return {
+                          [newKey]: parsedCoverArt[curr],
+                          ...acc,
+                        };
+                      }, updatedOrientation);
+
+                      onUpdate(
+                        'apple_news_coverart',
+                        JSON.stringify(updatedCoverArt)
+                      );
+                    }}
+                  />
+                  <p>
+                    <em>
+                      {
+                        // eslint-disable-next-line max-len
+                        __('Note: You must provide the largest size (iPad Pro 12.9 in) in order for your submission to be considered.', 'apple-news')
+                      }
+                    </em>
+
+                  </p>
+                  <div>
+                    {
+                      coverArtSizes.map((item) => (
+                        <div>
+                          <h4>{item.title}</h4>
+                          <ImagePicker
+                            metaKey={item.key}
+                            onUpdate={(metaKey, value) => this
+                              .updateSelectCoverArtImage(
+                                metaKey,
+                                value
+                              )
+                            }
+                            value={parsedCoverArt[item.key]}
+                          />
+                        </div>
+                      ))
+                    }
+                  </div>
                 </div>
-              </div>
+              ) : (
+                <p>
+                  <em>
+                    {__('Cover Art must be enabled on the ', 'apple-news')}
+                    <a href={adminUrl}>
+                      {__('settings page', 'apple-news')}
+                    </a>
+                  </em>
+                </p>
+              )
+            }
+          </PanelBody>
+          <PanelBody
+            initialOpen={false}
+            title={__('Apple News Publish Information', 'apple-news')}
+          >
+            {'' !== publishState && 'N/A' !== publishState ? (
+              <Fragment>
+                <h4>{__('API Id', 'apple-news')}</h4>
+                <p>{apiId}</p>
+                <h4>{__('Created On', 'apple-news')}</h4>
+                <p>{dateCreated}</p>
+                <h4>{__('Last Updated On', 'apple-news')}</h4>
+                <p>{dateModified}</p>
+                <h4>{__('Share URL', 'apple-news')}</h4>
+                <p>{shareUrl}</p>
+                <h4>{__('Revision', 'apple-news')}</h4>
+                <p>{revision}</p>
+                <h4>{__('Publish State', 'apple-news')}</h4>
+                <p>{publishState}</p>
+                {! apiAutosyncUpdate && (
+                  <Button isPrimary onClick={this.updatePost}>
+                    {__('Update', 'apple-news')}
+                  </Button>
+                )}
+                {! apiAutosyncDelete && (
+                  <Button isDestructive onClick={this.deletePost}>
+                    {__('Delete', 'apple-news')}
+                  </Button>
+                )}
+              </Fragment>
             ) : (
-              <p>
-                <em>
-                  {__('Cover Art must be enabled on the ', 'apple-news')}
-                  <a href={adminUrl}>
-                    {__('settings page', 'apple-news')}
-                  </a>
-                </em>
-              </p>
-            )
-          }
-        </PanelBody>
-        <PanelBody
-          initialOpen={false}
-          title={__('Apple News Publish Information', 'apple-news')}
-        >
-          {'' !== publishState && 'N/A' !== publishState ? (
-            <Fragment>
-              <h4>{__('API Id', 'apple-news')}</h4>
-              <p>{apiId}</p>
-              <h4>{__('Created On', 'apple-news')}</h4>
-              <p>{dateCreated}</p>
-              <h4>{__('Last Updated On', 'apple-news')}</h4>
-              <p>{dateModified}</p>
-              <h4>{__('Share URL', 'apple-news')}</h4>
-              <p>{shareUrl}</p>
-              <h4>{__('Revision', 'apple-news')}</h4>
-              <p>{revision}</p>
-              <h4>{__('Publish State', 'apple-news')}</h4>
-              <p>{publishState}</p>
-              {! apiAutosyncUpdate && (
-                <Button isPrimary onClick={this.updatePost}>
-                  {__('Update', 'apple-news')}
-                </Button>
-              )}
-              {! apiAutosyncDelete && (
-                <Button isDestructive onClick={this.deletePost}>
-                  {__('Delete', 'apple-news')}
-                </Button>
-              )}
-            </Fragment>
-          ) : (
-            <Fragment>
-              {! apiAutosync && (
-                <Button isPrimary onClick={this.publishPost}>
-                  {__('Publish', 'apple-news')}
-                </Button>
-              )}
-            </Fragment>
-          )}
-        </PanelBody>
-      </PluginSidebar>
+              <Fragment>
+                {! apiAutosync && (
+                  <Button isPrimary onClick={this.publishPost}>
+                    {__('Publish', 'apple-news')}
+                  </Button>
+                )}
+              </Fragment>
+            )}
+          </PanelBody>
+        </PluginSidebar>
+      </Fragment>
     );
   }
 }

--- a/includes/REST/apple-news-delete.php
+++ b/includes/REST/apple-news-delete.php
@@ -85,7 +85,6 @@ function rest_post_delete( $data ) {
 			'apiId'        => get_post_meta( $id, 'apple_news_api_id', true ),
 			'dateCreated'  => get_post_meta( $id, 'apple_news_api_created_at', true ),
 			'dateModified' => get_post_meta( $id, 'apple_news_api_modified_at', true ),
-			'messages'     => Admin_Apple_Notice::get_user_meta( get_current_user_id() ),
 			'publishState' => Admin_Apple_News::get_post_status( $id ),
 			'revision'     => get_post_meta( $id, 'apple_news_api_revision', true ),
 			'shareUrl'     => get_post_meta( $id, 'apple_news_api_share_url', true ),

--- a/includes/REST/apple-news-delete.php
+++ b/includes/REST/apple-news-delete.php
@@ -78,15 +78,17 @@ function rest_post_delete( $data ) {
 
 		// Negotiate the message based on whether delete will happen asynchronously or not.
 		if ( 'yes' === Admin_Apple_News::$settings->api_async ) {
-			$message = __( 'Your article will be deleted shortly.', 'apple-news' );
-			Admin_Apple_Notice::success( $message );
-		} else {
-			$message = __( 'Your article has been deleted successfully!', 'apple-news' );
+			Admin_Apple_Notice::success( __( 'Your article will be deleted shortly.', 'apple-news' ) );
 		}
 
-		// Return the success message in the JSON response also.
 		return [
-			'message' => $message,
+			'apiId'        => get_post_meta( $id, 'apple_news_api_id', true ),
+			'dateCreated'  => get_post_meta( $id, 'apple_news_api_created_at', true ),
+			'dateModified' => get_post_meta( $id, 'apple_news_api_modified_at', true ),
+			'messages'     => Admin_Apple_Notice::get_user_meta( get_current_user_id() ),
+			'publishState' => Admin_Apple_News::get_post_status( $id ),
+			'revision'     => get_post_meta( $id, 'apple_news_api_revision', true ),
+			'shareUrl'     => get_post_meta( $id, 'apple_news_api_share_url', true ),
 		];
 	} catch ( Action_Exception $e ) {
 		// Add the error message to the list of messages to display to the user using normal means.

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -12,18 +12,27 @@ namespace Apple_News\REST;
  * @return array updated response.
  */
 function get_settings_response( $data ) {
-  $response = [];
-
-	if ( ! empty( get_current_user_id() ) ) {
-		// Get admin settings
-		$admin_settings = new \Admin_Apple_Settings();
-		$settings = $admin_settings->fetch_settings();
-		$response['automaticAssignment'] = ! empty( get_option( 'apple_news_section_taxonomy_mappings' ) );
-		$response['enableCoverArt'] = 'no' !== $settings->enable_cover_art;
-		$response['adminUrl'] = esc_url( admin_url( 'admin.php?page=apple-news-options' ) );
+	if ( empty( get_current_user_id() ) ) {
+		return [];
 	}
 
-  return $response;
+	// Compile non-sensitive plugin settings into a JS-friendly format and return.
+	$admin_settings = new \Admin_Apple_Settings();
+	$settings = $admin_settings->fetch_settings();
+	return [
+		'adminUrl'            => esc_url_raw( admin_url( 'admin.php?page=apple-news-options' ) ),
+		'automaticAssignment' => ! empty( get_option( 'apple_news_section_taxonomy_mappings' ) ),
+		'apiAsync'            => 'yes' === $settings->api_async,
+		'apiAutosync'         => 'yes' === $settings->api_autosync,
+		'apiAutosyncDelete'   => 'yes' === $settings->api_autosync_delete,
+		'apiAutosyncUpdate'   => 'yes' === $settings->api_autosync_update,
+		'enableCoverArt'      => 'yes' === $settings->enable_cover_art,
+		'fullBleedImages'     => 'yes' === $settings->full_bleed_images,
+		'htmlSupport'         => 'yes' === $settings->html_support,
+		'postTypes'           => ! empty( $settings->post_types ) && is_array( $settings->post_types ) ? array_map( 'sanitize_text_field', $settings->post_types ) : [],
+		'showMetabox'         => 'yes' === $settings->show_metabox,
+		'useRemoteImages'     => 'yes' === $settings->use_remote_images,
+	];
 }
 
 /**

--- a/includes/REST/apple-news-publish.php
+++ b/includes/REST/apple-news-publish.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * A custom endpoint for publishing a post to Apple News.
+ *
+ * @package Apple_News
+ */
+namespace Apple_News\REST;
+
+/**
+ * Handle a REST POST request to the /apple-news/v1/publish endpoint.
+ *
+ * @param array $data Data from query args.
+ *
+ * @return array|\WP_error Response to the request - either data about a successfully published article, or error.
+ */
+function rest_post_publish( $data ) {
+
+	// Ensure there is a post ID provided in the data.
+	$id = $data->get_param( 'id' );
+	if ( empty( $id ) ) {
+		return new \WP_Error(
+			'apple_news_no_post_id',
+			esc_html__( 'No post ID was specified.', 'apple-news' ),
+			[
+				'status' => 400,
+			]
+		);
+	}
+
+	// TODO: Try to get the post based on ID.
+	// TODO: Perform a permissions check to ensure the current user can publish this type of post.
+	// TODO: Try to publish the article to the API.
+	// TODO: If successful, return info about the published article.
+
+	return [];
+}
+/**
+ * Initialize this REST Endpoint.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		// Register route count argument.
+		register_rest_route(
+			'apple-news/v1',
+			'/publish',
+			[
+				'methods'  => 'POST',
+				'callback' => __NAMESPACE__ . '\rest_post_publish',
+			]
+		);
+	}
+);

--- a/includes/REST/apple-news-publish.php
+++ b/includes/REST/apple-news-publish.php
@@ -6,19 +6,25 @@
  */
 namespace Apple_News\REST;
 
+use \Admin_Apple_News;
+use \Admin_Apple_Notice;
+use \Apple_Actions\Action_Exception;
+use \Apple_Actions\Index\Push;
+use \WP_Error;
+
 /**
  * Handle a REST POST request to the /apple-news/v1/publish endpoint.
  *
  * @param array $data Data from query args.
  *
- * @return array|\WP_error Response to the request - either data about a successfully published article, or error.
+ * @return array|WP_Error Response to the request - either data about a successfully published article, or error.
  */
 function rest_post_publish( $data ) {
 
 	// Ensure there is a post ID provided in the data.
 	$id = $data->get_param( 'id' );
 	if ( empty( $id ) ) {
-		return new \WP_Error(
+		return new WP_Error(
 			'apple_news_no_post_id',
 			esc_html__( 'No post ID was specified.', 'apple-news' ),
 			[
@@ -27,12 +33,70 @@ function rest_post_publish( $data ) {
 		);
 	}
 
-	// TODO: Try to get the post based on ID.
-	// TODO: Perform a permissions check to ensure the current user can publish this type of post.
-	// TODO: Try to publish the article to the API.
-	// TODO: If successful, return info about the published article.
+	// Try to get the post by ID.
+	$post = get_post( $id );
+	if ( empty( $post ) ) {
+		return new WP_Error(
+			'apple_news_bad_post_id',
+			esc_html__( 'No post was found with the given ID.', 'apple-news' ),
+			[
+				'status' => 404,
+			]
+		);
+	}
 
-	return [];
+	// Ensure the user can publish this type of post.
+	$post_type = get_post_type_object( get_post_type( $post ) );
+	if ( ! current_user_can( $post_type->cap->publish_posts ) ) {
+		return new WP_Error(
+			'apple_news_failed_cap_check',
+			esc_html__( 'Your user account is not permitted to publish this post to Apple News.', 'apple-news' ),
+			[
+				'status' => 401,
+			]
+		);
+	}
+
+	// If this post is not owned by this user, ensure the user has the right to edit others' posts.
+	if ( get_current_user_id() !== (int) $post->post_author
+		&& ! current_user_can( $post_type->cap->edit_others_posts )
+	) {
+		return new WP_Error(
+			'apple_news_failed_cap_check',
+			esc_html__( 'Your user account is not permitted to publish this post to Apple News.', 'apple-news' ),
+			[
+				'status' => 401,
+			]
+		);
+	}
+
+	// Try to publish the article to the API.
+	$action = new Push( Admin_Apple_News::$settings, $id );
+	try {
+		$action->perform();
+
+		// Negotiate the message based on whether publish will happen asynchronously or not.
+		if ( 'yes' === Admin_Apple_News::$settings->api_async ) {
+			$message = __( 'Your article will be pushed shortly.', 'apple-news' );
+			Admin_Apple_Notice::success( $message );
+		} else {
+			$message = __( 'Your article has been pushed successfully!', 'apple-news' );
+		}
+
+		// Return the success message in the JSON response also.
+		return [
+			'message' => $message,
+		];
+	} catch ( Action_Exception $e ) {
+		// Add the error message to the list of messages to display to the user using normal means.
+		Admin_Apple_Notice::error( $e->getMessage() );
+
+		// Return the error message in the JSON response also.
+		return new WP_Error(
+			'apple_news_publish_failed',
+			$e->getMessage()
+		);
+	}
 }
 /**
  * Initialize this REST Endpoint.

--- a/includes/REST/apple-news-publish.php
+++ b/includes/REST/apple-news-publish.php
@@ -85,7 +85,6 @@ function rest_post_publish( $data ) {
 			'apiId'        => get_post_meta( $id, 'apple_news_api_id', true ),
             'dateCreated'  => get_post_meta( $id, 'apple_news_api_created_at', true ),
             'dateModified' => get_post_meta( $id, 'apple_news_api_modified_at', true ),
-			'messages'     => Admin_Apple_Notice::get_user_meta( get_current_user_id() ),
 			'publishState' => Admin_Apple_News::get_post_status( $id ),
             'revision'     => get_post_meta( $id, 'apple_news_api_revision', true ),
             'shareUrl'     => get_post_meta( $id, 'apple_news_api_share_url', true ),

--- a/includes/REST/apple-news-publish.php
+++ b/includes/REST/apple-news-publish.php
@@ -78,15 +78,17 @@ function rest_post_publish( $data ) {
 
 		// Negotiate the message based on whether publish will happen asynchronously or not.
 		if ( 'yes' === Admin_Apple_News::$settings->api_async ) {
-			$message = __( 'Your article will be pushed shortly.', 'apple-news' );
-			Admin_Apple_Notice::success( $message );
-		} else {
-			$message = __( 'Your article has been pushed successfully!', 'apple-news' );
+			Admin_Apple_Notice::success( __( 'Your article will be pushed shortly.', 'apple-news' ) );
 		}
 
-		// Return the success message in the JSON response also.
 		return [
-			'message' => $message,
+			'apiId'        => get_post_meta( $id, 'apple_news_api_id', true ),
+            'dateCreated'  => get_post_meta( $id, 'apple_news_api_created_at', true ),
+            'dateModified' => get_post_meta( $id, 'apple_news_api_modified_at', true ),
+			'messages'     => Admin_Apple_Notice::get_user_meta( get_current_user_id() ),
+			'publishState' => Admin_Apple_News::get_post_status( $id ),
+            'revision'     => get_post_meta( $id, 'apple_news_api_revision', true ),
+            'shareUrl'     => get_post_meta( $id, 'apple_news_api_share_url', true ),
 		];
 	} catch ( Action_Exception $e ) {
 		// Add the error message to the list of messages to display to the user using normal means.

--- a/includes/REST/apple-news-publish.php
+++ b/includes/REST/apple-news-publish.php
@@ -10,6 +10,7 @@ use \Admin_Apple_News;
 use \Admin_Apple_Notice;
 use \Apple_Actions\Action_Exception;
 use \Apple_Actions\Index\Push;
+use \Apple_News;
 use \WP_Error;
 use \WP_REST_Request;
 
@@ -46,25 +47,11 @@ function rest_post_publish( $data ) {
 		);
 	}
 
-	// Ensure the user can publish this type of post.
-	$post_type = get_post_type_object( get_post_type( $post ) );
-	if ( ! current_user_can( $post_type->cap->publish_posts ) ) {
+	// Ensure the user is authorized to make changes to Apple News posts.
+	if ( ! current_user_can( apply_filters( 'apple_news_publish_capability', Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type ) ) ) ) {
 		return new WP_Error(
 			'apple_news_failed_cap_check',
-			esc_html__( 'Your user account is not permitted to publish this post to Apple News.', 'apple-news' ),
-			[
-				'status' => 401,
-			]
-		);
-	}
-
-	// If this post is not owned by this user, ensure the user has the right to edit others' posts.
-	if ( get_current_user_id() !== (int) $post->post_author
-		&& ! current_user_can( $post_type->cap->edit_others_posts )
-	) {
-		return new WP_Error(
-			'apple_news_failed_cap_check',
-			esc_html__( 'Your user account is not permitted to publish this post to Apple News.', 'apple-news' ),
+			esc_html__( 'Your user account is not permitted to publish this post on Apple News.', 'apple-news' ),
 			[
 				'status' => 401,
 			]

--- a/includes/REST/apple-news-update.php
+++ b/includes/REST/apple-news-update.php
@@ -78,15 +78,17 @@ function rest_post_update( $data ) {
 
 		// Negotiate the message based on whether update will happen asynchronously or not.
 		if ( 'yes' === Admin_Apple_News::$settings->api_async ) {
-			$message = __( 'Your article will be updated shortly.', 'apple-news' );
-			Admin_Apple_Notice::success( $message );
-		} else {
-			$message = __( 'Your article has been updated successfully!', 'apple-news' );
+			Admin_Apple_Notice::success( __( 'Your article will be updated shortly.', 'apple-news' ) );
 		}
 
-		// Return the success message in the JSON response also.
 		return [
-			'message' => $message,
+			'apiId'        => get_post_meta( $id, 'apple_news_api_id', true ),
+			'dateCreated'  => get_post_meta( $id, 'apple_news_api_created_at', true ),
+			'dateModified' => get_post_meta( $id, 'apple_news_api_modified_at', true ),
+			'messages'     => Admin_Apple_Notice::get_user_meta( get_current_user_id() ),
+			'publishState' => Admin_Apple_News::get_post_status( $id ),
+			'revision'     => get_post_meta( $id, 'apple_news_api_revision', true ),
+			'shareUrl'     => get_post_meta( $id, 'apple_news_api_share_url', true ),
 		];
 	} catch ( Action_Exception $e ) {
 		// Add the error message to the list of messages to display to the user using normal means.

--- a/includes/REST/apple-news-update.php
+++ b/includes/REST/apple-news-update.php
@@ -85,7 +85,6 @@ function rest_post_update( $data ) {
 			'apiId'        => get_post_meta( $id, 'apple_news_api_id', true ),
 			'dateCreated'  => get_post_meta( $id, 'apple_news_api_created_at', true ),
 			'dateModified' => get_post_meta( $id, 'apple_news_api_modified_at', true ),
-			'messages'     => Admin_Apple_Notice::get_user_meta( get_current_user_id() ),
 			'publishState' => Admin_Apple_News::get_post_status( $id ),
 			'revision'     => get_post_meta( $id, 'apple_news_api_revision', true ),
 			'shareUrl'     => get_post_meta( $id, 'apple_news_api_share_url', true ),

--- a/includes/REST/apple-news-update.php
+++ b/includes/REST/apple-news-update.php
@@ -10,6 +10,7 @@ use \Admin_Apple_News;
 use \Admin_Apple_Notice;
 use \Apple_Actions\Action_Exception;
 use \Apple_Actions\Index\Push;
+use \Apple_News;
 use \WP_Error;
 use \WP_REST_Request;
 
@@ -46,22 +47,8 @@ function rest_post_update( $data ) {
 		);
 	}
 
-	// Ensure the user can update published posts for this post type.
-	$post_type = get_post_type_object( get_post_type( $post ) );
-	if ( ! current_user_can( $post_type->cap->edit_published_posts ) ) {
-		return new WP_Error(
-			'apple_news_failed_cap_check',
-			esc_html__( 'Your user account is not permitted to update this post on Apple News.', 'apple-news' ),
-			[
-				'status' => 401,
-			]
-		);
-	}
-
-	// If this post is not owned by this user, ensure the user has the right to edit others' posts.
-	if ( get_current_user_id() !== (int) $post->post_author
-		&& ! current_user_can( $post_type->cap->edit_others_posts )
-	) {
+	// Ensure the user is authorized to make changes to Apple News posts.
+	if ( ! current_user_can( apply_filters( 'apple_news_publish_capability', Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type ) ) ) ) {
 		return new WP_Error(
 			'apple_news_failed_cap_check',
 			esc_html__( 'Your user account is not permitted to update this post on Apple News.', 'apple-news' ),

--- a/includes/REST/apple-news-user-can-publish.php
+++ b/includes/REST/apple-news-user-can-publish.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Returns a determination about whether the current user can publish the current post type to Apple News.
+ *
+ * @package Apple_News
+ */
+namespace Apple_News\REST;
+
+use \Apple_News;
+
+/**
+ * Get API response.
+ *
+ * @param array $args Args present in the URL.
+ *
+ * @return array An array that contains the key 'userCanPublish' which is true if the user can publish, false if not.
+ */
+function get_user_can_publish( $args ) {
+
+	// Ensure there is a post ID provided in the data.
+	$id = ! empty( $args['id'] ) ? (int) $args['id'] : 0;
+	if ( empty( $id ) ) {
+		return [
+			'userCanPublish' => false,
+		];
+	}
+
+	// Try to get the post by ID.
+	$post = get_post( $id );
+	if ( empty( $post ) ) {
+		return [
+			'userCanPublish' => false,
+		];
+	}
+
+	// Ensure the user is authorized to make changes to Apple News posts.
+	return [
+		'userCanPublish' => current_user_can(
+			apply_filters(
+				'apple_news_publish_capability',
+				Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type )
+			)
+		),
+	];
+}
+
+/**
+ * Initialize this REST Endpoint.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		// Register route count argument.
+		register_rest_route(
+			'apple-news/v1',
+			'/user-can-publish/(?P<id>\d+)',
+			[
+				'methods'  => 'GET',
+				'callback' => __NAMESPACE__ . '\get_user_can_publish',
+			]
+		);
+	}
+);


### PR DESCRIPTION
* Adds Publish, Update, and Delete buttons if the settings for "automatically publish/update/delete in Apple News if published/updated/deleted in WordPress" are set to "no."
* Adds permissions checks to only show the buttons if users are authorized to use them.
* Creates new REST endpoints to handle these actions.
* Adds a handler for if a user closes and un-favorites the Apple News PluginSidebar to be able to get it back without hacking localStorage.
* Augments the list of settings returned by the API to return all non-sensitive settings for logged-in users.