### PR TITLE
APPLE-13 Fix for repeated intro issue

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -115,6 +115,21 @@ class Export extends Action {
 		// Get the content.
 		$content = $this->get_content( $post );
 
+		/*
+		 * If the excerpt looks too similar to the content, remove it.
+		 * We do this before the filter, to allow overrides for the final value.
+		 * This essentially prevents the case where someone intentionally copies
+		 * the first paragraph of content into the `post_excerpt` field and
+		 * unintentionally introduces a duplicate content issue.
+		 */
+		if ( ! empty( $excerpt ) ) {
+			$content_normalized = strtolower( str_replace( ' ', '', wp_strip_all_tags( $content ) ) );
+			$excerpt_normalized = strtolower( str_replace( ' ', '', wp_strip_all_tags( $excerpt ) ) );
+			if ( false !== strpos( $content_normalized, $excerpt_normalized ) ) {
+				$excerpt = '';
+			}
+		}
+
 		// Filter each of our items before passing into the exporter class.
 		$title      = apply_filters( 'apple_news_exporter_title', $post->post_title, $post->ID );
 		$excerpt    = apply_filters( 'apple_news_exporter_excerpt', $excerpt, $post->ID );

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 = 2.1.0 =
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 * Bugfix: If the same image is used for the featured image and the first image embedded into the post, it no longer shows up twice.
+* Bugfix: If a custom excerpt is used, but the custom excerpt repeats text in its entirety from elsewhere in the article (e.g., the first paragraph), then the Intro component will be skipped. This prevents an issue where Apple will flag articles that contain repeated text due to the Intro component using a custom excerpt suitable in a WordPress context but not an Apple News context.
 
 = 2.0.8 =
 * Enhancement: Adds styles for Button elements that are links which are added by the Gutenberg editor.

--- a/tests/apple-exporter/components/test-class-intro.php
+++ b/tests/apple-exporter/components/test-class-intro.php
@@ -72,7 +72,7 @@ class Intro_Test extends Component_TestCase {
 		$settings_object                  = new Settings();
 		$theme                            = \Apple_Exporter\Theme::get_used();
 		$settings                         = $theme->all_settings();
-		$settings['meta_component_order'] = ['cover', 'title', 'byline', 'intro'];
+		$settings['meta_component_order'] = [ 'cover', 'title', 'byline', 'intro' ];
 		$theme->load( $settings );
 		$this->assertTrue( $theme->save() );
 

--- a/tests/apple-exporter/components/test-class-intro.php
+++ b/tests/apple-exporter/components/test-class-intro.php
@@ -81,7 +81,7 @@ class Intro_Test extends Component_TestCase {
 			[
 				'post_content' => '<p>Lorem ipsum dolor sit amet.</p>',
 				'post_excerpt' => '',
-			],
+			]
 		);
 
 		// Run the exporter against the sample post and verify that the Intro component is not used, since there is no custom excerpt.
@@ -95,7 +95,7 @@ class Intro_Test extends Component_TestCase {
 			[
 				'post_content' => '<p>Lorem ipsum dolor sit amet.</p>',
 				'post_excerpt' => 'Sample excerpt',
-			],
+			]
 		);
 
 		// Run the exporter against the sample post and verify that the Intro component is used, and matches the custom excerpt.
@@ -109,7 +109,7 @@ class Intro_Test extends Component_TestCase {
 			[
 				'post_content' => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis arcu risus, vestibulum non nulla a, mollis posuere lectus. Quisque lectus ex, viverra nec massa et, elementum sodales dui. Nam nec congue libero. Nunc eu lectus quis quam eleifend gravida. Nulla condimentum, nisl ornare rhoncus ultrices, ex ipsum luctus dolor, vitae iaculis metus magna vitae neque. Maecenas in risus id est hendrerit mattis. Curabitur pulvinar ante a ligula tincidunt, id porta ante ornare. Donec neque metus, hendrerit nec lectus in, consectetur porta dolor. Curabitur egestas orci eu tortor congue, eu varius ipsum finibus. In in faucibus mi. Donec odio leo, blandit non varius nec, cursus ac eros. Aenean sagittis mauris eget interdum elementum. Etiam hendrerit lectus at lacus pretium pretium. Vivamus eu egestas dolor. Nam a ultricies lectus.</p>',
 				'post_excerpt' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis arcu risus, vestibulum non nulla a, mollis posuere lectus.',
-			],
+			]
 		);
 
 		// Run the exporter against the sample post and verify that the Intro component is not used because it duplicates content from the main body.

--- a/tests/apple-exporter/components/test-class-intro.php
+++ b/tests/apple-exporter/components/test-class-intro.php
@@ -1,14 +1,34 @@
 <?php
+/**
+ * Apple News Tests: Intro_Test class
+ *
+ * @package Apple_News
+ */
 
 require_once __DIR__ . '/class-component-testcase.php';
 
-use Apple_Exporter\Components\Intro as Intro;
+use Apple_Exporter\Components\Intro;
+use Apple_Actions\Index\Export;
+use Apple_Exporter\Settings;
 
