### PR TITLE
AN-182 version 201 bugs

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -237,7 +237,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	public function add_meta_boxes( $post ) {
 
 		// If the block editor is active, do not add meta boxes.
-		if ( use_block_editor_for_post( $post->ID ) ) {
+		if ( function_exists( 'use_block_editor_for_post' ) && use_block_editor_for_post( $post->ID ) ) {
 			return;
 		}
 

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -81,7 +81,7 @@ class Admin_Apple_Post_Sync {
 			|| ! in_array( $post->post_type, $this->settings->post_types, true )
 			|| ( ! current_user_can( apply_filters( 'apple_news_publish_capability', Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type ) ) )
 				&& ! ( defined( 'DOING_CRON' ) && DOING_CRON ) )
-			|| function_exists( 'has_blocks' ) && has_blocks( $post )
+			|| ( function_exists( 'has_blocks' ) && has_blocks( $post ) )
 		) {
 			return;
 		}

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -48,11 +48,8 @@ class Admin_Apple_Post_Sync {
 			|| 'yes' === $this->settings->get( 'api_autosync_update' )
 		) {
 			// This needs to happen after meta boxes save.
-			if ( apple_news_block_editor_is_active() ) {
-				add_action( 'rest_after_insert_post', [ $this, 'do_publish_from_rest' ] );
-			} else {
-				add_action( 'save_post', [ $this, 'do_publish' ], 99, 2 );
-			}
+			add_action( 'rest_after_insert_post', [ $this, 'do_publish_from_rest' ] );
+			add_action( 'save_post', [ $this, 'do_publish' ], 99, 2 );
 		}
 
 		// Register delete hook if needed.
@@ -83,7 +80,9 @@ class Admin_Apple_Post_Sync {
 		if ( 'publish' !== $post->post_status
 			|| ! in_array( $post->post_type, $this->settings->post_types, true )
 			|| ( ! current_user_can( apply_filters( 'apple_news_publish_capability', Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type ) ) )
-				&& ! ( defined( 'DOING_CRON' ) && DOING_CRON ) ) ) {
+				&& ! ( defined( 'DOING_CRON' ) && DOING_CRON ) )
+			|| function_exists( 'has_blocks' ) && has_blocks( $post )
+		) {
 			return;
 		}
 

