### PR TITLE
APPLE-36: sections by category default fix

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.0.4
+ * Version:     2.0.5
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -265,9 +265,14 @@ class Sidebar extends React.PureComponent {
       } = {},
     } = this.props;
 
+    const parsedSelectedSections = safeJsonParseArray(selectedSections) || [];
+
     apiFetch({ path })
       .then((settings) => this.setState({
-        autoAssignCategories: 'null' === selectedSections
+        autoAssignCategories: (
+          null === parsedSelectedSections
+          || 0 === parsedSelectedSections.length
+        )
           && true === settings.automaticAssignment,
         settings,
       }))

--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -559,7 +559,7 @@ class Sidebar extends React.PureComponent {
               dismissNotification={this.dismissNotification}
               notifications={notifications}
             />
-            <h3>Sections</h3>
+            <h3>{__('Sections', 'apple-news')}</h3>
             {automaticAssignment && [
               <CheckboxControl
                 label={__('Assign sections by category', 'apple-news')}
@@ -591,32 +591,36 @@ class Sidebar extends React.PureComponent {
               />,
               <hr />,
             ]}
-            {(! autoAssignCategories || ! automaticAssignment) && [
-              <h4>Manual Section Selection</h4>,
-              Array.isArray(sections) && (
-                <ul className="apple-news-sections">
-                  {sections.map(({ id, name }) => (
-                    <li key={id}>
-                      <CheckboxControl
-                        label={name}
-                        checked={- 1 !== selectedSectionsArray.indexOf(id)}
-                        onChange={
-                          (checked) => this.updateSelectedSections(checked, id)
-                        }
-                      />
-                    </li>
-                  ))}
-                </ul>
-              ),
-            ]}
-            <p>
-              <em>
-                {
-                  // eslint-disable-next-line max-len
-                  __('Select the sections in which to publish this article. If none are selected, it will be published to the default section.', 'apple-news')
-                }
-              </em>
-            </p>
+            {(! autoAssignCategories || ! automaticAssignment) && (
+              sections && 0 < sections.length && (
+                <>
+                  <h4>Manual Section Selection</h4>
+                  {Array.isArray(sections) && (
+                    <ul className="apple-news-sections">
+                      {sections.map(({ id, name }) => (
+                        <li key={id}>
+                          <CheckboxControl
+                            label={name}
+                            checked={- 1 !== selectedSectionsArray.indexOf(id)}
+                            onChange={
+                              (checked) => this.updateSelectedSections(checked, id) // eslint-disable-line max-len
+                            }
+                          />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  <p>
+                    <em>
+                      {
+                        // eslint-disable-next-line max-len
+                        __('Select the sections in which to publish this article. If none are selected, it will be published to the default section.', 'apple-news')
+                      }
+                    </em>
+                  </p>
+                </>
+              )
+            )}
             <h3>{__('Paid Article', 'apple-news')}</h3>
             <CheckboxControl
               // eslint-disable-next-line max-len

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.0.6';
+	public static $version = '2.0.7';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2708,7 +2708,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -5091,8 +5092,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5113,14 +5113,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5135,20 +5133,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5265,8 +5260,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5278,7 +5272,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5293,7 +5286,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5301,14 +5293,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5327,7 +5317,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5408,8 +5397,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5421,7 +5409,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5507,8 +5494,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5544,7 +5530,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5564,7 +5549,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5608,14 +5592,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10417,7 +10399,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,11 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.4.0
 Requires PHP: 5.6
-<<<<<<< HEAD
-Stable tag: 2.0.5
-=======
-Stable tag: 2.0.6
->>>>>>> develop
+Stable tag: 2.0.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,10 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 == Changelog ==
 
+= 2.0.5 =
+* Fixes a bug where sections by category is not checked by default for new posts.
+* Fixes visual bug when manual section selection are visible.
+
 = 2.0.4 =
 * Bump "tested up to" tag to 5.4.
 * Upgrades node version used for compiling assets to version 12, and patches vulnerabilities reported via npm audit.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.4.0
 Requires PHP: 5.6
-Stable tag: 2.0.4
+Stable tag: 2.0.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 


### PR DESCRIPTION
Closes #737

* Fixes a bug where sections by category is not checked by default for new posts.
* Fixes visual bug when manual section selection are visible.