### PR TITLE
APPLE-35 phpcs: Re-enable short ternaries check and fix errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # Travis CI (MIT License) configuration file for Publish to Apple News
 # @link https://travis-ci.org/
 
-# Bionic image has PHP versions 7.1, 7.2, 7.3 pre-installed.
-dist: bionic
+# Xenial image has PHP versions 5.6,7.1,7.2 pre-installed
+dist: xenial
 
-# Bionic does not start mysql by default.
+# Xenial does not start mysql by default
 services:
   - mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # @link https://travis-ci.org/
 
 # Xenial image has PHP versions 5.6,7.1,7.2 pre-installed
-dist: bionic
+dist: xenial
 
 # Xenial does not start mysql by default
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # Travis CI (MIT License) configuration file for Publish to Apple News
 # @link https://travis-ci.org/
 
-# Xenial image has PHP versions 5.6,7.1,7.2 pre-installed
-dist: xenial
+# Bionic image has PHP versions 7.1, 7.2, 7.3 pre-installed.
+dist: bionic
 
-# Xenial does not start mysql by default
+# Bionic does not start mysql by default.
 services:
   - mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@
 # @link https://travis-ci.org/
 
 # Xenial image has PHP versions 5.6,7.1,7.2 pre-installed
-dist: xenial
+dist: bionic
 
 # Xenial does not start mysql by default
 services:
   - mysql
-  - memcached
 
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
@@ -83,7 +82,7 @@ before_script:
   # Set up jest.
   - |
     if [[ "$WP_JS" == "1" ]] ; then
-      nvm install 8
+      nvm install 12
       npm i -g npm@6
       npm install
     fi

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -107,7 +107,10 @@ class Export extends Action {
 		$excerpt = has_excerpt( $post ) ? wp_strip_all_tags( $post->post_excerpt ) : '';
 
 		// Get the post thumbnail.
-		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) ) ?: null;
+		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) );
+		if ( empty( $post_thumb ) ) {
+			$post_thumb = null;
+		}
 
 		// Build the byline.
 		$byline = $this->format_byline( $post );

--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -130,7 +130,7 @@ class Exporter_Content {
 		$this->intro    = $intro;
 		$this->cover    = $cover;
 		$this->byline   = $byline;
-		$this->settings = $settings ?: new Exporter_Content_Settings();
+		$this->settings = ! empty( $settings ) ? $settings : new Exporter_Content_Settings();
 	}
 
 	/**

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -68,8 +68,8 @@ class Exporter {
 	 */
 	public function __construct( $content, $workspace = null, $settings = null ) {
 		$this->content   = $content;
-		$this->workspace = $workspace ?: new Workspace( $this->content_id() );
-		$this->settings  = $settings ?: new Settings();
+		$this->workspace = ! empty( $workspace ) ? $workspace : new Workspace( $this->content_id() );
+		$this->settings  = ! empty( $settings ) ? $settings : new Settings();
 		$this->builders  = array();
 	}
 
@@ -320,7 +320,8 @@ class Exporter {
 	 * @return string The title of the content being exported.
 	 */
 	private function content_title() {
-		return $this->content->title() ?: 'Untitled Article';
+		$title = $this->content->title();
+		return ! empty( $title ) ? $title : __( 'Untitled Article', 'apple-news' );
 	}
 
 	/**

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -66,7 +66,7 @@ class Request {
 	public function __construct( $credentials, $debug = false, $mime_builder = null ) {
 		$this->credentials  = $credentials;
 		$this->debug        = $debug;
-		$this->mime_builder = $mime_builder ?: new MIME_Builder();
+		$this->mime_builder = ! empty( $mime_builder ) ? $mime_builder : new MIME_Builder();
 
 		// Set the default WordPress HTTP API args.
 		$this->default_args = apply_filters(

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,9 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-  <rule ref="WordPress.PHP.DisallowShortTernary.Found">
-    <severity>0</severity>
-  </rule>
 	<rule ref="WordPress.Security.NonceVerification.NoNonceVerification">
 		<severity>0</severity>
 	</rule>


### PR DESCRIPTION
* Re-enables the phpcs short ternaries check and fixes errors that were flagged.
* Upgrades the Travis config to use Bionic and node 12.