### PR TITLE
Add warning for use of isPaid flag to prevent confusion on error

### DIFF
--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -32,7 +32,7 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		<h3><?php esc_html_e( 'Paid?', 'apple-news' ); ?></h3>
 		<label for="apple-news-is-paid">
 			<input id="apple-news-is-paid" name="apple_news_is_paid" type="checkbox" value="1" <?php checked( $is_paid ); ?>>
-			<?php esc_html_e( 'Check this to indicate that viewing the article requires a paid subscription.', 'apple-news' ); ?>
+			<?php esc_html_e( 'Check this to indicate that viewing the article requires a paid subscription. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news' ); ?>
 		</label>
 	</div>
 	<div id="apple-news-metabox-is-preview" class="apple-news-metabox-section">

--- a/admin/partials/page-single-push.php
+++ b/admin/partials/page-single-push.php
@@ -37,7 +37,7 @@
 				<td>
 					<label for="apple-news-is-paid">
 						<input id="apple-news-is-paid" name="apple_news_is_paid" type="checkbox" value="1" <?php checked( $post_meta['apple_news_is_paid'][0] ); ?>>
-						<?php esc_html_e( 'Check this to indicate that viewing the article requires a paid subscription.', 'apple-news' ); ?>
+						<?php esc_html_e( 'Check this to indicate that viewing the article requires a paid subscription. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news' ); ?>
 					</label>
 				</td>
 			</tr>

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -615,7 +615,7 @@ class Sidebar extends React.PureComponent {
             <h3>{__('Paid Article', 'apple-news')}</h3>
             <CheckboxControl
               // eslint-disable-next-line max-len
-              label={__('Check this to indicate that viewing the article requires a paid subscription.', 'apple-news')}
+              label={__('Check this to indicate that viewing the article requires a paid subscription. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news')}
               onChange={(value) => onUpdate(
                 'apple_news_is_paid',
                 value


### PR DESCRIPTION
Per #693 the error message about paid content is confusing if you aren't aware that Apple requires the channel to be approved for paid content before attempting to use the `isPaid` flag. This PR adds an explanation to all areas where the flag can be configured to hopefully head off support requests when users attempt to apply the flag on channels that don't support paid content.

A future enhancement could query the channel to see if paid content is allowed, if possible, before displaying the checkbox as an option to the user at all.