### PR TITLE
APPLE-26 Modify theme customization prompt

### DIFF
--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -529,18 +529,8 @@ class Admin_Apple_Themes extends Apple_News {
 			);
 		}
 
-		// If the active theme isn't named "Default", don't nag the user.
-		if ( __( 'Default', 'apple-news' ) !== \Apple_Exporter\Theme::get_active_theme_name() ) {
-			return;
-		}
-
-		// Determine if the theme is using the default settings.
-		$theme = new \Apple_Exporter\Theme();
-		$theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
-		$theme->load();
-
-		// If the theme has been customized, don't nag the user.
-		if ( ! $theme->is_default() ) {
+		// If the active theme isn't the default, don't nag the user.
+		if ( ! Apple_News::is_default_theme() ) {
 			return;
 		}
 

--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.0.8
+ * Version:     2.1.0
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1321,6 +1321,11 @@ class Theme {
 				continue;
 			}
 
+			// Ignore the screenshot URL. This gets set automatically on install but doesn't have a default value.
+			if ( 'screenshot_url' === $option ) {
+				continue;
+			}
+
 			// If the values don't match, it is not using the default.
 			if ( $this->values[ $option ] !== $option_config['default'] ) {
 				return false;
@@ -1500,6 +1505,11 @@ class Theme {
 		// Refresh used if in active use.
 		if ( $old_name === self::$used_name ) {
 			$this->use_this();
+		}
+
+		// Update pointer to active theme, if this was the active theme.
+		if ( $old_name === self::get_active_theme_name() ) {
+			$this->set_active();
 		}
 
 		return true;

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1508,7 +1508,7 @@ class Theme {
 		}
 
 		// Update pointer to active theme, if this was the active theme.
-		if ( $old_name === self::get_active_theme_name() ) {
+		if ( self::get_active_theme_name() === $old_name ) {
 			$this->set_active();
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -186,7 +186,7 @@ class Apple_News {
 	public static function is_default_theme() {
 		// If the theme is not named "Default", then it is customized, and is not the default theme.
 		$active_theme = \Apple_Exporter\Theme::get_active_theme_name();
-		if ( 'Default' !== $active_theme ) {
+		if ( __( 'Default', 'apple-news' ) !== $active_theme ) {
 			return false;
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -174,6 +174,40 @@ class Apple_News {
 	}
 
 	/**
+	 * Determines whether the currently selected theme is the default theme that
+	 * ships with the plugin or not.
+	 *
+	 * Returns true only if the name of the theme is "Default" and the config
+	 * options for the theme match the default theme from the plugin's source
+	 * files.
+	 *
+	 * @return bool True if the default theme is the current active theme, false otherwise.
+	 */
+	public static function is_default_theme() {
+		// If the theme is not named "Default", then it is customized, and is not the default theme.
+		if ( 'Default' !== \Apple_Exporter\Theme::get_active_theme_name() ) {
+			return false;
+		}
+
+		// If the theme _is_ named "Default", check its configuration against the default.
+		$default = new \Apple_Exporter\Theme();
+		$theme   = new \Apple_Exporter\Theme();
+		$theme->set_name( 'Default' );
+		$theme->load();
+
+		// Set the screenshot URL for the default theme.
+		$default->set_value(
+			'screenshot_url',
+			plugins_url(
+				'/assets/screenshots/default.png',
+				__DIR__
+			)
+		);
+
+		return $theme->all_settings() === $default->all_settings();
+	}
+
+	/**
 	 * Determines whether the plugin is initialized with the minimum settings.
 	 *
 	 * @access public

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.0.8';
+	public static $version = '2.1.0';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -185,26 +185,17 @@ class Apple_News {
 	 */
 	public static function is_default_theme() {
 		// If the theme is not named "Default", then it is customized, and is not the default theme.
-		if ( 'Default' !== \Apple_Exporter\Theme::get_active_theme_name() ) {
+		$active_theme = \Apple_Exporter\Theme::get_active_theme_name();
+		if ( 'Default' !== $active_theme ) {
 			return false;
 		}
 
 		// If the theme _is_ named "Default", check its configuration against the default.
-		$default = new \Apple_Exporter\Theme();
-		$theme   = new \Apple_Exporter\Theme();
-		$theme->set_name( 'Default' );
+		$theme = new \Apple_Exporter\Theme();
+		$theme->set_name( $active_theme );
 		$theme->load();
 
-		// Set the screenshot URL for the default theme.
-		$default->set_value(
-			'screenshot_url',
-			plugins_url(
-				'/assets/screenshots/default.png',
-				__DIR__
-			)
-		);
-
-		return $theme->all_settings() === $default->all_settings();
+		return $theme->is_default();
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: potatomaster, kevinfodness, jomurgel, danbowles, alleyinteractive,
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 4.0
-Tested up to: 5.4.0
+Tested up to: 5.4.2
 Requires PHP: 5.6
-Stable tag: 2.0.8
+Stable tag: 2.1.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.1.0 =
+* Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 
 = 2.0.8 =
 * Enhancement: Adds styles for Button elements that are links which are added by the Gutenberg editor.

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -39,6 +39,36 @@ class Apple_News_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the functionality of Apple_News::is_default_theme.
+	 */
+	public function testIsDefaultTheme() {
+		// Absent any customizations, the check for the default theme should return true.
+		$this->assertTrue( Apple_News::is_default_theme() );
+
+		// Load the default theme and change its name but not its settings.
+		$theme = new \Apple_Exporter\Theme();
+		$theme->set_name( 'Default' );
+		$theme->load();
+		$theme->rename( 'Not Default' );
+
+		// The check for the default theme should now return false, since the name was changed.
+		$this->assertFalse( Apple_News::is_default_theme() );
+
+		// If we change the name back to Default, the check should go back to being true.
+		$theme->rename( 'Default' );
+		$this->assertTrue( Apple_News::is_default_theme() );
+
+		// If we leave the name as Default but change one of the theme options, the check should return false.
+		$theme->set_value( 'body_size', 72 );
+		$theme->save();
+		$this->assertFalse( Apple_News::is_default_theme() );
+
+		// If we also rename the theme, the check should return false.
+		$theme->rename( 'Not Default' );
+		$this->assertFalse( Apple_News::is_default_theme() );
+	}
+
+	/**
 	 * Ensures that the migrate_api_settings function migrates settings.
 	 *
 	 * @see Apple_News::migrate_api_settings()


### PR DESCRIPTION
The functionality for the theme customization prompt wasn't working properly due to the automatic addition of the screenshot URL, which was counting as a customization in the comparison. This PR breaks out the check for the default theme into a separate, testable function, and removes the `screenshot_url` property from the list of keys that are compared to the default values in the `is_default` function.

Additionally, as the first commit to the `v2.1.0` branch, it bumps the version number and starts the changelog.