### PR TITLE
fixed nbsp; bug with empty paragraphs

### DIFF
--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -50,6 +50,13 @@ class Body extends Component {
 			return null;
 		}
 
+		// Remove p nodes with &nbsp; as the only character
+		// This could only be selected by typing Shift+Opt+Space
+		// https://stackoverflow.com/questions/247135/using-xpath-to-search-text-containing-nbsp
+		if ( 'p' == $node->nodeName && ' ' == $node->nodeValue ) {
+			return null;
+		}
+
 		// Negotiate open and close values.
 		$open  = '<' . $node->nodeName . '>';
 		$close = '</' . $node->nodeName . '>';


### PR DESCRIPTION
Fixes issue where the '&nbsp' character would create an empty paragraph node in the APN JSON.
https://github.com/alleyinteractive/apple-news/issues/635