### PR TITLE
APPLE-13 phpcs fixes, part 1

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -220,7 +220,7 @@ class Export extends Action {
 		 * HTML. We use 'the_content' filter for that.
 		 */
 		$content = apply_filters( 'apple_news_exporter_content_pre', $post->post_content, $post->ID );
-		$content = apply_filters( 'the_content', $content );
+		$content = apply_filters( 'the_content', $content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$content = $this->remove_tags( $content );
 		$content = $this->remove_entities( $content );
 		return $content;

--- a/admin/class-admin-apple-news-list-table.php
+++ b/admin/class-admin-apple-news-list-table.php
@@ -326,7 +326,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 		if ( ! empty( $publish_status ) ) {
 			switch ( $publish_status ) {
 				case 'published':
-					$args['meta_query'] = array(
+					$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						array(
 							'key'     => 'apple_news_api_id',
 							'compare' => '!=',
@@ -335,7 +335,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 					);
 					break;
 				case 'not_published':
-					$args['meta_query'] = array(
+					$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						'relation' => 'AND',
 						array(
 							'relation' => 'OR',
@@ -356,7 +356,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 					);
 					break;
 				case 'deleted':
-					$args['meta_query'] = array(
+					$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						array(
 							'key'     => 'apple_news_api_deleted',
 							'compare' => 'EXISTS',
@@ -364,7 +364,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 					);
 					break;
 				case 'pending':
-					$args['meta_query'] = array(
+					$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						array(
 							'key'     => 'apple_news_api_pending',
 							'compare' => 'EXISTS',

--- a/admin/partials/cover-art.php
+++ b/admin/partials/cover-art.php
@@ -5,8 +5,8 @@
  * @package Apple_News
  */
 
-$cover_art    = get_post_meta( $post->ID, 'apple_news_coverart', true );
-$orientations = array(
+$apple_cover_art    = get_post_meta( $post->ID, 'apple_news_coverart', true );
+$apple_orientations = array(
 	'landscape' => __( 'Landscape (4:3)', 'apple-news' ),
 	'portrait'  => __( 'Portrait (3:4)', 'apple-news' ),
 	'square'    => __( 'Square (1:1)', 'apple-news' ),
@@ -25,48 +25,48 @@ $orientations = array(
 <div>
 	<label for="apple-news-coverart-orientation"><?php esc_html_e( 'Orientation:', 'apple-news' ); ?></label>
 	<select id="apple-news-coverart-orientation" name="apple-news-coverart-orientation">
-		<?php $orientation = ( ! empty( $cover_art['orientation'] ) ) ? $cover_art['orientation'] : 'landscape'; ?>
-		<?php foreach ( $orientations as $key => $label ) : ?>
-			<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $orientation, $key ); ?>><?php echo esc_html( $label ); ?></option>
+		<?php $apple_orientation = ( ! empty( $apple_cover_art['orientation'] ) ) ? $apple_cover_art['orientation'] : 'landscape'; ?>
+		<?php foreach ( $apple_orientations as $apple_key => $apple_label ) : ?>
+			<option value="<?php echo esc_attr( $apple_key ); ?>" <?php selected( $apple_orientation, $apple_key ); ?>><?php echo esc_html( $apple_label ); ?></option>
 		<?php endforeach; ?>
 	</select>
 </div>
 <p class="description"><?php esc_html_e( 'Note: You must provide the largest size (iPad Pro 12.9 in) in order for your submission to be considered.', 'apple-news' ); ?></p>
-<?php $image_sizes = Admin_Apple_News::get_image_sizes(); ?>
-<?php foreach ( $image_sizes as $key => $data ) : ?>
+<?php $apple_image_sizes = Admin_Apple_News::get_image_sizes(); ?>
+<?php foreach ( $apple_image_sizes as $apple_key => $apple_data ) : ?>
 	<?php
-	if ( 'coverArt' !== $data['type'] ) {
+	if ( 'coverArt' !== $apple_data['type'] ) {
 		continue;
 	}
 	?>
-	<div class="apple-news-coverart-image-container apple-news-coverart-image-<?php echo esc_attr( $data['orientation'] ); ?>">
-		<?php $image_id = ( ! empty( $cover_art[ $key ] ) ) ? absint( $cover_art[ $key ] ) : ''; ?>
-		<h4><?php echo esc_html( $data['label'] ); ?></h4>
+	<div class="apple-news-coverart-image-container apple-news-coverart-image-<?php echo esc_attr( $apple_data['orientation'] ); ?>">
+		<?php $apple_image_id = ( ! empty( $apple_cover_art[ $apple_key ] ) ) ? absint( $apple_cover_art[ $apple_key ] ) : ''; ?>
+		<h4><?php echo esc_html( $apple_data['label'] ); ?></h4>
 		<div class="apple-news-coverart-image">
 			<?php
-			if ( ! empty( $image_id ) ) {
-				echo wp_get_attachment_image( $image_id, 'medium' );
-				$add_hidden    = 'hidden';
-				$remove_hidden = '';
+			if ( ! empty( $apple_image_id ) ) {
+				echo wp_get_attachment_image( $apple_image_id, 'medium' );
+				$apple_add_hidden    = 'hidden';
+				$apple_remove_hidden = '';
 			} else {
-				$add_hidden    = '';
-				$remove_hidden = 'hidden';
+				$apple_add_hidden    = '';
+				$apple_remove_hidden = 'hidden';
 			}
 			?>
 		</div>
-		<input name="<?php echo esc_attr( $key ); ?>"
+		<input name="<?php echo esc_attr( $apple_key ); ?>"
 			class="apple-news-coverart-id"
 			type="hidden"
-			value="<?php echo esc_attr( $image_id ); ?>"
-			data-height="<?php echo esc_attr( $data['height'] ); ?>"
-			data-width="<?php echo esc_attr( $data['width'] ); ?>"
+			value="<?php echo esc_attr( $apple_image_id ); ?>"
+			data-height="<?php echo esc_attr( $apple_data['height'] ); ?>"
+			data-width="<?php echo esc_attr( $apple_data['width'] ); ?>"
 		/>
 		<input type="button"
-			class="button-primary apple-news-coverart-add <?php echo esc_attr( $add_hidden ); ?>"
+			class="button-primary apple-news-coverart-add <?php echo esc_attr( $apple_add_hidden ); ?>"
 			value="<?php esc_attr_e( 'Add image', 'apple-news' ); ?>"
 		/>
 		<input type="button"
-			class="button-primary apple-news-coverart-remove <?php echo esc_attr( $remove_hidden ); ?>"
+			class="button-primary apple-news-coverart-remove <?php echo esc_attr( $apple_remove_hidden ); ?>"
 			value="<?php esc_attr_e( 'Remove image', 'apple-news' ); ?>"
 		/>
 	</div>

--- a/admin/partials/field-meta-component-order.php
+++ b/admin/partials/field-meta-component-order.php
@@ -9,12 +9,12 @@
 <div class="apple-news-sortable-list">
 	<h4><?php esc_html_e( 'Active', 'apple-news' ); ?></h4>
 	<ul id="meta-component-order-sort" class="component-order ui-sortable">
-		<?php foreach ( $component_order as $component_name ) : ?>
+		<?php foreach ( $component_order as $apple_component_name ) : ?>
 			<?php
 			echo sprintf(
 				'<li id="%s" class="ui-sortable-handle">%s</li>',
-				esc_attr( $component_name ),
-				esc_html( ucwords( $component_name ) )
+				esc_attr( $apple_component_name ),
+				esc_html( ucwords( $apple_component_name ) )
 			);
 			?>
 		<?php endforeach; ?>
@@ -23,12 +23,12 @@
 <div class="apple-news-sortable-list">
 	<h4><?php esc_html_e( 'Inactive', 'apple-news' ); ?></h4>
 	<ul id="meta-component-inactive" class="component-order ui-sortable">
-		<?php foreach ( $inactive_components as $component_name ) : ?>
+		<?php foreach ( $inactive_components as $apple_component_name ) : ?>
 			<?php
 			echo sprintf(
 				'<li id="%s" class="ui-sortable-handle">%s</li>',
-				esc_attr( $component_name ),
-				esc_html( ucwords( $component_name ) )
+				esc_attr( $apple_component_name ),
+				esc_html( ucwords( $apple_component_name ) )
 			);
 			?>
 		<?php endforeach; ?>

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -61,8 +61,8 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		<label for="apple-news-maturity-rating">
 			<select id="apple-news-maturity-rating" name="apple_news_maturity_rating">
 				<option value=""></option>
-				<?php foreach ( self::$maturity_ratings as $rating ) : ?>
-					<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( $maturity_rating, $rating ); ?>><?php echo esc_html( ucwords( strtolower( $rating ) ) ); ?></option>
+				<?php foreach ( self::$maturity_ratings as $apple_rating ) : ?>
+					<option value="<?php echo esc_attr( $apple_rating ); ?>" <?php selected( $maturity_rating, $apple_rating ); ?>><?php echo esc_html( ucwords( strtolower( $apple_rating ) ) ); ?></option>
 				<?php endforeach; ?>
 			</select>
 			<p class="description"><?php esc_html_e( 'Select the optional maturity rating for this post.', 'apple-news' ); ?></p>
@@ -128,22 +128,22 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 	<?php if ( ! empty( $api_id ) ) : ?>
 		<?php
 		// Add data about the article if it exists.
-		$state       = \Admin_Apple_News::get_post_status( $post->ID );
-		$share_url   = get_post_meta( $post->ID, 'apple_news_api_share_url', true );
-		$created_at  = get_post_meta( $post->ID, 'apple_news_api_created_at', true );
-		$created_at  = empty( $created_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $created_at ) ), 'F j, h:i a' );
-		$modified_at = get_post_meta( $post->ID, 'apple_news_api_modified_at', true );
-		$modified_at = empty( $modified_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $modified_at ) ), 'F j, h:i a' );
+		$apple_state       = \Admin_Apple_News::get_post_status( $post->ID );
+		$apple_share_url   = get_post_meta( $post->ID, 'apple_news_api_share_url', true );
+		$apple_created_at  = get_post_meta( $post->ID, 'apple_news_api_created_at', true );
+		$apple_created_at  = empty( $apple_created_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $apple_created_at ) ), 'F j, h:i a' );
+		$apple_modified_at = get_post_meta( $post->ID, 'apple_news_api_modified_at', true );
+		$apple_modified_at = empty( $apple_modified_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $apple_modified_at ) ), 'F j, h:i a' );
 		?>
 	<div id="apple-news-metabox-pullquote" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
 		<h3><?php esc_html_e( 'Apple News Publish Information', 'apple-news' ); ?></h3>
 		<ul>
 			<li><strong><?php esc_html_e( 'ID', 'apple-news' ); ?>:</strong> <?php echo esc_html( $api_id ); ?></li>
-			<li><strong><?php esc_html_e( 'Created at', 'apple-news' ); ?>:</strong> <?php echo esc_html( $created_at ); ?></li>
-			<li><strong><?php esc_html_e( 'Modified at', 'apple-news' ); ?>:</strong> <?php echo esc_html( $modified_at ); ?></li>
-			<li><strong><?php esc_html_e( 'Share URL', 'apple-news' ); ?>:</strong> <a href="<?php echo esc_url( $share_url ); ?>" target="_blank"><?php echo esc_html( $share_url ); ?></a></li>
+			<li><strong><?php esc_html_e( 'Created at', 'apple-news' ); ?>:</strong> <?php echo esc_html( $apple_created_at ); ?></li>
+			<li><strong><?php esc_html_e( 'Modified at', 'apple-news' ); ?>:</strong> <?php echo esc_html( $apple_modified_at ); ?></li>
+			<li><strong><?php esc_html_e( 'Share URL', 'apple-news' ); ?>:</strong> <a href="<?php echo esc_url( $apple_share_url ); ?>" target="_blank"><?php echo esc_html( $apple_share_url ); ?></a></li>
 			<li><strong><?php esc_html_e( 'Revision', 'apple-news' ); ?>:</strong> <?php echo esc_html( get_post_meta( $post->ID, 'apple_news_api_revision', true ) ); ?></li>
-			<li><strong><?php esc_html_e( 'State', 'apple-news' ); ?>:</strong> <?php echo esc_html( $state ); ?></li>
+			<li><strong><?php esc_html_e( 'State', 'apple-news' ); ?>:</strong> <?php echo esc_html( $apple_state ); ?></li>
 		</ul>
 	</div>
 	<?php endif; ?>

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -67,10 +67,10 @@
 					<?php esc_html_e( 'Theme', 'apple-news' ); ?>:
 					<select id="apple_news_theme" name="apple_news_theme">
 						<option value="""><?php esc_html_e( 'Select a theme', 'apple-news' ); ?></option>
-						<?php foreach ( $all_themes as $theme_name ) : ?>
-							<option value="<?php echo esc_attr( $theme_name ); ?>"
-								<?php selected( $theme_name, $selected_theme ); ?>>
-									<?php echo esc_html( $theme_name ); ?>
+						<?php foreach ( $all_themes as $apple_theme_name ) : ?>
+							<option value="<?php echo esc_attr( $apple_theme_name ); ?>"
+								<?php selected( $apple_theme_name, $selected_theme ); ?>>
+									<?php echo esc_html( $apple_theme_name ); ?>
 							</option>
 						<?php endforeach; ?>
 					</select>
@@ -82,10 +82,10 @@
 						<?php esc_html_e( 'Component', 'apple-news' ); ?>:
 						<select id="apple_news_component" name="apple_news_component">
 							<option value=""><?php esc_html_e( 'Select a component', 'apple-news' ); ?></option>
-							<?php foreach ( $components as $component_key => $component_name ) : ?>
-								<option value="<?php echo esc_attr( $component_key ); ?>"
-									<?php selected( $component_key, $selected_component ); ?>>
-										<?php echo esc_html( $component_name ); ?>
+							<?php foreach ( $components as $apple_component_key => $apple_component_name ) : ?>
+								<option value="<?php echo esc_attr( $apple_component_key ); ?>"
+									<?php selected( $apple_component_key, $selected_component ); ?>>
+										<?php echo esc_html( $apple_component_name ); ?>
 								</option>
 							<?php endforeach; ?>
 						</select>
@@ -93,36 +93,36 @@
 				</div>
 			<?php endif; ?>
 
-			<?php if ( ! empty( $specs ) ) : ?>
+			<?php if ( ! empty( $apple_specs ) ) : ?>
 				<?php
-				foreach ( $specs as $spec ) :
-					$field_name   = 'apple_news_json_' . $spec->key_from_name( $spec->name );
-					$json_display = $spec->format_json( $spec->get_spec( $selected_theme ) );
-					$rows         = substr_count( $json_display, "\n" ) + 1;
-					$editor_name  = 'editor_' . str_replace( '-', '_', $field_name );
-					$editor_style = sprintf(
+				foreach ( $apple_specs as $apple_spec ) :
+					$apple_field_name   = 'apple_news_json_' . $apple_spec->key_from_name( $apple_spec->name );
+					$apple_json_display = $apple_spec->format_json( $apple_spec->get_spec( $selected_theme ) );
+					$apple_rows         = substr_count( $apple_json_display, "\n" ) + 1;
+					$apple_editor_name  = 'editor_' . str_replace( '-', '_', $apple_field_name );
+					$apple_editor_style = sprintf(
 						'width: %spx; height: %spx',
 						500,
-						absint( 17 * $rows )
+						absint( 17 * $apple_rows )
 					);
 					?>
 					<p>
-						<label for="<?php echo esc_attr( $field_name ); ?>"><?php echo esc_html( $spec->label ); ?></label>
-						<div id="<?php echo esc_attr( $editor_name ); ?>" style="<?php echo esc_attr( $editor_style ); ?>"></div>
-						<textarea id="<?php echo esc_attr( $field_name ); ?>" name="<?php echo esc_attr( $field_name ); ?>"><?php echo esc_textarea( $json_display ); ?></textarea>
+						<label for="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_html( $apple_spec->label ); ?></label>
+						<div id="<?php echo esc_attr( $apple_editor_name ); ?>" style="<?php echo esc_attr( $apple_editor_style ); ?>"></div>
+						<textarea id="<?php echo esc_attr( $apple_field_name ); ?>" name="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_textarea( $apple_json_display ); ?></textarea>
 						<script type="text/javascript">
-							var <?php echo esc_js( $editor_name ); ?> = ace.edit( '<?php echo esc_js( $editor_name ); ?>' );
+							var <?php echo esc_js( $apple_editor_name ); ?> = ace.edit( '<?php echo esc_js( $apple_editor_name ); ?>' );
 							jQuery( function() {
-								jQuery( '#<?php echo esc_js( $field_name ); ?>' ).hide();
-								<?php echo esc_js( $editor_name ); ?>.setTheme( '<?php echo esc_js( apply_filters( 'apple_news_json_editor_ace_theme', 'ace/theme/textmate', $selected_component, $field_name ) ); ?>' );
-								<?php echo esc_js( $editor_name ); ?>.getSession().setMode( 'ace/mode/json' );
-								<?php echo esc_js( $editor_name ); ?>.getSession().setTabSize( 2 );
-								<?php echo esc_js( $editor_name ); ?>.getSession().setUseSoftTabs( false );
-								<?php echo esc_js( $editor_name ); ?>.setReadOnly( false );
-								<?php echo esc_js( $editor_name ); ?>.getSession().setUseWrapMode( true );
-								<?php echo esc_js( $editor_name ); ?>.getSession().setValue( jQuery( '#<?php echo esc_js( $field_name ); ?>' ).val() );
-								<?php echo esc_js( $editor_name ); ?>.getSession().on( 'change', function() {
-									jQuery( '#<?php echo esc_js( $field_name ); ?>' ).val( <?php echo esc_js( $editor_name ); ?>.getSession().getValue() );
+								jQuery( '#<?php echo esc_js( $apple_field_name ); ?>' ).hide();
+								<?php echo esc_js( $apple_editor_name ); ?>.setTheme( '<?php echo esc_js( apply_filters( 'apple_news_json_editor_ace_theme', 'ace/theme/textmate', $selected_component, $apple_field_name ) ); ?>' );
+								<?php echo esc_js( $apple_editor_name ); ?>.getSession().setMode( 'ace/mode/json' );
+								<?php echo esc_js( $apple_editor_name ); ?>.getSession().setTabSize( 2 );
+								<?php echo esc_js( $apple_editor_name ); ?>.getSession().setUseSoftTabs( false );
+								<?php echo esc_js( $apple_editor_name ); ?>.setReadOnly( false );
+								<?php echo esc_js( $apple_editor_name ); ?>.getSession().setUseWrapMode( true );
+								<?php echo esc_js( $apple_editor_name ); ?>.getSession().setValue( jQuery( '#<?php echo esc_js( $apple_field_name ); ?>' ).val() );
+								<?php echo esc_js( $apple_editor_name ); ?>.getSession().on( 'change', function() {
+									jQuery( '#<?php echo esc_js( $apple_field_name ); ?>' ).val( <?php echo esc_js( $apple_editor_name ); ?>.getSession().getValue() );
 								} );
 							} );
 						</script>

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -93,9 +93,9 @@
 				</div>
 			<?php endif; ?>
 
-			<?php if ( ! empty( $apple_specs ) ) : ?>
+			<?php if ( ! empty( $specs ) ) : ?>
 				<?php
-				foreach ( $apple_specs as $apple_spec ) :
+				foreach ( $specs as $apple_spec ) :
 					$apple_field_name   = 'apple_news_json_' . $apple_spec->key_from_name( $apple_spec->name );
 					$apple_json_display = $apple_spec->format_json( $apple_spec->get_spec( $selected_theme ) );
 					$apple_rows         = substr_count( $apple_json_display, "\n" ) + 1;

--- a/admin/partials/page-options-section-hidden.php
+++ b/admin/partials/page-options-section-hidden.php
@@ -5,21 +5,21 @@
  * @package Apple_News
  */
 
-foreach ( $section->groups() as $group ) {
-	do_action( 'apple_news_before_setting_group', $group, true );
-	foreach ( $group['settings'] as $setting_name => $setting_meta ) {
-		do_action( 'apple_news_before_setting', $setting_name, $setting_meta );
+foreach ( $section->groups() as $apple_group ) {
+	do_action( 'apple_news_before_setting_group', $apple_group, true );
+	foreach ( $apple_group['settings'] as $apple_setting_name => $apple_setting_meta ) {
+		do_action( 'apple_news_before_setting', $apple_setting_name, $apple_setting_meta );
 		echo wp_kses(
 			$section->render_field(
 				array(
-					$setting_name,
-					$setting_meta['default'],
-					$setting_meta['callback'],
+					$apple_setting_name,
+					$apple_setting_meta['default'],
+					$apple_setting_meta['callback'],
 				)
 			),
 			Admin_Apple_Settings_Section::$allowed_html
 		);
-		do_action( 'apple_news_after_setting', $setting_name, $setting_meta );
+		do_action( 'apple_news_after_setting', $apple_setting_name, $apple_setting_meta );
 	}
-	do_action( 'apple_news_after_setting_group', $group, true );
+	do_action( 'apple_news_after_setting_group', $apple_group, true );
 }

--- a/admin/partials/page-options-section.php
+++ b/admin/partials/page-options-section.php
@@ -9,41 +9,41 @@
 <h3><?php echo esc_html( $section->name() ); ?></h3>
 <?php echo wp_kses_post( $section->get_section_info() ); ?>
 <table class="form-table apple-news">
-	<?php foreach ( $section->groups() as $group ) : ?>
-		<?php do_action( 'apple_news_before_setting_group', $group, false ); ?>
+	<?php foreach ( $section->groups() as $apple_group ) : ?>
+		<?php do_action( 'apple_news_before_setting_group', $apple_group, false ); ?>
 	<tr>
-		<th scope="row"><?php echo esc_html( $group['label'] ); ?></th>
+		<th scope="row"><?php echo esc_html( $apple_group['label'] ); ?></th>
 		<td>
 			<fieldset>
-				<?php foreach ( $group['settings'] as $setting_name => $setting_meta ) : ?>
-					<?php do_action( 'apple_news_before_setting', $setting_name, $setting_meta ); ?>
+				<?php foreach ( $apple_group['settings'] as $apple_setting_name => $apple_setting_meta ) : ?>
+					<?php do_action( 'apple_news_before_setting', $apple_setting_name, $apple_setting_meta ); ?>
 				<label class="setting-container">
-					<?php if ( ! empty( $setting_meta['label'] ) ) : ?>
-						<span class="label-name"><?php echo esc_html( $setting_meta['label'] ); ?></span>
+					<?php if ( ! empty( $apple_setting_meta['label'] ) ) : ?>
+						<span class="label-name"><?php echo esc_html( $apple_setting_meta['label'] ); ?></span>
 					<?php endif; ?>
 					<?php
 						echo wp_kses(
 							$section->render_field(
 								array(
-									$setting_name,
-									$setting_meta['default'],
-									$setting_meta['callback'],
+									$apple_setting_name,
+									$apple_setting_meta['default'],
+									$apple_setting_meta['callback'],
 								)
 							),
 							Admin_Apple_Settings_Section::$allowed_html
 						);
 					?>
 				</label>
-					<?php do_action( 'apple_news_after_setting', $setting_name, $setting_meta ); ?>
+					<?php do_action( 'apple_news_after_setting', $apple_setting_name, $apple_setting_meta ); ?>
 				<br />
 				<?php endforeach; ?>
 
-				<?php if ( $group['description'] ) : ?>
-					<p class="description"><?php echo '(' . wp_kses_post( $group['description'] ) . ')'; ?></p>
+				<?php if ( $apple_group['description'] ) : ?>
+					<p class="description"><?php echo '(' . wp_kses_post( $apple_group['description'] ) . ')'; ?></p>
 				<?php endif; ?>
 			</fieldset>
 		</td>
 	</tr>
-		<?php do_action( 'apple_news_after_setting_group', $group, false ); ?>
+		<?php do_action( 'apple_news_after_setting_group', $apple_group, false ); ?>
 	<?php endforeach; ?>
 </table>

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -11,15 +11,15 @@
 	<form method="post" action="" id="apple-news-settings-form">
 		<?php wp_nonce_field( 'apple_news_options' ); ?>
 		<input type="hidden" name="action" value="apple_news_options" />
-		<?php foreach ( $sections as $section ) : ?>
-			<?php $section->before_section(); ?>
+		<?php foreach ( $sections as $apple_section ) : ?>
+			<?php $apple_section->before_section(); ?>
 			<?php
-			if ( $section->is_hidden() ) {
+			if ( $apple_section->is_hidden() ) {
 				include plugin_dir_path( __FILE__ ) . 'page-options-section-hidden.php';
 			} else {
 				include plugin_dir_path( __FILE__ ) . 'page-options-section.php';
 			}
-				$section->after_section();
+				$apple_section->after_section();
 			?>
 		<?php endforeach; ?>
 

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -26,7 +26,7 @@
 		sprintf(
 			// translators: first argument is an opening <a> tag, second argument is </a>.
 			__( 'You can also map a theme to automatically be used for posts with a specific Apple News section, if you want to use something other than the %1$sactive theme%2$s. This will only work for posts with precisely one Apple News section to avoid conflicts.', 'apple-news' ),
-			'<a href="' . esc_url( $apple_theme_admin_url ) . '">',
+			'<a href="' . esc_url( $theme_admin_url ) . '">',
 			'</a>'
 		)
 	);

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -26,7 +26,7 @@
 		sprintf(
 			// translators: first argument is an opening <a> tag, second argument is </a>.
 			__( 'You can also map a theme to automatically be used for posts with a specific Apple News section, if you want to use something other than the %1$sactive theme%2$s. This will only work for posts with precisely one Apple News section to avoid conflicts.', 'apple-news' ),
-			'<a href="' . esc_url( $theme_admin_url ) . '">',
+			'<a href="' . esc_url( $apple_theme_admin_url ) . '">',
 			'</a>'
 		)
 	);
@@ -49,36 +49,36 @@
 			</tr>
 			</thead>
 			<tbody id="apple-news-sections-list">
-			<?php $count = 0; ?>
-			<?php foreach ( $sections as $section_id => $section_name ) : ?>
-				<tr id="apple-news-section-<?php echo esc_attr( $section_id ); ?>">
-					<td><?php echo esc_html( $section_name ); ?></td>
+			<?php $apple_count = 0; ?>
+			<?php foreach ( $sections as $apple_section_id => $apple_section_name ) : ?>
+				<tr id="apple-news-section-<?php echo esc_attr( $apple_section_id ); ?>">
+					<td><?php echo esc_html( $apple_section_name ); ?></td>
 					<td>
 						<ul class="apple-news-section-taxonomy-mapping-list">
-						<?php if ( ! empty( $taxonomy_mappings[ $section_id ] ) ) : ?>
-							<?php foreach ( $taxonomy_mappings[ $section_id ] as $term ) : ?>
-								<?php $taxonomy_id = 'apple-news-section-mapping-' . ( ++ $count ); ?>
+						<?php if ( ! empty( $taxonomy_mappings[ $apple_section_id ] ) ) : ?>
+							<?php foreach ( $taxonomy_mappings[ $apple_section_id ] as $term ) : ?>
+								<?php $apple_taxonomy_id = 'apple-news-section-mapping-' . ( ++ $apple_count ); ?>
 								<li>
-									<label for="<?php echo esc_attr( $taxonomy_id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
-									<input name="taxonomy-mapping-<?php echo esc_attr( $section_id ); ?>[]" id="<?php echo esc_attr( $taxonomy_id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
+									<label for="<?php echo esc_attr( $apple_taxonomy_id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
+									<input name="taxonomy-mapping-<?php echo esc_attr( $apple_section_id ); ?>[]" id="<?php echo esc_attr( $apple_taxonomy_id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
 									<button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
 								</li>
 							<?php endforeach; ?>
 						<?php endif; ?>
 						</ul>
-						<button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $section_id ); ?>"><?php esc_html_e( 'Add', 'apple-news' ); ?> <?php echo esc_html( $taxonomy->labels->singular_name ); ?></button>
+						<button type="button" class="apple-news-add-section-taxonomy-mapping" data-section-id="<?php echo esc_attr( $apple_section_id ); ?>"><?php esc_html_e( 'Add', 'apple-news' ); ?> <?php echo esc_html( $taxonomy->labels->singular_name ); ?></button>
 					</td>
 					<td>
 						<?php
-							$theme_id       = 'apple-news-theme-mapping-' . ( ++ $count );
-							$selected_theme = ( isset( $theme_mappings[ $section_id ] ) ) ? $theme_mappings[ $section_id ] : '';
+							$apple_theme_id       = 'apple-news-theme-mapping-' . ( ++ $apple_count );
+							$apple_selected_theme = ( isset( $apple_theme_mappings[ $apple_section_id ] ) ) ? $apple_theme_mappings[ $apple_section_id ] : '';
 						?>
-						<select name="theme-mapping-<?php echo esc_attr( $section_id ); ?>" id="<?php echo esc_attr( $theme_id ); ?>">
+						<select name="theme-mapping-<?php echo esc_attr( $apple_section_id ); ?>" id="<?php echo esc_attr( $apple_theme_id ); ?>">
 							<option value=""></option>
 							<?php
-							foreach ( $themes as $theme ) :
+							foreach ( $themes as $apple_theme ) :
 								?>
-								<option value="<?php echo esc_attr( $theme ); ?>" <?php selected( $theme, $selected_theme ); ?>><?php echo esc_html( $theme ); ?></option>
+								<option value="<?php echo esc_attr( $apple_theme ); ?>" <?php selected( $apple_theme, $apple_selected_theme ); ?>><?php echo esc_html( $apple_theme ); ?></option>
 									<?php
 								endforeach;
 							?>

--- a/admin/partials/page-single-push.php
+++ b/admin/partials/page-single-push.php
@@ -73,8 +73,8 @@
 				<td>
 					<select id="apple-news-maturity-rating" name="apple_news_maturity_rating">
 						<option value=""></option>
-						<?php foreach ( \Apple_News::$maturity_ratings as $rating ) : ?>
-							<option value="<?php echo esc_attr( $rating ); ?>" <?php selected( isset( $post_meta['apple_news_maturity_rating'][0] ) ? $post_meta['apple_news_maturity_rating'][0] : '', $rating ); ?>><?php echo esc_html( ucwords( strtolower( $rating ) ) ); ?></option>
+						<?php foreach ( \Apple_News::$maturity_ratings as $apple_rating ) : ?>
+							<option value="<?php echo esc_attr( $apple_rating ); ?>" <?php selected( isset( $post_meta['apple_news_maturity_rating'][0] ) ? $post_meta['apple_news_maturity_rating'][0] : '', $apple_rating ); ?>><?php echo esc_html( ucwords( strtolower( $apple_rating ) ) ); ?></option>
 						<?php endforeach; ?>
 					</select>
 					<p class="description"><?php esc_html_e( 'Select the optional maturity rating for this post.', 'apple-news' ); ?></p>
@@ -90,11 +90,11 @@
 			<tr>
 				<th scope="row"><?php esc_html_e( 'Pull quote position', 'apple-news' ); ?></th>
 				<td>
-					<?php $pullquote_position = ! empty( $post_meta['apple_news_pullquote_position'][0] ) ? $post_meta['apple_news_pullquote_position'][0] : 'middle'; ?>
+					<?php $apple_pullquote_position = ! empty( $post_meta['apple_news_pullquote_position'][0] ) ? $post_meta['apple_news_pullquote_position'][0] : 'middle'; ?>
 					<select name="apple_news_pullquote_position">
-						<option <?php selected( $pullquote_position, 'top' ); ?> value="top"><?php esc_html_e( 'top', 'apple-news' ); ?></option>
-						<option <?php selected( $pullquote_position, 'middle' ); ?> value="middle"><?php esc_html_e( 'middle', 'apple-news' ); ?></option>
-						<option <?php selected( $pullquote_position, 'bottom' ); ?> value="bottom"><?php esc_html_e( 'bottom', 'apple-news' ); ?></option>
+						<option <?php selected( $apple_pullquote_position, 'top' ); ?> value="top"><?php esc_html_e( 'top', 'apple-news' ); ?></option>
+						<option <?php selected( $apple_pullquote_position, 'middle' ); ?> value="middle"><?php esc_html_e( 'middle', 'apple-news' ); ?></option>
+						<option <?php selected( $apple_pullquote_position, 'bottom' ); ?> value="bottom"><?php esc_html_e( 'bottom', 'apple-news' ); ?></option>
 					</select>
 					<p class="description"><?php esc_html_e( 'The position in the article where the pull quote will appear.', 'apple-news' ); ?></p>
 				</td>

--- a/admin/partials/page-theme-edit.php
+++ b/admin/partials/page-theme-edit.php
@@ -32,36 +32,36 @@
 					?>
 				</p>
 				<table class="form-table apple-news">
-					<?php foreach ( $theme->get_groups() as $group ) : ?>
-						<?php do_action( 'apple_news_before_setting_group', $group, false ); ?>
+					<?php foreach ( $theme->get_groups() as $apple_group ) : ?>
+						<?php do_action( 'apple_news_before_setting_group', $apple_group, false ); ?>
 						<tr>
-							<th scope="row"><?php echo esc_html( $group['label'] ); ?></th>
+							<th scope="row"><?php echo esc_html( $apple_group['label'] ); ?></th>
 							<td>
 								<fieldset>
-									<?php foreach ( $group['settings'] as $setting_name ) : ?>
-										<?php do_action( 'apple_news_before_setting', $setting_name, $theme_options[ $setting_name ] ); ?>
+									<?php foreach ( $apple_group['settings'] as $apple_setting_name ) : ?>
+										<?php do_action( 'apple_news_before_setting', $apple_setting_name, $theme_options[ $apple_setting_name ] ); ?>
 										<label class="setting-container">
-											<?php if ( ! empty( $theme_options[ $setting_name ]['label'] ) ) : ?>
-												<span class="label-name"><?php echo esc_html( $theme_options[ $setting_name ]['label'] ); ?></span>
+											<?php if ( ! empty( $theme_options[ $apple_setting_name ]['label'] ) ) : ?>
+												<span class="label-name"><?php echo esc_html( $theme_options[ $apple_setting_name ]['label'] ); ?></span>
 											<?php endif; ?>
 											<?php
 											echo wp_kses(
-												Admin_Apple_Themes::render_field( $theme, $setting_name ),
+												Admin_Apple_Themes::render_field( $theme, $apple_setting_name ),
 												Admin_Apple_Settings_Section::$allowed_html
 											);
 											?>
 										</label>
-										<?php do_action( 'apple_news_after_setting', $setting_name, $theme_options[ $setting_name ] ); ?>
+										<?php do_action( 'apple_news_after_setting', $apple_setting_name, $theme_options[ $apple_setting_name ] ); ?>
 										<br />
 									<?php endforeach; ?>
 
-									<?php if ( ! empty( $group['description'] ) ) : ?>
-										<p class="description"><?php echo '(' . wp_kses_post( $group['description'] ) . ')'; ?></p>
+									<?php if ( ! empty( $apple_group['description'] ) ) : ?>
+										<p class="description"><?php echo '(' . wp_kses_post( $apple_group['description'] ) . ')'; ?></p>
 									<?php endif; ?>
 								</fieldset>
 							</td>
 						</tr>
-						<?php do_action( 'apple_news_after_setting_group', $group, false ); ?>
+						<?php do_action( 'apple_news_after_setting_group', $apple_group, false ); ?>
 					<?php endforeach; ?>
 				</table>
 			</div>

--- a/admin/partials/page-themes.php
+++ b/admin/partials/page-themes.php
@@ -5,7 +5,7 @@
  * @package Apple_News
  */
 
-$themes = new \Admin_Apple_Themes(); ?>
+$apple_themes = new \Admin_Apple_Themes(); ?>
 <div class="wrap apple-news-themes">
 	<h1 id="apple_news_themes_title"><?php esc_html_e( 'Manage Themes', 'apple-news' ); ?></h1>
 
@@ -16,7 +16,7 @@ $themes = new \Admin_Apple_Themes(); ?>
 		<input type="hidden" id="apple_news_action" name="action" value="apple_news_set_theme" />
 		<input type="hidden" id="apple_news_theme" name="apple_news_theme" value="" />
 
-		<a class="button" href="<?php echo esc_url( $themes->theme_edit_url() ); ?>"><?php esc_html_e( 'Create New Theme', 'apple-news' ); ?></a>
+		<a class="button" href="<?php echo esc_url( $apple_themes->theme_edit_url() ); ?>"><?php esc_html_e( 'Create New Theme', 'apple-news' ); ?></a>
 		<?php
 		submit_button(
 			__( 'Import Theme', 'apple-news' ),
@@ -64,50 +64,50 @@ $themes = new \Admin_Apple_Themes(); ?>
 		<div class="theme-browser">
 			<div class="themes wp-clearfix">
 				<?php
-				$all_themes   = \Apple_Exporter\Theme::get_registry();
-				$active_theme = \Apple_Exporter\Theme::get_active_theme_name();
-				if ( empty( $all_themes ) ) :
+				$apple_all_themes   = \Apple_Exporter\Theme::get_registry();
+				$apple_active_theme = \Apple_Exporter\Theme::get_active_theme_name();
+				if ( empty( $apple_all_themes ) ) :
 					?>
 					<h2><?php esc_html_e( 'No themes were found', 'apple-news' ); ?></h2>
 				<?php else : ?>
-					<?php foreach ( $all_themes as $theme ) : ?>
+					<?php foreach ( $apple_all_themes as $apple_theme ) : ?>
 						<?php
-						$active       = ( $theme === $active_theme ) ? 'active' : '';
-						$aria_name    = 'apple-news-theme-' . $theme . '-name';
-						$theme_object = new \Apple_Exporter\Theme();
-						$theme_object->set_name( $theme );
-						$theme_object->load();
-						$theme_screenshot = $theme_object->get_value( 'screenshot_url' );
+						$apple_active       = ( $apple_theme === $apple_active_theme ) ? 'active' : '';
+						$apple_aria_name    = 'apple-news-theme-' . $apple_theme . '-name';
+						$apple_theme_object = new \Apple_Exporter\Theme();
+						$apple_theme_object->set_name( $apple_theme );
+						$apple_theme_object->load();
+						$apple_theme_screenshot = $apple_theme_object->get_value( 'screenshot_url' );
 						?>
-						<div class="theme <?php echo sanitize_html_class( $active ); ?>" tabindex="0" aria-describedby="<?php echo esc_attr( $aria_name ); ?>">
-							<?php if ( ! empty( $theme_screenshot ) ) : ?>
+						<div class="theme <?php echo sanitize_html_class( $apple_active ); ?>" tabindex="0" aria-describedby="<?php echo esc_attr( $apple_aria_name ); ?>">
+							<?php if ( ! empty( $apple_theme_screenshot ) ) : ?>
 								<div class="theme-screenshot">
-									<img src="<?php echo esc_url( $theme_screenshot ); ?>" alt="" />
+									<img src="<?php echo esc_url( $apple_theme_screenshot ); ?>" alt="" />
 								</div>
 							<?php else : ?>
 								<div class="theme-screenshot blank"></div>
 							<?php endif; ?>
 
-							<?php if ( ! empty( $active ) ) : ?>
-								<h2 class="theme-name" id="<?php echo esc_attr( $aria_name ); ?>">
+							<?php if ( ! empty( $apple_active ) ) : ?>
+								<h2 class="theme-name" id="<?php echo esc_attr( $apple_aria_name ); ?>">
 									<span><?php esc_html_e( 'Active', 'apple-news' ); ?>:</span>
-									<?php echo esc_html( $theme ); ?>
+									<?php echo esc_html( $apple_theme ); ?>
 								</h2>
 							<?php else : ?>
-								<h2 class="theme-name" id="<?php echo esc_attr( $aria_name ); ?>">
-									<?php echo esc_html( $theme ); ?>
+								<h2 class="theme-name" id="<?php echo esc_attr( $apple_aria_name ); ?>">
+									<?php echo esc_html( $apple_theme ); ?>
 								</h2>
 							<?php endif; ?>
 
 							<div class="theme-actions">
-								<input type="radio" name="apple_news_active_theme" value="<?php echo esc_attr( $theme ); ?>" <?php checked( $theme, $active_theme ); ?> />
-								<?php if ( $theme !== $active_theme ) : ?>
+								<input type="radio" name="apple_news_active_theme" value="<?php echo esc_attr( $apple_theme ); ?>" <?php checked( $apple_theme, $apple_active_theme ); ?> />
+								<?php if ( $apple_theme !== $apple_active_theme ) : ?>
 									<a class="button button-primary apple-news-activate-theme" href="#"><?php esc_html_e( 'Activate', 'apple-news' ); ?></a>
 								<?php endif; ?>
-								<a class="button" href="<?php echo esc_url( $themes->theme_edit_url( $theme ) ); ?>" data-theme="<?php echo esc_attr( $theme ); ?>"><?php esc_html_e( 'Edit', 'apple-news' ); ?></a>
-								<a class="button apple-news-export-theme" href="#" data-theme="<?php echo esc_attr( $theme ); ?>"><?php esc_html_e( 'Export', 'apple-news' ); ?></a>
-								<?php if ( $theme !== $active_theme ) : ?>
-									<a class="button button-danger apple-news-delete-theme" href="#" data-theme="<?php echo esc_attr( $theme ); ?>"><?php esc_html_e( 'Delete', 'apple-news' ); ?></a>
+								<a class="button" href="<?php echo esc_url( $apple_themes->theme_edit_url( $apple_theme ) ); ?>" data-theme="<?php echo esc_attr( $apple_theme ); ?>"><?php esc_html_e( 'Edit', 'apple-news' ); ?></a>
+								<a class="button apple-news-export-theme" href="#" data-theme="<?php echo esc_attr( $apple_theme ); ?>"><?php esc_html_e( 'Export', 'apple-news' ); ?></a>
+								<?php if ( $apple_theme !== $apple_active_theme ) : ?>
+									<a class="button button-danger apple-news-delete-theme" href="#" data-theme="<?php echo esc_attr( $apple_theme ); ?>"><?php esc_html_e( 'Delete', 'apple-news' ); ?></a>
 								<?php endif; ?>
 							</div>
 						</div>

--- a/includes/apple-exporter/components/class-body.php
+++ b/includes/apple-exporter/components/class-body.php
@@ -257,7 +257,7 @@ class Body extends Component {
 	 * @access protected
 	 * @return bool Whether HTML format is enabled for this component type.
 	 */
-	protected function html_enabled( $enabled = true ) {
+	protected function html_enabled( $enabled = true ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		return parent::html_enabled( $enabled );
 	}
 

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -106,7 +106,7 @@ class Heading extends Component {
 	 * @access protected
 	 * @return bool Whether HTML format is enabled for this component type.
 	 */
-	protected function html_enabled( $enabled = true ) {
+	protected function html_enabled( $enabled = true ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		return parent::html_enabled( $enabled );
 	}
 

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -260,7 +260,7 @@ class Quote extends Component {
 	 * @access protected
 	 * @return bool Whether HTML format is enabled for this component type.
 	 */
-	protected function html_enabled( $enabled = true ) {
+	protected function html_enabled( $enabled = true ) {  // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		return parent::html_enabled( $enabled );
 	}
 

--- a/includes/apple-exporter/components/class-table.php
+++ b/includes/apple-exporter/components/class-table.php
@@ -226,7 +226,7 @@ class Table extends Component {
 	 * @access protected
 	 * @return bool Whether HTML format is enabled for this component type.
 	 */
-	protected function html_enabled( $enabled = true ) {
+	protected function html_enabled( $enabled = true ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		return parent::html_enabled( $enabled );
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -83,14 +83,13 @@
     </properties>
   </rule>
 
-  <!-- Turn off a few newly added or renamed rules until we put fixes in place. -->
-	<!-- We will target version 2.1.0 for these fixes. -->
+  <!-- Allow short array syntax. -->
   <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
     <severity>0</severity>
   </rule>
-	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
-		<severity>0</severity>
-	</rule>
+
+  <!-- Turn off a few newly added or renamed rules until we put fixes in place. -->
+	<!-- We will target version 2.1.0 for these fixes. -->
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,9 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound">
-		<severity>0</severity>
-	</rule>
   <rule ref="WordPress.PHP.DisallowShortTernary.Found">
     <severity>0</severity>
   </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,9 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPress.DB.SlowDBQuery.slow_db_query_meta_query">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,9 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound">
 		<severity>0</severity>
 	</rule>


### PR DESCRIPTION
Begins to dig into the backlog of ignored phpcs sniffs and address them.

* Allows short array syntax.
* Re-enables sniff for `Generic.CodeAnalysis.UselessOverridingMethod.Found` and allows specific usages.
* Re-enables sniff for `WordPress.DB.SlowDBQuery.slow_db_query_meta_query` and allows specific usages.
* Re-enables sniff for `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound` and allows specific usages.
* Re-enables sniff for `WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound` and fixes found issues.