### PR TITLE
Fix for Facebook URLs contained in-text incorrectly getting converted to Facebook components

### DIFF
--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -71,7 +71,9 @@ class Facebook extends Component {
 		}
 
 		// Check for element with just a Facebook url.
-		if ( false !== self::get_facebook_url( $node->nodeValue ) ) {
+		if ( false !== self::get_facebook_url( $node->nodeValue )
+			&& false !== filter_var( $node->nodeValue, FILTER_VALIDATE_URL )
+		) {
 			return $node;
 		}
 

--- a/tests/apple-exporter/components/test-class-facebook.php
+++ b/tests/apple-exporter/components/test-class-facebook.php
@@ -150,5 +150,10 @@ class Facebook_Test extends Component_TestCase {
 		$node_failure = self::build_node( sprintf( '<div class="invalid-fb-post" data-href="%s"></div>', esc_url( $url ) ) );
 
 		$this->assertEmpty( $component->node_matches( $node_failure ) );
+
+		// Test the node - in-text Facebook URL.
+		$node_failure = self::build_node( sprintf( 'Visit us on Facebook at <a href="%s">%s</a>!', esc_url( $url ), esc_html( $url ) ) );
+
+		$this->assertEmpty( $component->node_matches( $node_failure ) );
 	}
 }


### PR DESCRIPTION
If you have something that looks like a Facebook URL in your HTML, for example:

```html
Visit us at <a href="https://www.facebook.com/alleyinteractive/">facebook.com/alleyinteractive</a>!
```

The Facebook matcher will overzealously assume that `facebook.com/alleyinteractive` is a Facebook oEmbed and will convert the entire block to a Facebook component. This fix a) confirms the issue via a unit test and b) fixes the issue, validating the fix via the unit test.

The core of the issue here is that the Facebook URL matcher is *very* permissive, so we want to make sure that when matching against the value of a node for just a URL that the only thing that is being matched is an actual URL, which is the case when WordPress is embedding something via oEmbed - the only thing on the line is the URL for the embeddable object. So, in addition to doing the regex match, we're *also* verifying that the node value is *just* a URL and nothing else using `filter_var`.