### PR TITLE
AN-169 Additional Gutenberg Embeds Support

### DIFF
--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -95,6 +95,7 @@ class Component_Factory {
 		self::register_component( 'table', '\\Apple_Exporter\\Components\\Table' );
 		self::register_component( 'flickr', '\\Apple_Exporter\\Components\\Flickr' );
 		self::register_component( 'wp-embed', '\\Apple_Exporter\\Components\\WP_Embed' );
+		self::register_component( 'spotify', '\\Apple_Exporter\\Components\\Spotify' );
 		self::register_component( 'iframe', '\\Apple_Exporter\\Components\\Embed_Web_Video' );
 		self::register_component( 'img', '\\Apple_Exporter\\Components\\Image' );
 		self::register_component( 'video', '\\Apple_Exporter\\Components\\Video' );

--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -94,6 +94,7 @@ class Component_Factory {
 		self::register_component( 'instagram', '\\Apple_Exporter\\Components\\Instagram' );
 		self::register_component( 'table', '\\Apple_Exporter\\Components\\Table' );
 		self::register_component( 'flickr', '\\Apple_Exporter\\Components\\Flickr' );
+		self::register_component( 'wp-embed', '\\Apple_Exporter\\Components\\WP_Embed' );
 		self::register_component( 'iframe', '\\Apple_Exporter\\Components\\Embed_Web_Video' );
 		self::register_component( 'img', '\\Apple_Exporter\\Components\\Image' );
 		self::register_component( 'video', '\\Apple_Exporter\\Components\\Video' );

--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -96,6 +96,7 @@ class Component_Factory {
 		self::register_component( 'flickr', '\\Apple_Exporter\\Components\\Flickr' );
 		self::register_component( 'wp-embed', '\\Apple_Exporter\\Components\\WP_Embed' );
 		self::register_component( 'spotify', '\\Apple_Exporter\\Components\\Spotify' );
+		self::register_component( 'soundcloud', '\\Apple_Exporter\\Components\\SoundCloud' );
 		self::register_component( 'iframe', '\\Apple_Exporter\\Components\\Embed_Web_Video' );
 		self::register_component( 'img', '\\Apple_Exporter\\Components\\Image' );
 		self::register_component( 'video', '\\Apple_Exporter\\Components\\Video' );

--- a/includes/apple-exporter/components/class-soundcloud.php
+++ b/includes/apple-exporter/components/class-soundcloud.php
@@ -19,6 +19,17 @@ namespace Apple_Exporter\Components;
 class SoundCloud extends Component {
 
 	/**
+	 * Spotify URLs to validate.
+	 *
+	 * @return void
+	 */
+	public static function validateUrl( $url = '' ) {
+		return (
+			preg_match( '#https?:\/\/(?:w\.|www\.|)soundcloud\.com\/player\/[^"\']++#', $url )
+		);
+	}
+
+	/**
 	 * Look for node matches for this component.
 	 *
 	 * @param \DOMElement $node The node to examine for matches.
@@ -28,9 +39,10 @@ class SoundCloud extends Component {
 	 */
 	public static function node_matches( $node ) {
 
-		// Match the src attribute against a flickr regex
+		// Match the src attribute against a classname (gutenberg) or soundcloud regex (classic)
 		if (
 			'figure' === $node->nodeName && self::node_has_class( $node, 'is-provider-soundcloud' )
+			|| $node->hasChildNodes() && 'iframe' === $node->childNodes[0]->nodeName && self::validateUrl( $node->childNodes[0]->getAttribute( 'src' ) )
 		) {
 			return $node;
 		}
@@ -98,8 +110,9 @@ class SoundCloud extends Component {
 		$registration_array = [
 			'#components#' => [
 				[
-					'role' => 'heading2',
-					'text' => $title,
+					'role'   => 'heading2',
+					'text'   => $title,
+					'format' => 'html',
 				],
 			],
 		];

--- a/includes/apple-exporter/components/class-soundcloud.php
+++ b/includes/apple-exporter/components/class-soundcloud.php
@@ -121,7 +121,7 @@ class SoundCloud extends Component {
 			'text'      => $link,
 			'format'    => 'html',
 			'textStyle' => [
-				'fontSize' => 14,
+				'fontSize' => 18,
 			],
 		];
 

--- a/includes/apple-exporter/components/class-soundcloud.php
+++ b/includes/apple-exporter/components/class-soundcloud.php
@@ -110,7 +110,7 @@ class SoundCloud extends Component {
 				'text'      => $caption,
 				'format'    => 'html',
 				'textStyle' => [
-					'fontSize' => 14,
+					'fontSize' => 16,
 				],
 				'hidden'    => $hide_article_caption,
 			];
@@ -121,7 +121,7 @@ class SoundCloud extends Component {
 			'text'      => $link,
 			'format'    => 'html',
 			'textStyle' => [
-				'fontSize' => 18,
+				'fontSize' => 14,
 			],
 		];
 

--- a/includes/apple-exporter/components/class-soundcloud.php
+++ b/includes/apple-exporter/components/class-soundcloud.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Components\SoundCloud class
+ *
+ * Contains a class which is used to transform SoundCloud embeds into Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
+
+namespace Apple_Exporter\Components;
+
+/**
+ * A class to transform an SoundCloud embed into an SoundCloud Apple News component.
+ *
+ * @since 0.2.0
+ */
+class SoundCloud extends Component {
+
+	/**
+	 * Look for node matches for this component.
+	 *
+	 * @param \DOMElement $node The node to examine for matches.
+	 *
+	 * @access public
+	 * @return \DOMElement|null The node on success, or null on no match.
+	 */
+	public static function node_matches( $node ) {
+
+		// Match the src attribute against a flickr regex
+		if (
+			'figure' === $node->nodeName && self::node_has_class( $node, 'is-provider-soundcloud' )
+		) {
+			return $node;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Register all specs for the component.
+	 *
+	 * @access public
+	 */
+	public function register_specs() {
+		$this->register_spec(
+			'soundcloud-json',
+			__( 'SoundCloud JSON', 'apple-news' ),
+			array(
+				'layout'     => 'soundcloud-layout',
+				'role'       => 'container',
+				'components' => '#components#',
+			)
+		);
+
+		$this->register_spec(
+			'soundcloud-layout',
+			__( 'Embed Layout', 'apple-news' ),
+			array(
+				'margin'      => array(
+					'top'    => 15,
+					'bottom' => 15,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Build the component.
+	 *
+	 * @param string $html The HTML to parse into text for processing.
+	 *
+	 * @access protected
+	 */
+	protected function build( $html ) {
+
+		$caption              = '';
+		$hide_article_caption = true;
+		$link                 = '';
+		$title                = '';
+		$url                  = '';
+
+		// If we have a url, parse.
+		if ( preg_match( '#<iframe.*?title="(.*?)".*?src="(.*?)"(.*?)>#', $html, $matches ) ) {
+			$title = $matches[1];
+			$url   = $matches[2];
+			$link  = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'View on SoundCloud.', 'apple-news' ) . '</a>';
+
+			// If caption exists, set as caption.
+			$hide_article_caption = false;
+			if ( preg_match( '#figcaption>(.*?)</fig#', $html, $caption_matches ) ) {
+				$caption = $caption_matches[1];
+				$hide_article_caption = false;
+			}
+		}
+
+		$registration_array = [
+			'#components#' => [
+				[
+					'role' => 'heading2',
+					'text' => $title,
+				],
+			],
+		];
+
+		if ( ! empty( $caption ) ) {
+			$registration_array['#components#'][]= [
+				'role'      => 'caption',
+				'text'      => $caption,
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+				'hidden'    => $hide_article_caption,
+			];
+		}
+
+		$registration_array['#components#'][] = [
+			'role'      => 'body',
+			'text'      => $link,
+			'format'    => 'html',
+			'textStyle' => [
+				'fontSize' => 14,
+			],
+		];
+
+		$this->register_json(
+			'soundcloud-json',
+			$registration_array
+		);
+
+		// Get information about the currently loaded theme.
+		$theme = \Apple_Exporter\Theme::get_used();
+
+		// Register the layout for the table.
+		$this->register_layout( 'soundcloud-layout', 'soundcloud-layout' );
+	}
+}

--- a/includes/apple-exporter/components/class-spotify.php
+++ b/includes/apple-exporter/components/class-spotify.php
@@ -19,6 +19,17 @@ namespace Apple_Exporter\Components;
 class Spotify extends Component {
 
 	/**
+	 * Spotify URLs to validate.
+	 *
+	 * @return void
+	 */
+	public static function validateUrl( $url = '' ) {
+		return (
+			preg_match( '/https?:\/\/(?:embed\.|open\.)(?:spotify\.com\/)(?:track\/|\?uri=spotify:track:)((\w|-){22})/', $url )
+		);
+	}
+
+	/**
 	 * Look for node matches for this component.
 	 *
 	 * @param \DOMElement $node The node to examine for matches.
@@ -28,9 +39,10 @@ class Spotify extends Component {
 	 */
 	public static function node_matches( $node ) {
 
-		// Match the src attribute against a flickr regex
+		// Match the src attribute against a classname (gutenberg) or spotify regex (classic)
 		if (
 			'figure' === $node->nodeName && self::node_has_class( $node, 'is-provider-spotify' )
+			|| $node->hasChildNodes() && 'iframe' === $node->childNodes[0]->nodeName && self::validateUrl( $node->childNodes[0]->getAttribute( 'src' ) )
 		) {
 			return $node;
 		}
@@ -98,8 +110,9 @@ class Spotify extends Component {
 		$registration_array = [
 			'#components#' => [
 				[
-					'role' => 'heading2',
-					'text' => $title,
+					'role'   => 'heading2',
+					'text'   => $title,
+					'format' => 'html',
 				],
 			],
 		];

--- a/includes/apple-exporter/components/class-spotify.php
+++ b/includes/apple-exporter/components/class-spotify.php
@@ -25,7 +25,7 @@ class Spotify extends Component {
 	 */
 	public static function validateUrl( $url = '' ) {
 		return (
-			preg_match( '/https?:\/\/(?:embed\.|open\.)(?:spotify\.com\/)(?:track\/|\?uri=spotify:track:)((\w|-){22})/', $url )
+			preg_match( '#https?:\/\/(?:play\.|open\.)(?:)spotify\.com\/#', $url )
 		);
 	}
 

--- a/includes/apple-exporter/components/class-spotify.php
+++ b/includes/apple-exporter/components/class-spotify.php
@@ -110,7 +110,7 @@ class Spotify extends Component {
 				'text'      => $caption,
 				'format'    => 'html',
 				'textStyle' => [
-					'fontSize' => 14,
+					'fontSize' => 16,
 				],
 				'hidden'    => $hide_article_caption,
 			];
@@ -121,7 +121,7 @@ class Spotify extends Component {
 			'text'      => $link,
 			'format'    => 'html',
 			'textStyle' => [
-				'fontSize' => 18,
+				'fontSize' => 14,
 			],
 		];
 

--- a/includes/apple-exporter/components/class-spotify.php
+++ b/includes/apple-exporter/components/class-spotify.php
@@ -76,19 +76,21 @@ class Spotify extends Component {
 	protected function build( $html ) {
 
 		$caption              = '';
+		$hide_article_caption = true;
+		$link                 = '';
 		$title                = '';
 		$url                  = '';
-		$hide_article_caption = true;
 
 		// If we have a url, parse.
 		if ( preg_match( '#<iframe.*?title="(.*?)".*?src="(.*?)"(.*?)>#', $html, $matches ) ) {
 			$title = $matches[1];
 			$url   = $matches[2];
+			$link  = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'View on Spotify.', 'apple-news' ) . '</a>';
 
 			// If caption exists, set as caption.
 			$hide_article_caption = false;
-			if ( preg_match( '#figcaption>(.*?)</fig#', $html, $caption_matches ) ) {
-				$caption = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'View on Spotify.', 'apple-news' ) . '</a>';
+			if ( preg_match( '#figcaption>(.*?)</figcaption#', $html, $caption_matches ) ) {
+				$caption = $caption_matches[1];
 				$hide_article_caption = false;
 			}
 		}
@@ -103,7 +105,7 @@ class Spotify extends Component {
 		];
 
 		if ( ! empty( $caption ) ) {
-			$registration_array['#components#'][]= [
+			$registration_array['#components#'][] = [
 				'role'      => 'caption',
 				'text'      => $caption,
 				'format'    => 'html',
@@ -113,6 +115,15 @@ class Spotify extends Component {
 				'hidden'    => $hide_article_caption,
 			];
 		}
+
+		$registration_array['#components#'][] = [
+			'role'      => 'body',
+			'text'      => $link,
+			'format'    => 'html',
+			'textStyle' => [
+				'fontSize' => 14,
+			],
+		];
 
 		$this->register_json(
 			'spotify-json',

--- a/includes/apple-exporter/components/class-spotify.php
+++ b/includes/apple-exporter/components/class-spotify.php
@@ -121,7 +121,7 @@ class Spotify extends Component {
 			'text'      => $link,
 			'format'    => 'html',
 			'textStyle' => [
-				'fontSize' => 14,
+				'fontSize' => 18,
 			],
 		];
 

--- a/includes/apple-exporter/components/class-spotify.php
+++ b/includes/apple-exporter/components/class-spotify.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Components\Spotify class
+ *
+ * Contains a class which is used to transform Spotify embeds into Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
+
+namespace Apple_Exporter\Components;
+
+/**
+ * A class to transform an Spotify embed into an Spotify Apple News component.
+ *
+ * @since 0.2.0
+ */
+class Spotify extends Component {
+
+	/**
+	 * Look for node matches for this component.
+	 *
+	 * @param \DOMElement $node The node to examine for matches.
+	 *
+	 * @access public
+	 * @return \DOMElement|null The node on success, or null on no match.
+	 */
+	public static function node_matches( $node ) {
+
+		// Match the src attribute against a flickr regex
+		if (
+			'figure' === $node->nodeName && self::node_has_class( $node, 'is-provider-spotify' )
+		) {
+			return $node;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Register all specs for the component.
+	 *
+	 * @access public
+	 */
+	public function register_specs() {
+		$this->register_spec(
+			'spotify-json',
+			__( 'Spotify JSON', 'apple-news' ),
+			array(
+				'layout'     => 'spotify-layout',
+				'role'       => 'container',
+				'components' => '#components#',
+			)
+		);
+
+		$this->register_spec(
+			'spotify-layout',
+			__( 'Embed Layout', 'apple-news' ),
+			array(
+				'margin'      => array(
+					'top'    => 15,
+					'bottom' => 15,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Build the component.
+	 *
+	 * @param string $html The HTML to parse into text for processing.
+	 *
+	 * @access protected
+	 */
+	protected function build( $html ) {
+
+		$caption              = '';
+		$title                = '';
+		$url                  = '';
+		$hide_article_caption = true;
+
+		// If we have a url, parse.
+		if ( preg_match( '#<iframe.*?title="(.*?)".*?src="(.*?)"(.*?)>#', $html, $matches ) ) {
+			$title = $matches[1];
+			$url   = $matches[2];
+
+			// If caption exists, set as caption.
+			$hide_article_caption = false;
+			if ( preg_match( '#figcaption>(.*?)</fig#', $html, $caption_matches ) ) {
+				$caption = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'View on Spotify.', 'apple-news' ) . '</a>';
+				$hide_article_caption = false;
+			}
+		}
+
+		$registration_array = [
+			'#components#' => [
+				[
+					'role' => 'heading2',
+					'text' => $title,
+				],
+			],
+		];
+
+		if ( ! empty( $caption ) ) {
+			$registration_array['#components#'][]= [
+				'role'      => 'caption',
+				'text'      => $caption,
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+				'hidden'    => $hide_article_caption,
+			];
+		}
+
+		$this->register_json(
+			'spotify-json',
+			$registration_array
+		);
+
+		// Get information about the currently loaded theme.
+		$theme = \Apple_Exporter\Theme::get_used();
+
+		// Register the layout for the table.
+		$this->register_layout( 'spotify-layout', 'spotify-layout' );
+	}
+}

--- a/includes/apple-exporter/components/class-wp-embed.php
+++ b/includes/apple-exporter/components/class-wp-embed.php
@@ -28,9 +28,10 @@ class WP_Embed extends Component {
 	 */
 	public static function node_matches( $node ) {
 
-		// Match the src attribute against a flickr regex
+		// Match the src attribute against node classnames
 		if (
 			'figure' === $node->nodeName && self::node_has_class( $node, 'is-type-wp-embed' )
+			|| 'iframe' === $node->nodeName && self::node_has_class( $node, 'wp-embedded-content' )
 		) {
 			return $node;
 		}
@@ -88,6 +89,12 @@ class WP_Embed extends Component {
 				$parsed_url = wp_parse_url( $url );
 				$caption = '<a href="' . esc_url( $url ) . '">' . sprintf( esc_html__( 'View on %s.', 'apple-news' ), esc_html( $parsed_url['host'] ) ) . '</a>';
 
+				// Classic Editor.
+				if (  preg_match( '#<iframe.*?title="(.*?)".*?src="(.*?)"(.*?)>#', $html, $title_matches ) ) {
+					$title = sprintf( esc_html__( 'WordPress Embed: %s.', 'apple-news' ), esc_html( $title_matches[1] ) );
+				}
+
+				// Gutenberg Editor.
 				if ( preg_match( '#<\s*?a href\b[^>]*>(.*?)</a\b[^>]*>#s', $html, $title_matches ) ) {
 					$title = sprintf( esc_html__( 'WordPress Embed: %s.', 'apple-news' ), esc_html( $title_matches[1] ) );
 				}
@@ -98,8 +105,9 @@ class WP_Embed extends Component {
 			'layout'          => 'embed-layout',
 			'#components#'    => [
 				[
-					'role' => 'heading2',
-					'text' => $title,
+					'role'   => 'heading2',
+					'text'   => $title,
+					'format' => 'html',
 				],
 				[
 					'role'      => 'body',

--- a/includes/apple-exporter/components/class-wp-embed.php
+++ b/includes/apple-exporter/components/class-wp-embed.php
@@ -74,7 +74,7 @@ class WP_Embed extends Component {
 			// If the url has a host, set as caption.
 			if ( $url && isset( wp_parse_url( $url )['host'] ) ) {
 				$parsed_url = wp_parse_url( $url );
-				$caption = '<a href="' . esc_url( $url ) . '">' . sprintf( esc_html__( 'View on %s', 'apple-news' ), esc_html( $parsed_url['host'] ) ) . '</a>';
+				$caption = '<a href="' . esc_url( $url ) . '">' . sprintf( esc_html__( 'View on %s.', 'apple-news' ), esc_html( $parsed_url['host'] ) ) . '</a>';
 
 				if ( preg_match( '#<\s*?a href\b[^>]*>(.*?)</a\b[^>]*>#s', $html, $title_matches ) ) {
 					$title = $title_matches[1];

--- a/includes/apple-exporter/components/class-wp-embed.php
+++ b/includes/apple-exporter/components/class-wp-embed.php
@@ -48,8 +48,20 @@ class WP_Embed extends Component {
 			'wp-embed-json',
 			__( 'WP_Embed JSON', 'apple-news' ),
 			array(
+				'layout'     => 'embed-layout',
 				'role'       => 'container',
 				'components' => '#components#',
+			)
+		);
+
+		$this->register_spec(
+			'embed-layout',
+			__( 'Embed Layout', 'apple-news' ),
+			array(
+				'margin'      => array(
+					'top'    => 15,
+					'bottom' => 15,
+				),
 			)
 		);
 	}
@@ -77,24 +89,25 @@ class WP_Embed extends Component {
 				$caption = '<a href="' . esc_url( $url ) . '">' . sprintf( esc_html__( 'View on %s.', 'apple-news' ), esc_html( $parsed_url['host'] ) ) . '</a>';
 
 				if ( preg_match( '#<\s*?a href\b[^>]*>(.*?)</a\b[^>]*>#s', $html, $title_matches ) ) {
-					$title = $title_matches[1];
+					$title = sprintf( esc_html__( 'WordPress Embed: %s.', 'apple-news' ), esc_html( $title_matches[1] ) );
 				}
 			}
 		}
 
 		$registration_array = [
-			'#components#' => [
+			'layout'          => 'embed-layout',
+			'#components#'    => [
 				[
 					'role' => 'heading2',
 					'text' => $title,
 				],
 				[
-					'role'   => 'body',
-					'text'   => $caption,
-					'format' => 'html',
+					'role'      => 'body',
+					'text'      => $caption,
+					'format'    => 'html',
 					'textStyle' => [
 						'fontSize' => 14,
-					]
+					],
 				],
 			],
 		];
@@ -103,5 +116,11 @@ class WP_Embed extends Component {
 			'wp-embed-json',
 			$registration_array
 		);
+
+		// Get information about the currently loaded theme.
+		$theme = \Apple_Exporter\Theme::get_used();
+
+		// Register the layout for the table.
+		$this->register_layout( 'embed-layout', 'embed-layout' );
 	}
 }

--- a/includes/apple-exporter/components/class-wp-embed.php
+++ b/includes/apple-exporter/components/class-wp-embed.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Publish to Apple News Includes: Apple_Exporter\Components\WPEmbed class
+ *
+ * Contains a class which is used to transform WPEmbed embeds into Apple News format.
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter
+ * @since 0.2.0
+ */
+
+namespace Apple_Exporter\Components;
+
+/**
+ * A class to transform an WPEmbed embed into an WPEmbed Apple News component.
+ *
+ * @since 0.2.0
+ */
+class WP_Embed extends Component {
+
+	/**
+	 * Look for node matches for this component.
+	 *
+	 * @param \DOMElement $node The node to examine for matches.
+	 *
+	 * @access public
+	 * @return \DOMElement|null The node on success, or null on no match.
+	 */
+	public static function node_matches( $node ) {
+
+		// Match the src attribute against a flickr regex
+		if (
+			'figure' === $node->nodeName && self::node_has_class( $node, 'is-type-wp-embed' )
+		) {
+			return $node;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Register all specs for the component.
+	 *
+	 * @access public
+	 */
+	public function register_specs() {
+		$this->register_spec(
+			'wp-embed-json',
+			__( 'WPEmbed JSON', 'apple-news' ),
+			array(
+				'role'       => 'container',
+				'components' => '#components#',
+			)
+		);
+	}
+
+	/**
+	 * Build the component.
+	 *
+	 * @param string $html The HTML to parse into text for processing.
+	 *
+	 * @access protected
+	 */
+	protected function build( $html ) {
+
+		$caption = '';
+		$title   = '';
+		$url     = '';
+
+		// If we have a url, parse.
+		if ( preg_match( '#https?://[^"]+#', $html, $url_matches ) ) {
+			$url = $url_matches[0];
+
+			// If the url has a host, set as caption.
+			if ( $url && isset( wp_parse_url( $url )['host'] ) ) {
+				$parsed_url = wp_parse_url( $url );
+				$caption = '<a href="' . esc_url( $url ) . '">' . sprintf( esc_html__( 'View on %s', 'apple-news' ), esc_html( $parsed_url['host'] ) ) . '</a>';
+
+				if ( preg_match( '#<\s*?a href\b[^>]*>(.*?)</a\b[^>]*>#s', $html, $title_matches ) ) {
+					$title = $title_matches[1];
+				}
+			}
+		}
+
+		$registration_array = [
+			'#components#' => [
+				[
+					'role' => 'heading2',
+					'text' => $title,
+				],
+				[
+					'role'   => 'body',
+					'text'   => $caption,
+					'format' => 'html',
+					'textStyle' => [
+						'fontSize' => 14,
+					]
+				],
+			],
+		];
+
+		$this->register_json(
+			'wp-embed-json',
+			$registration_array
+		);
+	}
+}

--- a/includes/apple-exporter/components/class-wp-embed.php
+++ b/includes/apple-exporter/components/class-wp-embed.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Publish to Apple News Includes: Apple_Exporter\Components\WPEmbed class
+ * Publish to Apple News Includes: Apple_Exporter\Components\WP_Embed class
  *
- * Contains a class which is used to transform WPEmbed embeds into Apple News format.
+ * Contains a class which is used to transform WP_Embed embeds into Apple News format.
  *
  * @package Apple_News
  * @subpackage Apple_Exporter
@@ -12,7 +12,7 @@
 namespace Apple_Exporter\Components;
 
 /**
- * A class to transform an WPEmbed embed into an WPEmbed Apple News component.
+ * A class to transform an WP_Embed embed into an WP_Embed Apple News component.
  *
  * @since 0.2.0
  */
@@ -46,7 +46,7 @@ class WP_Embed extends Component {
 	public function register_specs() {
 		$this->register_spec(
 			'wp-embed-json',
-			__( 'WPEmbed JSON', 'apple-news' ),
+			__( 'WP_Embed JSON', 'apple-news' ),
 			array(
 				'role'       => 'container',
 				'components' => '#components#',

--- a/tests/apple-exporter/components/test-class-soundcloud.php
+++ b/tests/apple-exporter/components/test-class-soundcloud.php
@@ -104,6 +104,7 @@ class SoundCloud_Test extends Component_TestCase {
 			[
 				'role' => 'heading2',
 				'text' => 'SONG NAME - Band Name',
+				'format' => 'html',
 			],
 			$component->to_array()['components'][0]
 		);

--- a/tests/apple-exporter/components/test-class-soundcloud.php
+++ b/tests/apple-exporter/components/test-class-soundcloud.php
@@ -133,8 +133,9 @@ class SoundCloud_Test extends Component_TestCase {
 		// Test Heading
 		$this->assertEquals(
 			[
-				'role' => 'heading2',
-				'text' => 'SONG NAME - Band Name',
+				'role'   => 'heading2',
+				'text'   => 'SONG NAME - Band Name',
+				'format' => 'html',
 			],
 			$component->to_array()['components'][0]
 		);

--- a/tests/apple-exporter/components/test-class-soundcloud.php
+++ b/tests/apple-exporter/components/test-class-soundcloud.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Publish to Apple News Tests: SoundCloud_Test class
+ *
+ * Contains a class which is used to test Apple_Exporter\Components\SoundCloud.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+require_once __DIR__ . '/class-component-testcase.php';
+
+use Apple_Exporter\Components\SoundCloud;
+
+/**
+ * A class which is used to test the Apple_Exporter\Components\SoundCloud class.
+ */
+class SoundCloud_Test extends Component_TestCase {
+
+	/**
+	 * A data provider for the test_transform function.
+	 *
+	 * @see self::test_transform()
+	 *
+	 * @access public
+	 * @return array An array of test data
+	 */
+	public function data_transform() {
+		return [
+			[ 'https://w.soundcloud.com/player/999999999' ],
+		];
+	}
+
+	/**
+	 * A filter function to modify the URL in the generated JSON.
+	 *
+	 * @param array $json The JSON array to modify.
+	 *
+	 * @access public
+	 * @return array The modified JSON.
+	 */
+	public function filter_apple_news_soundclound_json( $json ) {
+		$json['URL'] = 'https://w.soundcloud.com/player/999999999';
+
+		return $json;
+	}
+
+	/**
+	 * Test the `apple_news_soundclound_json` filter.
+	 *
+	 * @access public
+	 */
+	public function testFilterSoundCloud() {
+
+		// Setup.
+		$component = new SoundCloud(
+			'https://w.soundcloud.com/player/999999999',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		add_filter(
+			'apple_news_soundclound_json',
+			[ $this, 'filter_apple_news_soundclound_json' ]
+		);
+
+		// Test.
+		$result = $component->to_array();
+		var_dump( $result );
+		die();
+		$this->assertEquals(
+			'https://w.soundcloud.com/player/999999999',
+			$result['URL']
+		);
+
+		// Teardown.
+		remove_filter(
+			'apple_news_soundclound_json',
+			[ $this, 'filter_apple_news_soundclound_json' ]
+		);
+	}
+
+	/**
+	 * Tests the transformation process from an oEmbed URL to a SoundCloud component.
+	 *
+	 * @dataProvider data_transform
+	 *
+	 * @param string $url The URL to test.
+	 *
+	 * @access public
+	 */
+	public function testTransform( $url ) {
+
+		// Setup. Test Block without Caption
+		$component = new SoundCloud(
+			'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><iframe title="SONG NAME - Band Name" width="500" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/999999999"></iframe></div></figure>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test Heading
+		$this->assertEquals(
+			[
+				'role' => 'heading2',
+				'text' => 'SONG NAME - Band Name',
+			],
+			$component->to_array()['components'][0]
+		);
+
+		// Test body text / link.
+		$this->assertEquals(
+			[
+				'role'      => 'body',
+				'text'      => '<a href="https://w.soundcloud.com/player/999999999">View on SoundCloud.</a>',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+			],
+			$component->to_array()['components'][1]
+		);
+
+		// Setup. Embed generate caption from data.
+		$component = new SoundCloud(
+			'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><iframe title="SONG NAME - Band Name" width="500" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/999999999"></iframe></div><figcaption>Soundcloud Caption</figcaption></figure>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test Heading
+		$this->assertEquals(
+			[
+				'role' => 'heading2',
+				'text' => 'SONG NAME - Band Name',
+			],
+			$component->to_array()['components'][0]
+		);
+
+		// Test caption.
+		$this->assertEquals(
+			[
+				'role'      => 'caption',
+				'text'      => 'Soundcloud Caption',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 16,
+				],
+				'hidden'    => false,
+			],
+			$component->to_array()['components'][1]
+		);
+
+		// Test body text / link.
+		$this->assertEquals(
+			[
+				'role'      => 'body',
+				'text'      => '<a href="https://w.soundcloud.com/player/999999999">View on SoundCloud.</a>',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+			],
+			$component->to_array()['components'][2]
+		);
+	}
+}

--- a/tests/apple-exporter/components/test-class-soundcloud.php
+++ b/tests/apple-exporter/components/test-class-soundcloud.php
@@ -39,7 +39,7 @@ class SoundCloud_Test extends Component_TestCase {
 	 * @access public
 	 * @return array The modified JSON.
 	 */
-	public function filter_apple_news_soundclound_json( $json ) {
+	public function filter_apple_news_soundcloud_json( $json ) {
 		$json['URL'] = 'https://w.soundcloud.com/player/999999999';
 
 		return $json;
@@ -61,14 +61,12 @@ class SoundCloud_Test extends Component_TestCase {
 			$this->layouts
 		);
 		add_filter(
-			'apple_news_soundclound_json',
-			[ $this, 'filter_apple_news_soundclound_json' ]
+			'apple_news_soundcloud_json',
+			[ $this, 'filter_apple_news_soundcloud_json' ]
 		);
 
 		// Test.
 		$result = $component->to_array();
-		var_dump( $result );
-		die();
 		$this->assertEquals(
 			'https://w.soundcloud.com/player/999999999',
 			$result['URL']
@@ -76,8 +74,8 @@ class SoundCloud_Test extends Component_TestCase {
 
 		// Teardown.
 		remove_filter(
-			'apple_news_soundclound_json',
-			[ $this, 'filter_apple_news_soundclound_json' ]
+			'apple_news_soundcloud_json',
+			[ $this, 'filter_apple_news_soundcloud_json' ]
 		);
 	}
 
@@ -90,7 +88,7 @@ class SoundCloud_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testTransform( $url ) {
+	public function testTransformSoundCloud( $url ) {
 
 		// Setup. Test Block without Caption
 		$component = new SoundCloud(

--- a/tests/apple-exporter/components/test-class-spotify.php
+++ b/tests/apple-exporter/components/test-class-spotify.php
@@ -27,7 +27,7 @@ class Spotify_Test extends Component_TestCase {
 	 */
 	public function data_transform() {
 		return [
-			[ 'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw' ],
+			[ 'https://open.spotify.com/embed/track/999999999' ],
 		];
 	}
 
@@ -40,7 +40,7 @@ class Spotify_Test extends Component_TestCase {
 	 * @return array The modified JSON.
 	 */
 	public function filter_apple_news_spotify_json( $json ) {
-		$json['URL'] = 'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw';
+		$json['URL'] = 'https://open.spotify.com/embed/track/999999999';
 
 		return $json;
 	}
@@ -54,7 +54,7 @@ class Spotify_Test extends Component_TestCase {
 
 		// Setup.
 		$component = new Spotify(
-			'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw',
+			'https://open.spotify.com/embed/track/999999999',
 			null,
 			$this->settings,
 			$this->styles,
@@ -68,7 +68,7 @@ class Spotify_Test extends Component_TestCase {
 		// Test.
 		$result = $component->to_array();
 		$this->assertEquals(
-			'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw',
+			'https://open.spotify.com/embed/track/999999999',
 			$result['URL']
 		);
 
@@ -93,7 +93,7 @@ class Spotify_Test extends Component_TestCase {
 		// Setup. Test Block without Caption
 		$component = new Spotify(
 			'<figure class="wp-block-embed-spotify wp-block-embed is-type-rich is-provider-spotify wp-embed-aspect-9-16 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
-			<iframe title="Spotify Embed: dontbesoblue" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw"></iframe>
+			<iframe title="Spotify Embed: Band Name" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/track/999999999"></iframe>
 			</div></figure>',
 			null,
 			$this->settings,
@@ -105,7 +105,7 @@ class Spotify_Test extends Component_TestCase {
 		$this->assertEquals(
 			[
 				'role' => 'heading2',
-				'text' => 'Spotify Embed: dontbesoblue',
+				'text' => 'Spotify Embed: Band Name',
 			],
 			$component->to_array()['components'][0]
 		);
@@ -114,7 +114,7 @@ class Spotify_Test extends Component_TestCase {
 		$this->assertEquals(
 			[
 				'role'      => 'body',
-				'text'      => '<a href="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw">View on Spotify.</a>',
+				'text'      => '<a href="https://open.spotify.com/embed/track/999999999">View on Spotify.</a>',
 				'format'    => 'html',
 				'textStyle' => [
 					'fontSize' => 14,
@@ -126,7 +126,7 @@ class Spotify_Test extends Component_TestCase {
 		// Setup. Embed generate caption from data.
 		$component = new Spotify(
 			'<figure class="wp-block-embed-spotify wp-block-embed is-type-rich is-provider-spotify wp-embed-aspect-9-16 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
-			<iframe title="Spotify Embed: dontbesoblue" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw"></iframe>
+			<iframe title="Spotify Embed: Band Name" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/track/999999999"></iframe>
 			</div><figcaption>Spotify Caption</figcaption></figure>',
 			null,
 			$this->settings,
@@ -138,7 +138,7 @@ class Spotify_Test extends Component_TestCase {
 		$this->assertEquals(
 			[
 				'role' => 'heading2',
-				'text' => 'Spotify Embed: dontbesoblue',
+				'text' => 'Spotify Embed: Band Name',
 			],
 			$component->to_array()['components'][0]
 		);
@@ -161,7 +161,7 @@ class Spotify_Test extends Component_TestCase {
 		$this->assertEquals(
 			[
 				'role'      => 'body',
-				'text'      => '<a href="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw">View on Spotify.</a>',
+				'text'      => '<a href="https://open.spotify.com/embed/track/999999999">View on Spotify.</a>',
 				'format'    => 'html',
 				'textStyle' => [
 					'fontSize' => 14,

--- a/tests/apple-exporter/components/test-class-spotify.php
+++ b/tests/apple-exporter/components/test-class-spotify.php
@@ -106,6 +106,7 @@ class Spotify_Test extends Component_TestCase {
 			[
 				'role' => 'heading2',
 				'text' => 'Spotify Embed: Band Name',
+				'format' => 'html',
 			],
 			$component->to_array()['components'][0]
 		);

--- a/tests/apple-exporter/components/test-class-spotify.php
+++ b/tests/apple-exporter/components/test-class-spotify.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Publish to Apple News Tests: Spotify_Test class
+ *
+ * Contains a class which is used to test Apple_Exporter\Components\Spotify.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+require_once __DIR__ . '/class-component-testcase.php';
+
+use Apple_Exporter\Components\Spotify;
+
+/**
+ * A class which is used to test the Apple_Exporter\Components\Spotify class.
+ */
+class Spotify_Test extends Component_TestCase {
+
+	/**
+	 * A data provider for the test_transform function.
+	 *
+	 * @see self::test_transform()
+	 *
+	 * @access public
+	 * @return array An array of test data
+	 */
+	public function data_transform() {
+		return [
+			[ 'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw' ],
+		];
+	}
+
+	/**
+	 * A filter function to modify the URL in the generated JSON.
+	 *
+	 * @param array $json The JSON array to modify.
+	 *
+	 * @access public
+	 * @return array The modified JSON.
+	 */
+	public function filter_apple_news_spotify_json( $json ) {
+		$json['URL'] = 'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw';
+
+		return $json;
+	}
+
+		/**
+	 * Test the `apple_news_spotify_json` filter.
+	 *
+	 * @access public
+	 */
+	public function testFilter() {
+
+		// Setup.
+		$component = new Spotify(
+			'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		add_filter(
+			'apple_news_spotify_json',
+			[ $this, 'filter_apple_news_spotify_json' ]
+		);
+
+		// Test.
+		$result = $component->to_array();
+		$this->assertEquals(
+			'https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw',
+			$result['URL']
+		);
+
+		// Teardown.
+		remove_filter(
+			'apple_news_spotify_json',
+			[ $this, 'filter_apple_news_spotify_json' ]
+		);
+	}
+
+	/**
+	 * Tests the transformation process from an oEmbed URL to a Spotify component.
+	 *
+	 * @dataProvider data_transform
+	 *
+	 * @param string $url The URL to test.
+	 *
+	 * @access public
+	 */
+	public function testTransform( $url ) {
+
+		// Setup. Test Block without Caption
+		$component = new Spotify(
+			'<figure class="wp-block-embed-spotify wp-block-embed is-type-rich is-provider-spotify wp-embed-aspect-9-16 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+			<iframe title="Spotify Embed: dontbesoblue" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw"></iframe>
+			</div></figure>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test Heading
+		$this->assertEquals(
+			[
+				'role' => 'heading2',
+				'text' => 'Spotify Embed: dontbesoblue',
+			],
+			$component->to_array()['components'][0]
+		);
+
+		// Test body text / link.
+		$this->assertEquals(
+			[
+				'role'      => 'body',
+				'text'      => '<a href="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw">View on Spotify.</a>',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+			],
+			$component->to_array()['components'][1]
+		);
+
+		// Setup. Embed generate caption from data.
+		$component = new Spotify(
+			'<figure class="wp-block-embed-spotify wp-block-embed is-type-rich is-provider-spotify wp-embed-aspect-9-16 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+			<iframe title="Spotify Embed: dontbesoblue" width="300" height="380" allowtransparency="true" frameborder="0" allow="encrypted-media" src="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw"></iframe>
+			</div><figcaption>Spotify Caption</figcaption></figure>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test Heading
+		$this->assertEquals(
+			[
+				'role' => 'heading2',
+				'text' => 'Spotify Embed: dontbesoblue',
+			],
+			$component->to_array()['components'][0]
+		);
+
+		// Test caption.
+		$this->assertEquals(
+			[
+				'role'      => 'caption',
+				'text'      => 'Spotify Caption',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 16,
+				],
+				'hidden'    => false,
+			],
+			$component->to_array()['components'][1]
+		);
+
+		// Test body text / link.
+		$this->assertEquals(
+			[
+				'role'      => 'body',
+				'text'      => '<a href="https://open.spotify.com/embed/track/4Wu4BIrP199NeG4DREWw8E?si=ljvW4ls1QYagWo1Ib9nYsw">View on Spotify.</a>',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+			],
+			$component->to_array()['components'][2]
+		);
+	}
+}

--- a/tests/apple-exporter/components/test-class-spotify.php
+++ b/tests/apple-exporter/components/test-class-spotify.php
@@ -50,7 +50,7 @@ class Spotify_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testFilter() {
+	public function testFilterSpotify() {
 
 		// Setup.
 		$component = new Spotify(
@@ -88,7 +88,7 @@ class Spotify_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testTransform( $url ) {
+	public function testTransformSpotify( $url ) {
 
 		// Setup. Test Block without Caption
 		$component = new Spotify(

--- a/tests/apple-exporter/components/test-class-spotify.php
+++ b/tests/apple-exporter/components/test-class-spotify.php
@@ -137,8 +137,9 @@ class Spotify_Test extends Component_TestCase {
 		// Test Heading
 		$this->assertEquals(
 			[
-				'role' => 'heading2',
-				'text' => 'Spotify Embed: Band Name',
+				'role'   => 'heading2',
+				'text'   => 'Spotify Embed: Band Name',
+				'format' => 'html',
 			],
 			$component->to_array()['components'][0]
 		);

--- a/tests/apple-exporter/components/test-class-wp-embed.php
+++ b/tests/apple-exporter/components/test-class-wp-embed.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Publish to Apple News Tests: WP_Embed_Test class
+ *
+ * Contains a class which is used to test Apple_Exporter\Components\WP_Embed.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+require_once __DIR__ . '/class-component-testcase.php';
+
+use Apple_Exporter\Components\WP_Embed;
+
+/**
+ * A class which is used to test the Apple_Exporter\Components\WP_Embed class.
+ */
+class WP_Embed_Test extends Component_TestCase {
+
+	/**
+	 * A data provider for the test_transform function.
+	 *
+	 * @see self::test_transform()
+	 *
+	 * @access public
+	 * @return array An array of test data
+	 */
+	public function data_transform() {
+		return array(
+			array( 'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/' ),
+		);
+	}
+
+	/**
+	 * A filter function to modify the URL in the generated JSON.
+	 *
+	 * @param array $json The JSON array to modify.
+	 *
+	 * @access public
+	 * @return array The modified JSON.
+	 */
+	public function filter_apple_news_wp_embed_json( $json ) {
+		$json['URL'] = 'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/';
+
+		return $json;
+	}
+
+		/**
+	 * Test the `apple_news_wp_embed_json` filter.
+	 *
+	 * @access public
+	 */
+	public function testFilter() {
+
+		// Setup.
+		$component = new WP_Embed(
+			'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+		add_filter(
+			'apple_news_wp_embed_json',
+			array( $this, 'filter_apple_news_wp_embed_json' )
+		);
+
+		// Test.
+		$result = $component->to_array();
+		$this->assertEquals(
+			'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/',
+			$result['URL']
+		);
+
+		// Teardown.
+		remove_filter(
+			'apple_news_wp_embed_json',
+			array( $this, 'filter_apple_news_wp_embed_json' )
+		);
+	}
+
+	/**
+	 * Tests the transformation process from an oEmbed URL to a WP_Embed component.
+	 *
+	 * @dataProvider data_transform
+	 *
+	 * @param string $url The URL to test.
+	 *
+	 * @access public
+	 */
+	public function testTransform( $url ) {
+
+		// Setup. Single photo, no article caption, full-view caption
+		$component = new WP_Embed(
+			'<figure class="wp-block-embed-wordpress wp-block-embed is-type-wp-embed is-provider-alley"><div class="wp-block-embed__wrapper">
+			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">What’s To Come At WordCamp for Publishers 2019</a></blockquote><iframe title="“What’s To Come At WordCamp for Publishers 2019” — Alley" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/embed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test Heading
+		$this->assertEquals(
+			array(
+				'role' => 'heading2',
+				'text' => 'WordPress Embed: What’s To Come At WordCamp for Publishers 2019.',
+			),
+			$component->to_array()['components'][0] // Photo component
+		);
+
+		// Setup. Single photo, article caption, full-view caption
+		$component = new WP_Embed(
+			'<figure class="wp-block-embed-wordpress wp-block-embed is-type-wp-embed is-provider-alley"><div class="wp-block-embed__wrapper">
+			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">What’s To Come At WordCamp for Publishers 2019</a></blockquote><iframe title="“What’s To Come At WordCamp for Publishers 2019” — Alley" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/embed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Test for Caption
+		$this->assertEquals(
+			array(
+				'role'      => 'body',
+				'text'      => '<a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">View on alley.co.</a>',
+				'format'    => 'html',
+				'textStyle' => [
+					'fontSize' => 14,
+				],
+			),
+			$component->to_array()['components'][1]
+		);
+	}
+}

--- a/tests/apple-exporter/components/test-class-wp-embed.php
+++ b/tests/apple-exporter/components/test-class-wp-embed.php
@@ -26,9 +26,9 @@ class WP_Embed_Test extends Component_TestCase {
 	 * @return array An array of test data
 	 */
 	public function data_transform() {
-		return array(
-			array( 'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/' ),
-		);
+		return [
+			[ 'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/' ],
+		];
 	}
 
 	/**
@@ -62,7 +62,7 @@ class WP_Embed_Test extends Component_TestCase {
 		);
 		add_filter(
 			'apple_news_wp_embed_json',
-			array( $this, 'filter_apple_news_wp_embed_json' )
+			[ $this, 'filter_apple_news_wp_embed_json' ]
 		);
 
 		// Test.
@@ -75,7 +75,7 @@ class WP_Embed_Test extends Component_TestCase {
 		// Teardown.
 		remove_filter(
 			'apple_news_wp_embed_json',
-			array( $this, 'filter_apple_news_wp_embed_json' )
+			[ $this, 'filter_apple_news_wp_embed_json' ]
 		);
 	}
 
@@ -90,7 +90,7 @@ class WP_Embed_Test extends Component_TestCase {
 	 */
 	public function testTransform( $url ) {
 
-		// Setup. Single photo, no article caption, full-view caption
+		// Setup. Heading for embed.
 		$component = new WP_Embed(
 			'<figure class="wp-block-embed-wordpress wp-block-embed is-type-wp-embed is-provider-alley"><div class="wp-block-embed__wrapper">
 			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">What’s To Come At WordCamp for Publishers 2019</a></blockquote><iframe title="“What’s To Come At WordCamp for Publishers 2019” — Alley" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/embed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
@@ -102,14 +102,14 @@ class WP_Embed_Test extends Component_TestCase {
 
 		// Test Heading
 		$this->assertEquals(
-			array(
+			[
 				'role' => 'heading2',
 				'text' => 'WordPress Embed: What’s To Come At WordCamp for Publishers 2019.',
-			),
-			$component->to_array()['components'][0] // Photo component
+			],
+			$component->to_array()['components'][0]
 		);
 
-		// Setup. Single photo, article caption, full-view caption
+		// Setup. Embed generate caption from data.
 		$component = new WP_Embed(
 			'<figure class="wp-block-embed-wordpress wp-block-embed is-type-wp-embed is-provider-alley"><div class="wp-block-embed__wrapper">
 			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">What’s To Come At WordCamp for Publishers 2019</a></blockquote><iframe title="“What’s To Come At WordCamp for Publishers 2019” — Alley" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/embed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
@@ -121,14 +121,14 @@ class WP_Embed_Test extends Component_TestCase {
 
 		// Test for Caption
 		$this->assertEquals(
-			array(
+			[
 				'role'      => 'body',
 				'text'      => '<a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">View on alley.co.</a>',
 				'format'    => 'html',
 				'textStyle' => [
 					'fontSize' => 14,
 				],
-			),
+			],
 			$component->to_array()['components'][1]
 		);
 	}

--- a/tests/apple-exporter/components/test-class-wp-embed.php
+++ b/tests/apple-exporter/components/test-class-wp-embed.php
@@ -103,8 +103,9 @@ class WP_Embed_Test extends Component_TestCase {
 		// Test Heading
 		$this->assertEquals(
 			[
-				'role' => 'heading2',
-				'text' => 'WordPress Embed: Blog Post Title.',
+				'role'   => 'heading2',
+				'text'   => 'WordPress Embed: Blog Post Title.',
+				'format' => 'html',
 			],
 			$component->to_array()['components'][0]
 		);

--- a/tests/apple-exporter/components/test-class-wp-embed.php
+++ b/tests/apple-exporter/components/test-class-wp-embed.php
@@ -27,7 +27,7 @@ class WP_Embed_Test extends Component_TestCase {
 	 */
 	public function data_transform() {
 		return [
-			[ 'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/' ],
+			[ 'https://test-url.com/blog-post-url-slug' ],
 		];
 	}
 
@@ -40,7 +40,7 @@ class WP_Embed_Test extends Component_TestCase {
 	 * @return array The modified JSON.
 	 */
 	public function filter_apple_news_wp_embed_json( $json ) {
-		$json['URL'] = 'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/';
+		$json['URL'] = 'https://test-url.com/blog-post-url-slug';
 
 		return $json;
 	}
@@ -50,11 +50,11 @@ class WP_Embed_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testFilter() {
+	public function testFilterWPEmbed() {
 
 		// Setup.
 		$component = new WP_Embed(
-			'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/',
+			'https://test-url.com/blog-post-url-slug',
 			null,
 			$this->settings,
 			$this->styles,
@@ -68,7 +68,7 @@ class WP_Embed_Test extends Component_TestCase {
 		// Test.
 		$result = $component->to_array();
 		$this->assertEquals(
-			'https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/',
+			'https://test-url.com/blog-post-url-slug',
 			$result['URL']
 		);
 
@@ -88,12 +88,12 @@ class WP_Embed_Test extends Component_TestCase {
 	 *
 	 * @access public
 	 */
-	public function testTransform( $url ) {
+	public function testTransformWPEmbed( $url ) {
 
 		// Setup. Heading for embed.
 		$component = new WP_Embed(
 			'<figure class="wp-block-embed-wordpress wp-block-embed is-type-wp-embed is-provider-alley"><div class="wp-block-embed__wrapper">
-			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">What’s To Come At WordCamp for Publishers 2019</a></blockquote><iframe title="“What’s To Come At WordCamp for Publishers 2019” — Alley" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/embed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
+			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://test-url.com/blog-post-url-slug">Blog Post Title</a></blockquote><iframe title="Blog Post Title" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://test-url.com/blog-post-url-slugembed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
 			null,
 			$this->settings,
 			$this->styles,
@@ -104,7 +104,7 @@ class WP_Embed_Test extends Component_TestCase {
 		$this->assertEquals(
 			[
 				'role' => 'heading2',
-				'text' => 'WordPress Embed: What’s To Come At WordCamp for Publishers 2019.',
+				'text' => 'WordPress Embed: Blog Post Title.',
 			],
 			$component->to_array()['components'][0]
 		);
@@ -112,7 +112,7 @@ class WP_Embed_Test extends Component_TestCase {
 		// Setup. Embed generate caption from data.
 		$component = new WP_Embed(
 			'<figure class="wp-block-embed-wordpress wp-block-embed is-type-wp-embed is-provider-alley"><div class="wp-block-embed__wrapper">
-			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">What’s To Come At WordCamp for Publishers 2019</a></blockquote><iframe title="“What’s To Come At WordCamp for Publishers 2019” — Alley" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/embed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
+			<blockquote class="wp-embedded-content" data-secret="laxVbHVh5h" style="display: none;"><a href="https://test-url.com/blog-post-url-slug">Blog Post Title</a></blockquote><iframe title="Blog Post Title" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" src="https://test-url.com/blog-post-url-slugembed/#?secret=laxVbHVh5h" data-secret="laxVbHVh5h" width="500" height="346" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></div></figure>',
 			null,
 			$this->settings,
 			$this->styles,
@@ -123,7 +123,7 @@ class WP_Embed_Test extends Component_TestCase {
 		$this->assertEquals(
 			[
 				'role'      => 'body',
-				'text'      => '<a href="https://alley.co/news/whats-to-come-at-wordcamp-for-publishers-2019/">View on alley.co.</a>',
+				'text'      => '<a href="https://test-url.com/blog-post-url-slug">View on test-url.com.</a>',
 				'format'    => 'html',
 				'textStyle' => [
 					'fontSize' => 14,


### PR DESCRIPTION
Closes: https://alleyinteractive.atlassian.net/browse/AN-176 formerly AN-169

- Adds Gutenberg support for WP Embeds, Spotify Embeds, and SoundCloud Embeds.
- Adds unit tests for each.
- Backward compatibility with the Classic Editor