--- a/apple-news.php
+++ b/apple-news.php
@@ -142,7 +142,7 @@ function apple_news_block_editor_is_active() {
 function apple_news_block_editor_is_active_for_post( $post_id = 0 ) {
 
 	// If get_current_screen is not defined, we can't get info about the view, so bail out.
-	if ( ! function_exists( 'get_current_screen' ) ) {
+	if ( ! function_exists( 'get_current_screen' ) || ! function_exists( 'use_block_editor_for_post' ) ) {
 		return false;
 	}
 

--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.0.1
+ * Version:     2.0.2
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -890,8 +890,9 @@ class Sidebar extends React.PureComponent {
 export default compose([
   withSelect((selector) => {
     const editor = selector('core/editor');
-    const meta = editor && editor.getEditedPostAttribute ?
-      editor.getEditedPostAttribute('meta') || {} : {};
+    const meta = editor && editor.getEditedPostAttribute
+      ? editor.getEditedPostAttribute('meta') || {}
+      : {};
     const {
       apple_news_is_paid: isPaid = false,
       apple_news_is_preview: isPreview = false,
@@ -909,8 +910,9 @@ export default compose([
       apple_news_api_revision: revision = '',
     } = meta;
 
-    const postId = editor && editor.getCurrentPostId ?
-      editor.getCurrentPostId() : 0;
+    const postId = editor && editor.getCurrentPostId
+      ? editor.getCurrentPostId()
+      : 0;
 
     return {
       meta: {

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -890,24 +890,27 @@ class Sidebar extends React.PureComponent {
 export default compose([
   withSelect((selector) => {
     const editor = selector('core/editor');
+    const meta = editor && editor.getEditedPostAttribute ?
+      editor.getEditedPostAttribute('meta') || {} : {};
     const {
-      apple_news_is_paid: isPaid,
-      apple_news_is_preview: isPreview,
-      apple_news_is_hidden: isHidden,
-      apple_news_is_sponsored: isSponsored,
-      apple_news_maturity_rating: maturityRating,
-      apple_news_pullquote: pullquoteText,
-      apple_news_pullquote_position: pullquotePosition,
-      apple_news_sections: selectedSections,
-      apple_news_coverart: coverArt,
-      apple_news_api_id: apiId,
-      apple_news_api_created_at: dateCreated,
-      apple_news_api_modified_at: dateModified,
-      apple_news_api_share_url: shareUrl,
-      apple_news_api_revision: revision,
-    } = editor.getEditedPostAttribute('meta');
+      apple_news_is_paid: isPaid = false,
+      apple_news_is_preview: isPreview = false,
+      apple_news_is_hidden: isHidden = false,
+      apple_news_is_sponsored: isSponsored = false,
+      apple_news_maturity_rating: maturityRating = '',
+      apple_news_pullquote: pullquoteText = '',
+      apple_news_pullquote_position: pullquotePosition = '',
+      apple_news_sections: selectedSections = '',
+      apple_news_coverart: coverArt = {},
+      apple_news_api_id: apiId = '',
+      apple_news_api_created_at: dateCreated = '',
+      apple_news_api_modified_at: dateModified = '',
+      apple_news_api_share_url: shareUrl = '',
+      apple_news_api_revision: revision = '',
+    } = meta;
 
-    const postId = editor.getCurrentPostId();
+    const postId = editor && editor.getCurrentPostId ?
+      editor.getCurrentPostId() : 0;
 
     return {
       meta: {
@@ -927,7 +930,7 @@ export default compose([
         revision,
         postId,
       },
-      post: editor.getCurrentPost(),
+      post: editor && editor.getCurrentPost ? editor.getCurrentPost() : {},
     };
   }),
   withDispatch((dispatch) => ({

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -200,8 +200,8 @@ class Apple_News {
 	 */
 	public function __construct() {
 		add_action(
-			'admin_enqueue_scripts',
-			[ $this, 'action_admin_enqueue_scripts' ]
+			'enqueue_block_editor_assets',
+			[ $this, 'enqueue_block_editor_scripts' ]
 		);
 		add_action(
 			'plugins_loaded',

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.0.1';
+	public static $version = '2.0.2';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -222,7 +222,12 @@ class Apple_News {
 	 *
 	 * @access public
 	 */
-	public function action_admin_enqueue_scripts( $hook ) {
+	public function enqueue_block_editor_scripts( $hook ) {
+
+		// Bail if gutenberg is not enabled.
+		if ( ! function_exists( 'use_block_editor_for_post' ) ) {
+			return;
+		}
 
 		// If the block editor is active, add PluginSidebar.
 		if ( get_the_ID() && use_block_editor_for_post( get_the_ID() ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,12 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 == Changelog ==
 
+= 2.0.2 =
+* Bugfix: Adds check for some 5.0.0+ functions before attempting to execute.
+* Bugfix: Adds fallback and additional checks for sidebarPlugin retrieval of post meta.
+* Bugfix: Only makes REST request for post save when Gutenberg is enabled.
+* Enhancement: Enqueues block editor scripts with `enqueue_block_editor_assets`.
+
 = 2.0.1 =
 * Bugfix: Including the built pluginSidebar.js files with the WordPress.org distribution which were erroneously left off.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.2.2
 Requires PHP: 5.6
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 


### PR DESCRIPTION
Closes: #666, #669, #670

- Adds check for some 5.0.0+ functions before attempting to execute.
- Adds fallback and additional checks for sidebarPlugin retrieval of post meta.
- Only makes REST request for post save when Gutenberg is enabled.
- Enqueues block editor scripts with `enqueue_block_editor_assets`.
- Version bump to 2.0.2.
- Updates changelog.