### PR TITLE
Adding TikTok compatibility to the generic embed component

### DIFF
--- a/includes/apple-exporter/components/class-embed-generic.php
+++ b/includes/apple-exporter/components/class-embed-generic.php
@@ -154,15 +154,15 @@ class Embed_Generic extends Component {
 		// Fork for iframe handling vs. not. Non-iframe detection is less straightforward, so it is best-effort.
 		if ( false !== strpos( $html, '<iframe' ) && $provider !== 'tiktok' ) {
 			// Try to get the source URL.
-			if (preg_match('/<iframe[^>]+?src=[\'"]([^\'"]+)/', $html, $matches)) {
+			if ( preg_match( '/<iframe[^>]+?src=[\'"]([^\'"]+)/', $html, $matches ) ) {
 				$url = $matches[1];
 			}
 
 			// Try to get the title.
-			if (preg_match('/<iframe[^>]+?title=[\'"]([^\'"]+)/', $html, $matches)) {
+			if ( preg_match( '/<iframe[^>]+?title=[\'"]([^\'"]+)/', $html, $matches ) ) {
 				$title = $matches[1];
 			}
-		} elseif ($provider === 'tiktok' && preg_match('/<blockquote[^>]+?cite=[\'"]([^\'"]+)/', $html, $matches)) {
+		} elseif ( $provider === 'tiktok' && preg_match( '/<blockquote[^>]+?cite=[\'"]([^\'"]+)/', $html, $matches ) ) {
 			//TikTok stores the source URL in the blockquote cite attribute.
 			$url = $matches[1];
 		} elseif ( preg_match( '/data-(?:url|href)=[\'"]([^\'"]+)/', $html, $matches ) ) {

--- a/includes/apple-exporter/components/class-embed-generic.php
+++ b/includes/apple-exporter/components/class-embed-generic.php
@@ -138,6 +138,7 @@ class Embed_Generic extends Component {
 				'wordpress.tv'     => 'wordpress-tv',
 				'reddit.com'       => 'reddit',
 				'imgur.com'        => 'imgur',
+				'tiktok.com'       => 'tiktok',
 				'amazon.com'       => 'amazon-kindle',
 			];
 
@@ -226,6 +227,9 @@ class Embed_Generic extends Component {
 				break;
 			case 'wordpress-tv':
 				$provider = 'WordPress.tv';
+				break;
+			case 'tiktok':
+				$provider = 'TikTok';
 				break;
 			default:
 				$provider = __( 'the original site', 'apple-news' );

--- a/includes/apple-exporter/components/class-embed-generic.php
+++ b/includes/apple-exporter/components/class-embed-generic.php
@@ -152,16 +152,19 @@ class Embed_Generic extends Component {
 		}
 
 		// Fork for iframe handling vs. not. Non-iframe detection is less straightforward, so it is best-effort.
-		if ( false !== strpos( $html, '<iframe' ) ) {
+		if ( false !== strpos( $html, '<iframe' ) && $provider !== 'tiktok' ) {
 			// Try to get the source URL.
-			if ( preg_match( '/<iframe[^>]+?src=[\'"]([^\'"]+)/', $html, $matches ) ) {
+			if (preg_match('/<iframe[^>]+?src=[\'"]([^\'"]+)/', $html, $matches)) {
 				$url = $matches[1];
 			}
 
 			// Try to get the title.
-			if ( preg_match( '/<iframe[^>]+?title=[\'"]([^\'"]+)/', $html, $matches ) ) {
+			if (preg_match('/<iframe[^>]+?title=[\'"]([^\'"]+)/', $html, $matches)) {
 				$title = $matches[1];
 			}
+		} elseif ($provider === 'tiktok' && preg_match('/<blockquote[^>]+?cite=[\'"]([^\'"]+)/', $html, $matches)) {
+			//TikTok stores the source URL in the blockquote cite attribute.
+			$url = $matches[1];
 		} elseif ( preg_match( '/data-(?:url|href)=[\'"]([^\'"]+)/', $html, $matches ) ) {
 			$url = $matches[1];
 		} elseif ( preg_match( '/<a[^>]+?href=[\'"]([^\'"]+)/', $html, $matches ) ) {

--- a/tests/apple-exporter/components/test-class-embed-generic.php
+++ b/tests/apple-exporter/components/test-class-embed-generic.php
@@ -326,6 +326,19 @@ HTML
 				'Jill Bolte Taylor: My stroke of insight',
 			],
 
+			// Gutenberg: TikTok embed.
+			[
+				<<<HTML
+<figure class="wp-block-embed-tiktok wp-block-embed is-type-video is-provider-tiktok"><div class="wp-block-embed__wrapper">
+<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@dynamic_wallpaper/video/6778286193776938241" data-video-id="6778286193776938241" style="max-width: 605px;min-width: 325px;"> <section><a target="_blank" title="@dynamic_wallpaper" href="https://www.tiktok.com/@dynamic_wallpaper">@dynamic_wallpaper</a> <p>そうゆうアプリがあるから無断転載じゃないよ</p> <a target="_blank" title="♬ Monster - LUM!X" href="https://www.tiktok.com/music/Monster-6764388127734761473">♬ Monster – LUM!X</a> </section>
+</blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
+</div></figure>
+HTML
+				,
+				'https://www.tiktok.com/@dynamic_wallpaper/video/6778286193776938241',
+				'TikTok',
+			],
+
 			// Gutenberg: Tumblr embed.
 			[
 				<<<HTML


### PR DESCRIPTION
5.4.0 adds TikTok as a supported embed and the generic embed component doesn't match the URL for TikTok correctly or list it as a provider.