+/**
+ * A class to test the functionality of the Intro component.
+ *
+ * @package Apple_News
+ */
 class Intro_Test extends Component_TestCase {
 
-	public function testBuildingRemovesTags() {
-		$component = new Intro( 'Test intro text.', null, $this->settings,
-			$this->styles, $this->layouts );
+	/**
+	 * Tests the build of an Intro component.
+	 */
+	public function testBuild() {
+		$component = new Intro(
+			'Test intro text.',
+			null,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		$this->assertEquals(
 			array(
@@ -20,6 +40,9 @@ class Intro_Test extends Component_TestCase {
 		);
 	}
 
+	/**
+	 * Tests the filter for intro content.
+	 */
 	public function testFilter() {
 		$component = new Intro( 'Test intro text.', null, $this->settings,
 			$this->styles, $this->layouts );
@@ -39,5 +62,60 @@ class Intro_Test extends Component_TestCase {
 		);
 	}
 
-}
+	/**
+	 * Ensures that the Intro component is skipped if there is no intro
+	 * specified. Intros can be specified either via customizing the
+	 * excerpt for a post.
+	 */
+	public function testSkip() {
+		// Set up the theme to have a specific component order that includes the intro.
+		$settings_object                  = new Settings();
+		$theme                            = \Apple_Exporter\Theme::get_used();
+		$settings                         = $theme->all_settings();
+		$settings['meta_component_order'] = ['cover', 'title', 'byline', 'intro'];
+		$theme->load( $settings );
+		$this->assertTrue( $theme->save() );
 
+		// Create an example post without a customized excerpt.
+		$sample_post = self::factory()->post->create(
+			[
+				'post_content' => '<p>Lorem ipsum dolor sit amet.</p>',
+				'post_excerpt' => '',
+			],
+		);
+
+		// Run the exporter against the sample post and verify that the Intro component is not used, since there is no custom excerpt.
+		$export           = new Export( $settings_object, $sample_post );
+		$exporter         = $export->fetch_exporter();
+		$exporter_content = $exporter->get_content();
+		$this->assertEquals( '', $exporter_content->intro() );
+
+		// Create an example post with a customized excerpt.
+		$sample_post = self::factory()->post->create(
+			[
+				'post_content' => '<p>Lorem ipsum dolor sit amet.</p>',
+				'post_excerpt' => 'Sample excerpt',
+			],
+		);
+
+		// Run the exporter against the sample post and verify that the Intro component is used, and matches the custom excerpt.
+		$export           = new Export( $settings_object, $sample_post );
+		$exporter         = $export->fetch_exporter();
+		$exporter_content = $exporter->get_content();
+		$this->assertEquals( 'Sample excerpt', $exporter_content->intro() );
+
+		// Create an example post with a bit more content and a custom excerpt that matches the first part of the content.
+		$sample_post = self::factory()->post->create(
+			[
+				'post_content' => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis arcu risus, vestibulum non nulla a, mollis posuere lectus. Quisque lectus ex, viverra nec massa et, elementum sodales dui. Nam nec congue libero. Nunc eu lectus quis quam eleifend gravida. Nulla condimentum, nisl ornare rhoncus ultrices, ex ipsum luctus dolor, vitae iaculis metus magna vitae neque. Maecenas in risus id est hendrerit mattis. Curabitur pulvinar ante a ligula tincidunt, id porta ante ornare. Donec neque metus, hendrerit nec lectus in, consectetur porta dolor. Curabitur egestas orci eu tortor congue, eu varius ipsum finibus. In in faucibus mi. Donec odio leo, blandit non varius nec, cursus ac eros. Aenean sagittis mauris eget interdum elementum. Etiam hendrerit lectus at lacus pretium pretium. Vivamus eu egestas dolor. Nam a ultricies lectus.</p>',
+				'post_excerpt' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis arcu risus, vestibulum non nulla a, mollis posuere lectus.',
+			],
+		);
+
+		// Run the exporter against the sample post and verify that the Intro component is not used because it duplicates content from the main body.
+		$export           = new Export( $settings_object, $sample_post );
+		$exporter         = $export->fetch_exporter();
+		$exporter_content = $exporter->get_content();
+		$this->assertEquals( '', $exporter_content->intro() );
+	}
+}


### PR DESCRIPTION
* The Intro component is intended to work by providing a custom crafted excerpt prior to the article content. If no excerpt is set (in `post_excerpt`, verified via `has_excerpt()`) then no Intro component is created. However, it is possible to introduce duplicated content between the Intro and the Body if a user intentionally populates the `post_excerpt` field with a subset of the content in the article body, most often the first paragraph. This PR solves for a case where a user or a theme/plugin sets a custom excerpt that is a subset of the body content by unsetting the excerpt before passing it to the Intro component, with an opportunity for filtering the final value via `apple_news_exporter_excerpt`.
* Cleans up the Intro component test while we're at it.

ref:

#606 
#565 