### PR TITLE
Patch fix undefined stdClass error message API_KEY_NOT_FOUND

### DIFF
--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -299,7 +299,7 @@ class Request {
 					'%s%s%s%s',
 					$error->code,
 					( ! empty( $error->message ) ) ? ' - ' : '',
-					$error->message,
+					( ! empty( $error->message ) ) ? $error->message : '',
 					$key_path
 				);
 			}


### PR DESCRIPTION
Fix the display message in posts  in case you don't enter a correct API:

```
object(stdClass)#4114 (1) { ["code"]=> string(17) "API_KEY_NOT_FOUND" }
```