### PR TITLE
Editor Unexpected Error Fix

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.0.2
+ * Version:     2.0.3
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -516,14 +516,13 @@ class Sidebar extends React.PureComponent {
       ? selectedSectionsRaw
       : [];
 
-    // Expects potentially an empty object,
-    // a string, or a null string from props.
-    // Contains object fallback if post type is not enabled,
-    // but still enables Gutenberg.
-    const parsedCoverArt = 0 !== Object.entries(coverArt).length
-      && '' !== coverArt
-      && 'null' !== coverArt
-      ? JSON.parse(coverArt) : {};
+    // Ensure we can parse the coverArt, else return empty object.
+    let parsedCoverArt;
+    try {
+      parsedCoverArt = JSON.parse(coverArt);
+    } catch (err) {
+      parsedCoverArt = {};
+    }
 
     const coverArtOrientation = parsedCoverArt.orientation || 'landscape';
 

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -516,7 +516,13 @@ class Sidebar extends React.PureComponent {
       ? selectedSectionsRaw
       : [];
 
-    const parsedCoverArt = '' !== coverArt && 'null' !== coverArt
+    // Expects potentially an empty object,
+    // a string, or a null string from props.
+    // Contains object fallback if post type is not enabled,
+    // but still enables Gutenberg.
+    const parsedCoverArt = 0 !== Object.entries(coverArt).length
+      && '' !== coverArt
+      && 'null' !== coverArt
       ? JSON.parse(coverArt) : {};
 
     const coverArtOrientation = parsedCoverArt.orientation || 'landscape';

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -225,7 +225,11 @@ class Apple_News {
 	public function enqueue_block_editor_scripts( $hook ) {
 
 		// Bail if gutenberg is not enabled.
-		if ( ! function_exists( 'use_block_editor_for_post' ) ) {
+		// Or if the post type is not active from settings.
+		if (
+			! function_exists( 'use_block_editor_for_post' )
+			|| ! in_array( get_post_type(), Admin_Apple_Settings_Section::$loaded_settings['post_types'], true )
+		) {
 			return;
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.0.2';
+	public static $version = '2.0.3';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 == Changelog ==
 
+= 2.0.3 =
+* Bugfix: Resolves fatal error when trying to load posts that aren't active in some cases.
+
 = 2.0.2 =
 * Bugfix: Adds check for some 5.0.0+ functions before attempting to execute.
 * Bugfix: Adds fallback and additional checks for sidebarPlugin retrieval of post meta.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.2.2
 Requires PHP: 5.6
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 


### PR DESCRIPTION
- Added fallback for the `coverArt` check to proceed even if it's an empty object.
- Added a check against the active post types in the Settings field before initializing the `pluginSidebar` scripts.
- Version bump
- Changelog update.