### PR TITLE
add condition to output an image caption housed in a figure element with a wp-caption CSS css selector

### DIFF
--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -28,7 +28,17 @@ class Image extends Component {
 
 		// Is this an image node?
 		if (
-			( self::node_has_class( $node, 'wp-block-cover' ) || 'img' === $node->nodeName || ( 'figure' === $node->nodeName && Component::is_embed_figure( $node ) ) )
+			(
+				self::node_has_class( $node, 'wp-block-cover' )
+				|| 'img' === $node->nodeName
+				|| (
+					'figure' === $node->nodeName
+					&& (
+						Component::is_embed_figure( $node )
+						|| self::node_has_class( $node, 'wp-caption' )
+					)
+				)
+			)
 			&& self::remote_file_exists( $node )
 		) {
 			return $node;
@@ -174,7 +184,7 @@ class Image extends Component {
 		}
 
 		// Check for caption.
-		$caption_regex = $is_cover_block ? '#<div.*?>?\n(.*)#m' : '#<figcaption.*?>(.*?)</figcaption>#m';
+		$caption_regex = $is_cover_block ? '#<div.*?>?\n(.*)#m' : '#<figcaption.*?>(.*?)</figcaption>#ms';
 		if ( preg_match( $caption_regex, $html, $matches ) ) {
 			$caption                  = trim( $matches[1] );
 			$values['#caption#']      = ! $is_cover_block ? $caption : array(

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -35,6 +35,93 @@ class Image_Test extends Component_TestCase {
 	}
 
 	/**
+	 * Test Image component matching and JSON
+	 * output with HTML markup for an image.
+	 *
+	 * @access public
+	 */
+	public function testTransformImage() {
+		$this->settings->set( 'html_support', 'yes' );
+		$this->settings->set( 'use_remote_images', 'yes' );
+
+		$html = '<img src="http://someurl.com/filename.jpg" alt="Example" align="left" />';
+
+		$component = new Image(
+			$html,
+			new Workspace( 1 ),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Build the node.
+		$node = self::build_node( $html );
+
+		// Test the match is not `null` and that it matches the original node.
+		$this->assertNotNull( $component->node_matches( $node ) );
+		$this->assertEquals(
+			$component->node_matches( $node ),
+			$node
+		);
+
+		// Get the JSON.
+		$json = $component->to_array();
+
+		// Test the JSON.
+		$this->assertEquals( 'photo', $json['role'] );
+		$this->assertEquals( 'http://someurl.com/filename.jpg', $json['URL'] );
+	}
+
+	/**
+	 * Test Image component matching and JSON output
+	 * with HTML5 markup for an image with a caption.
+	 *
+	 * @access public
+	 */
+	public function testTransformImageCaption() {
+		$this->settings->set( 'html_support', 'yes' );
+		$this->settings->set( 'use_remote_images', 'yes' );
+
+		$html_caption = <<<HTML
+	<figure class="wp-caption">
+		<img src="http://someurl.com/filename.jpg" alt="Example" align="left" />
+		<figcaption class="wp-caption-text">
+			Sed <strong>ac metus</strong> sagittis <em>urna feugiat</em> interdum. Duis vel blandit nisi, id tempus sem. Credit: <a href="https://domain.suffix">Domain</a>
+		</figcaption>
+	</figure>
+HTML;
+
+		// Assign an Image component.
+		$component = new Image(
+			$html_caption,
+			new Workspace( 1 ),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Build the node.
+		$node = self::build_node( $html_caption );
+
+		// Test the match is not `null` and that it matches the original node.
+		$this->assertNotNull( $component->node_matches( $node ) );
+		$this->assertEquals(
+			$component->node_matches( $node ),
+			$node
+		);
+
+		// Get the JSON.
+		$json = $component->to_array();
+
+		// Test the JSON.
+		$this->assertEquals( 'container', $json['role'] );
+		$this->assertContains( $json['components'], $json );
+		$this->assertEquals( 'photo', $json['components'][0]['role'] );
+		$this->assertEquals( 'http://someurl.com/filename.jpg', $json['components'][0]['URL'] );
+		$this->assertEquals( 'Sed <strong>ac metus</strong> sagittis <em>urna feugiat</em> interdum. Duis vel blandit nisi, id tempus sem. Credit: <a href="https://domain.suffix">Domain</a>', $json['components'][0]['caption'] );
+	}
+
+	/**
 	 * Test empty src attribute.
 	 *
 	 * @access public


### PR DESCRIPTION
This update will allow the following `<img />` and caption markup:

```
<figure class="wp-caption">
	<img src="https://wp.test/wp-content/uploads/sites/x/xxxx/xx/image.jpg">
	<figcaption class="wp-caption-text">
		Caption content.
		<span class="credit">Credit</span>
	</figcaption>
</figure>
```

get output correctly in the JSON.

Also reference: https://github.com/alleyinteractive/apple-news/issues/692