### PR TITLE
AN-198 Additional JavaScript safety checks

### DIFF
--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -10,7 +10,7 @@ const {
   apiFetch,
   compose: {
     compose,
-  },
+  } = {},
   components: {
     Button,
     CheckboxControl,
@@ -18,23 +18,23 @@ const {
     SelectControl,
     Spinner,
     TextareaControl,
-  },
+  } = {},
   data: {
     select,
     subscribe,
     withDispatch,
     withSelect,
-  },
+  } = {},
   editPost: {
     PluginSidebar,
     PluginSidebarMoreMenuItem,
-  },
+  } = {},
   element: {
     Fragment,
-  },
+  } = {},
   i18n: {
     __,
-  },
+  } = {},
 } = wp;
 
 /**
@@ -262,7 +262,7 @@ class Sidebar extends React.PureComponent {
     const {
       meta: {
         selectedSections,
-      },
+      } = {},
     } = this.props;
 
     apiFetch({ path })
@@ -404,7 +404,7 @@ class Sidebar extends React.PureComponent {
       onUpdate,
       meta: {
         coverArt,
-      },
+      } = {},
     } = this.props;
 
     let parsedCoverArt = safeJsonParseObject(coverArt);
@@ -437,7 +437,7 @@ class Sidebar extends React.PureComponent {
       onUpdate,
       meta: {
         selectedSections,
-      },
+      } = {},
     } = this.props;
     // Need to default to [], else JSON parse fails
     const selectedSectionsArray = safeJsonParseArray(selectedSections);
@@ -485,7 +485,7 @@ class Sidebar extends React.PureComponent {
         dateModified = '',
         shareUrl = '',
         revision = '',
-      },
+      } = {},
       post: {
         status = '',
       } = {},
@@ -504,7 +504,7 @@ class Sidebar extends React.PureComponent {
         apiAutosyncUpdate,
         automaticAssignment,
         enableCoverArt,
-      },
+      } = {},
       selectedSectionsPrev,
       userCanPublish,
     } = this.state;

--- a/assets/js/pluginsidebar/index.js
+++ b/assets/js/pluginsidebar/index.js
@@ -3,13 +3,17 @@
 import Icon from './components/icon';
 import Sidebar from './components/sidebar';
 
-const {
-  plugins: {
-    registerPlugin,
-  },
-} = wp;
+if ('undefined' !== typeof wp) {
+  const {
+    plugins: {
+      registerPlugin = null,
+    } = {},
+  } = wp;
 
-registerPlugin('publish-to-apple-news', {
-  icon: <Icon />,
-  render: Sidebar,
-});
+  if ('function' === typeof registerPlugin) {
+    registerPlugin('publish-to-apple-news', {
+      icon: <Icon />,
+      render: Sidebar,
+    });
+  }
+}

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -228,7 +228,7 @@ class Apple_News {
 	 */
 	public function action_admin_enqueue_scripts( $hook ) {
 		// Ensure we are in an appropriate context.
-		if ( ! in_array( $hook, $this->_contexts, true ) ) {
+		if ( ! in_array( $hook, $this->contexts, true ) ) {
 			return;
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -200,8 +200,12 @@ class Apple_News {
 	 */
 	public function __construct() {
 		add_action(
+			'admin_enqueue_scripts',
+			[ $this, 'action_admin_enqueue_scripts' ]
+		);
+		add_action(
 			'enqueue_block_editor_assets',
-			[ $this, 'enqueue_block_editor_scripts' ]
+			[ $this, 'action_enqueue_block_editor_assets' ]
 		);
 		add_action(
 			'plugins_loaded',
@@ -222,31 +226,9 @@ class Apple_News {
 	 *
 	 * @access public
 	 */
-	public function enqueue_block_editor_scripts( $hook ) {
-
-		// Bail if gutenberg is not enabled.
-		// Or if the post type is not active from settings.
-		if (
-			! function_exists( 'use_block_editor_for_post' )
-			|| ! in_array( get_post_type(), Admin_Apple_Settings_Section::$loaded_settings['post_types'], true )
-		) {
-			return;
-		}
-
-		// If the block editor is active, add PluginSidebar.
-		if ( get_the_ID() && use_block_editor_for_post( get_the_ID() ) ) {
-			wp_enqueue_script(
-				'publish-to-apple-news-plugin-sidebar',
-				plugins_url( 'build/pluginSidebar.js', __DIR__ ),
-				[ 'wp-i18n', 'wp-edit-post' ],
-				self::$version,
-				true
-			);
-			$this->inline_locale_data( 'apple-news-plugin-sidebar' );
-		}
-
+	public function action_admin_enqueue_scripts( $hook ) {
 		// Ensure we are in an appropriate context.
-		if ( ! in_array( $hook, $this->contexts, true ) ) {
+		if ( ! in_array( $hook, $this->_contexts, true ) ) {
 			return;
 		}
 
@@ -281,6 +263,35 @@ class Apple_News {
 				'media_modal_title'  => esc_html__( 'Choose an image', 'apple-news' ),
 			)
 		);
+	}
+
+	/**
+	 * Enqueues scripts for the block editor.
+	 *
+	 * @access public
+	 */
+	public function action_enqueue_block_editor_assets() {
+		// Bail if the post type is not one of the Publish to Apple News post types configured in settings.
+		if ( ! in_array( get_post_type(), Admin_Apple_Settings_Section::$loaded_settings['post_types'], true ) ) {
+			return;
+		}
+
+		// Bail if this post isn't using the block editor.
+		if ( ! function_exists( 'use_block_editor_for_post' )
+			|| ! use_block_editor_for_post( get_the_ID() )
+		) {
+			return;
+		}
+
+		// Add the PluginSidebar.
+		wp_enqueue_script(
+			'publish-to-apple-news-plugin-sidebar',
+			plugins_url( 'build/pluginSidebar.js', __DIR__ ),
+			[ 'wp-i18n', 'wp-edit-post' ],
+			self::$version,
+			true
+		);
+		$this->inline_locale_data( 'apple-news-plugin-sidebar' );
 	}
 
 	/**


### PR DESCRIPTION
* Re-split block editor and admin script enqueue
* Add safety checks for multi-level destructuring
* Don't register the PluginSidebar at all if the wp object doesn't exist or if registerSidebar isn't defined