### PR TITLE
APPLE-32 Add changelog text for theme rename bugfix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 = 2.1.0 =
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
+* Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.
 * Bugfix: If the same image is used for the featured image and the first image embedded into the post, it no longer shows up twice.
 * Bugfix: If a custom excerpt is used, but the custom excerpt repeats text in its entirety from elsewhere in the article (e.g., the first paragraph), then the Intro component will be skipped. This prevents an issue where Apple will flag articles that contain repeated text due to the Intro component using a custom excerpt suitable in a WordPress context but not an Apple News context.
 


### PR DESCRIPTION
This was fixed in a previous commit but not fully confirmed until now, so I'm just adding in the changelog text.