### PR TITLE
APPLE-9 Minor options page bugfixes

### DIFF
--- a/admin/partials/page-options-section-hidden.php
+++ b/admin/partials/page-options-section-hidden.php
@@ -5,12 +5,12 @@
  * @package Apple_News
  */
 
-foreach ( $section->groups() as $apple_group ) {
+foreach ( $apple_section->groups() as $apple_group ) {
 	do_action( 'apple_news_before_setting_group', $apple_group, true );
 	foreach ( $apple_group['settings'] as $apple_setting_name => $apple_setting_meta ) {
 		do_action( 'apple_news_before_setting', $apple_setting_name, $apple_setting_meta );
 		echo wp_kses(
-			$section->render_field(
+			$apple_section->render_field(
 				array(
 					$apple_setting_name,
 					$apple_setting_meta['default'],

--- a/admin/partials/page-options-section.php
+++ b/admin/partials/page-options-section.php
@@ -6,10 +6,10 @@
  */
 
 ?>
-<h3><?php echo esc_html( $section->name() ); ?></h3>
-<?php echo wp_kses_post( $section->get_section_info() ); ?>
+<h3><?php echo esc_html( $apple_section->name() ); ?></h3>
+<?php echo wp_kses_post( $apple_section->get_section_info() ); ?>
 <table class="form-table apple-news">
-	<?php foreach ( $section->groups() as $apple_group ) : ?>
+	<?php foreach ( $apple_section->groups() as $apple_group ) : ?>
 		<?php do_action( 'apple_news_before_setting_group', $apple_group, false ); ?>
 	<tr>
 		<th scope="row"><?php echo esc_html( $apple_group['label'] ); ?></th>
@@ -23,7 +23,7 @@
 					<?php endif; ?>
 					<?php
 						echo wp_kses(
-							$section->render_field(
+							$apple_section->render_field(
 								array(
 									$apple_setting_name,
 									$apple_setting_meta['default'],

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -261,6 +261,9 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			if ( $this->is_multiple( $name ) ) {
 				$multiple_name = '[]';
 				$multiple_attr = 'multiple="multiple"';
+				$size = min( $size, count( $type ) );
+			} else {
+				$size = 1;
 			}
 
 			// Check if we're using names as values.

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.
 * Bugfix: If the same image is used for the featured image and the first image embedded into the post, it no longer shows up twice.
 * Bugfix: If a custom excerpt is used, but the custom excerpt repeats text in its entirety from elsewhere in the article (e.g., the first paragraph), then the Intro component will be skipped. This prevents an issue where Apple will flag articles that contain repeated text due to the Intro component using a custom excerpt suitable in a WordPress context but not an Apple News context.
+* Bugfix: Select menus are no longer oversized on the settings page.
 
 = 2.0.8 =
 * Enhancement: Adds styles for Button elements that are links which are added by the Gutenberg editor.


### PR DESCRIPTION
* Fixes a bug from a previous phpcs refactor where variables inherited from global scope were not named correctly.
* Fixes a visual bug for select menus where they were larger than they needed to be for multi-selects and were displaying with a size greater than 1 for single selects.