### PR TITLE
APPLE-10 Add support for captions on cover images

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -107,9 +107,16 @@ class Export extends Action {
 		$excerpt = has_excerpt( $post ) ? wp_strip_all_tags( $post->post_excerpt ) : '';
 
 		// Get the post thumbnail.
-		$post_thumb = wp_get_attachment_url( get_post_thumbnail_id( $this->id ) );
+		$thumb_id   = get_post_thumbnail_id( $this->id );
+		$post_thumb = wp_get_attachment_url( $thumb_id );
 		if ( empty( $post_thumb ) ) {
 			$post_thumb = null;
+		} else {
+			$caption    = wp_get_attachment_caption( $thumb_id );
+			$post_thumb = [
+				'caption' => ! empty( $caption ) ? $caption : '',
+				'url'     => $post_thumb,
+			];
 		}
 
 		// Build the byline.
@@ -136,9 +143,31 @@ class Export extends Action {
 		// Filter each of our items before passing into the exporter class.
 		$title      = apply_filters( 'apple_news_exporter_title', $post->post_title, $post->ID );
 		$excerpt    = apply_filters( 'apple_news_exporter_excerpt', $excerpt, $post->ID );
-		$post_thumb = apply_filters( 'apple_news_exporter_post_thumb', $post_thumb, $post->ID );
+		$cover_url  = apply_filters( 'apple_news_exporter_post_thumb', ! empty( $post_thumb['url'] ) ? $post_thumb['url'] : null, $post->ID );
 		$byline     = apply_filters( 'apple_news_exporter_byline', $byline, $post->ID );
 		$content    = apply_filters( 'apple_news_exporter_content', $content, $post->ID );
+
+		// Re-apply the cover URL after filtering.
+		if ( ! empty( $cover_url ) ) {
+			$cover_caption = ! empty( $post_thumb['caption'] ) ? $post_thumb['caption'] : '';
+
+			/**
+			 * Filters the cover caption.
+			 *
+			 * @param string $caption The caption to use for the cover image.
+			 * @param int    $post_id The post ID.
+			 *
+			 * @since 2.1.0
+			 */
+			$cover_caption = apply_filters( 'apple_news_exporter_cover_caption', $cover_caption, $post->ID );
+
+			$post_thumb = [
+				'caption' => $cover_caption,
+				'url'     => $cover_url,
+			];
+		} else {
+			$post_thumb = null;
+		}
 
 		// Now pass all the variables into the Exporter_Content array.
 		$base_content = new Exporter_Content(

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -141,11 +141,11 @@ class Export extends Action {
 		}
 
 		// Filter each of our items before passing into the exporter class.
-		$title      = apply_filters( 'apple_news_exporter_title', $post->post_title, $post->ID );
-		$excerpt    = apply_filters( 'apple_news_exporter_excerpt', $excerpt, $post->ID );
-		$cover_url  = apply_filters( 'apple_news_exporter_post_thumb', ! empty( $post_thumb['url'] ) ? $post_thumb['url'] : null, $post->ID );
-		$byline     = apply_filters( 'apple_news_exporter_byline', $byline, $post->ID );
-		$content    = apply_filters( 'apple_news_exporter_content', $content, $post->ID );
+		$title     = apply_filters( 'apple_news_exporter_title', $post->post_title, $post->ID );
+		$excerpt   = apply_filters( 'apple_news_exporter_excerpt', $excerpt, $post->ID );
+		$cover_url = apply_filters( 'apple_news_exporter_post_thumb', ! empty( $post_thumb['url'] ) ? $post_thumb['url'] : null, $post->ID );
+		$byline    = apply_filters( 'apple_news_exporter_byline', $byline, $post->ID );
+		$content   = apply_filters( 'apple_news_exporter_content', $content, $post->ID );
 
 		// Re-apply the cover URL after filtering.
 		if ( ! empty( $cover_url ) ) {

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -261,7 +261,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			if ( $this->is_multiple( $name ) ) {
 				$multiple_name = '[]';
 				$multiple_attr = 'multiple="multiple"';
-				$size = min( $size, count( $type ) );
+				$size          = min( $size, count( $type ) );
 			} else {
 				$size = 1;
 			}

--- a/includes/apple-exporter/builders/class-builder.php
+++ b/includes/apple-exporter/builders/class-builder.php
@@ -87,7 +87,7 @@ abstract class Builder {
 	 * Gets the content cover.
 	 *
 	 * @access protected
-	 * @return string The URL for the cover image from the content object.
+	 * @return string|array The URL for the cover image from the content object, or an array specifying a 'url' and a 'caption'.
 	 */
 	protected function content_cover() {
 		return $this->content->cover();

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -188,7 +188,8 @@ class Components extends Builder {
 			}
 
 			// If the normalized URL for the first image is different than the URL for the featured image, use the featured image.
-			$cover_url      = $this->get_image_full_size_url( $this->content_cover() );
+			$cover_config   = $this->content_cover();
+			$cover_url      = $this->get_image_full_size_url( ! empty( $cover_config['url'] ) ? $cover_config['url'] : $cover_config );
 			$normalized_url = $this->get_image_full_size_url( $original_url );
 			if ( ! empty( $cover_url ) && $normalized_url !== $cover_url ) {
 				return;

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -195,15 +195,23 @@ class Components extends Builder {
 				return;
 			}
 
-			// Use this image as the cover.
-			$this->set_content_property( 'cover', $original_url );
-
 			// If the cover is set to be displayed, remove it from the flow.
-			$order = $theme->get_value( 'meta_component_order' );
+			$cover_caption = '';
+			$order         = $theme->get_value( 'meta_component_order' );
 			if ( is_array( $order ) && in_array( 'cover', $order, true ) ) {
+				$image_json = $components[ $i ]->to_array();
+				$cover_caption = ! empty( $image_json['components'][0]['caption'] ) ? $image_json['components'][0]['caption'] : '';
 				unset( $components[ $i ] );
 				$components = array_values( $components );
 			}
+
+			// Use this image as the cover.
+			$this->set_content_property(
+				'cover', [
+					'caption' => $cover_caption,
+					'url'     => $original_url,
+				]
+			);
 
 			break;
 		}

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -199,15 +199,16 @@ class Components extends Builder {
 			$cover_caption = '';
 			$order         = $theme->get_value( 'meta_component_order' );
 			if ( is_array( $order ) && in_array( 'cover', $order, true ) ) {
-				$image_json = $components[ $i ]->to_array();
-				$cover_caption = ! empty( $image_json['components'][0]['caption'] ) ? $image_json['components'][0]['caption'] : '';
+				$image_json    = $components[ $i ]->to_array();
+				$cover_caption = ! empty( $image_json['components'][0]['caption']['text'] ) ? $image_json['components'][0]['caption']['text'] : '';
 				unset( $components[ $i ] );
 				$components = array_values( $components );
 			}
 
 			// Use this image as the cover.
 			$this->set_content_property(
-				'cover', [
+				'cover',
+				[
 					'caption' => $cover_caption,
 					'url'     => $original_url,
 				]

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -37,9 +37,10 @@ class Metadata extends Builder {
 		}
 
 		// If the content has a cover, use it as thumb.
-		if ( $this->content_cover() ) {
+		$content_cover = $this->content_cover();
+		if ( ! empty( $content_cover ) ) {
 			$meta['thumbnailURL'] = $this->maybe_bundle_source(
-				$this->content_cover()
+				! empty( $content_cover['url'] ) ? $content_cover['url'] : $content_cover
 			);
 		}
 

--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -118,7 +118,7 @@ class Exporter_Content {
 	 * @param string                   $title    The title of the post to be exported.
 	 * @param string                   $content  The content of the post to be exported.
 	 * @param string                   $intro    Optional. The intro of the post to be exported.
-	 * @param string                   $cover    Optional. The cover of the post to be exported.
+	 * @param string|array             $cover    Optional. The cover of the post to be exported. If string, just the URL. If array, properties are 'url' and 'caption'.
 	 * @param string                   $byline   Optional. The byline of the post to be exported.
 	 * @param \Apple_Exporter\Settings $settings Optional. Settings for the exporter.
 	 * @access public

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -108,30 +108,36 @@ class Cover extends Component {
 	/**
 	 * Build the component.
 	 *
-	 * @param string $html The HTML for the cover image. Can be a bare URL or an img or figure tag.
+	 * @param array|string $options {
+	 *    The options for the component. If a string is provided, assume it is a URL.
+	 *
+	 *    @type string $caption The caption for the image.
+	 *    @type string $url     The URL to the featured image.
+	 * }
 	 * @access protected
 	 */
-	protected function build( $html ) {
+	protected function build( $options ) {
 
-		// Determine if we were given a bare URL or HTML.
-		$url = filter_var( $html, FILTER_VALIDATE_URL )
-			? $html
-			: self::url_from_src( $html );
+		// Handle case where options is a URL.
+		if ( is_string( $options ) ) {
+			$options = [
+				'url' => $options,
+			];
+		}
 
-		// Bundle the source, if necessary.
-		$url = trim( $this->maybe_bundle_source( $url ) );
-
-		// If we failed to get a URL, bail out.
-		if ( empty( $url ) ) {
+		// If we can't get a valid URL, bail.
+		$url   = $this->maybe_bundle_source( $options['url'] );
+		$check = trim( $url );
+		if ( empty( $check ) ) {
 			return;
 		}
 
 		// Fork for caption vs. not.
-		if ( preg_match( '/<(?:figcaption|p)[^>]+class=[\'"][^\'"]*wp-caption-text[^\'"]*[\'"][^>]*>(.+?)(?:<\/figcaption|<\/p>)/', $html, $matches ) ) {
+		if ( ! empty( $options['caption'] ) ) {
 			$this->register_json(
 				'jsonWithCaption',
 				array(
-					'#caption#' => $matches[1],
+					'#caption#' => $options['caption'],
 					'#url#'     => $url,
 				)
 			);

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -119,7 +119,7 @@ class Cover extends Component {
 	protected function build( $options ) {
 
 		// Handle case where options is a URL.
-		if ( is_string( $options ) ) {
+		if ( ! is_array( $options ) ) {
 			$options = [
 				'url' => $options,
 			];

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -55,7 +55,7 @@ class Cover extends Component {
 				'components' => array(
 					array(
 						'role'    => 'photo',
-						'layout'  => 'headerPhotoLayout',
+						'layout'  => 'headerPhotoLayoutWithCaption',
 						'URL'     => '#url#',
 						'caption' => '#caption#',
 					),
@@ -87,6 +87,19 @@ class Cover extends Component {
 				'ignoreDocumentMargin' => true,
 				'columnStart'          => 0,
 				'columnSpan'           => '#layout_columns#',
+			)
+		);
+
+		$this->register_spec(
+			'headerPhotoLayoutWithCaption',
+			__( 'Layout with Caption', 'apple-news' ),
+			array(
+				'ignoreDocumentMargin' => true,
+				'columnStart'          => 0,
+				'columnSpan'           => '#layout_columns#',
+				'margin'               => array(
+					'bottom' => '#caption_line_height#',
+				),
 			)
 		);
 
@@ -168,6 +181,15 @@ class Cover extends Component {
 			'headerPhotoLayout',
 			array(
 				'#layout_columns#' => $theme->get_layout_columns(),
+			)
+		);
+
+		$this->register_layout(
+			'headerPhotoLayoutWithCaption',
+			'headerPhotoLayoutWithCaption',
+			array(
+				'#caption_line_height#' => $theme->get_value( 'caption_line_height' ),
+				'#layout_columns#'      => $theme->get_layout_columns(),
 			)
 		);
 

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -57,7 +57,10 @@ class Cover extends Component {
 						'role'    => 'photo',
 						'layout'  => 'headerPhotoLayoutWithCaption',
 						'URL'     => '#url#',
-						'caption' => '#caption#',
+						'caption' => array(
+							'format' => 'html',
+							'text'   => '#caption#',
+						),
 					),
 					array(
 						'role'      => 'caption',

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -47,6 +47,40 @@ class Cover extends Component {
 		);
 
 		$this->register_spec(
+			'jsonWithCaption',
+			__( 'JSON with Caption', 'apple-news' ),
+			array(
+				'role'       => 'header',
+				'layout'     => 'headerPhotoLayout',
+				'components' => array(
+					array(
+						'role'    => 'photo',
+						'layout'  => 'headerPhotoLayout',
+						'URL'     => '#url#',
+						'caption' => '#caption#',
+					),
+					array(
+						'role'      => 'caption',
+						'text'      => '#caption#',
+						'format'    => 'html',
+						'textStyle' => array(
+							'textAlignment' => '#text_alignment#',
+							'fontName'      => '#caption_font#',
+							'fontSize'      => '#caption_size#',
+							'tracking'      => '#caption_tracking#',
+							'lineHeight'    => '#caption_line_height#',
+							'textColor'     => '#caption_color#',
+						),
+					),
+				),
+				'behavior'   => array(
+					'type'   => 'parallax',
+					'factor' => 0.8,
+				),
+			)
+		);
+
+		$this->register_spec(
 			'headerPhotoLayout',
 			__( 'Layout', 'apple-news' ),
 			array(
@@ -92,14 +126,23 @@ class Cover extends Component {
 			return;
 		}
 
-		// TODO: Fork for caption vs. not.
-
-		$this->register_json(
-			'json',
-			array(
-				'#url#' => $url,
-			)
-		);
+		// Fork for caption vs. not.
+		if ( preg_match( '/<(?:figcaption|p)[^>]+class=[\'"][^\'"]*wp-caption-text[^\'"]*[\'"][^>]*>(.+?)(?:<\/figcaption|<\/p>)/', $html, $matches ) ) {
+			$this->register_json(
+				'jsonWithCaption',
+				array(
+					'#caption#' => $matches[1],
+					'#url#'     => $url,
+				)
+			);
+		} else {
+			$this->register_json(
+				'json',
+				array(
+					'#url#' => $url,
+				)
+			);
+		}
 
 		$this->set_default_layout();
 	}
@@ -130,6 +173,4 @@ class Cover extends Component {
 			)
 		);
 	}
-
 }
-

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -74,17 +74,25 @@ class Cover extends Component {
 	/**
 	 * Build the component.
 	 *
-	 * @param string $url The URL for the cover image.
+	 * @param string $html The HTML for the cover image. Can be a bare URL or an img or figure tag.
 	 * @access protected
 	 */
-	protected function build( $url ) {
+	protected function build( $html ) {
 
-		// If we can't get a valid URL, bail.
-		$url   = $this->maybe_bundle_source( $url );
-		$check = trim( $url );
-		if ( empty( $check ) ) {
+		// Determine if we were given a bare URL or HTML.
+		$url = filter_var( $html, FILTER_VALIDATE_URL )
+			? $html
+			: self::url_from_src( $html );
+
+		// Bundle the source, if necessary.
+		$url = trim( $this->maybe_bundle_source( $url ) );
+
+		// If we failed to get a URL, bail out.
+		if ( empty( $url ) ) {
 			return;
 		}
+
+		// TODO: Fork for caption vs. not.
 
 		$this->register_json(
 			'json',

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -78,7 +78,10 @@ class Image extends Component {
 						'role'    => 'photo',
 						'URL'     => '#url#',
 						'layout'  => '#layout#',
-						'caption' => '#caption#',
+						'caption' => array(
+							'format' => 'html',
+							'text'   => '#caption#',
+						),
 					),
 					array(
 						'role'      => 'caption',

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,8 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 == Changelog ==
 
 = 2.1.0 =
+* Enhancement: The cover component now supports captions. If a featured image is used for the cover, the caption will come from the attachment itself in the database. If the first image from the content is used, the caption will be read from the HTML. There is also a new filter, apple_news_exporter_cover_caption, which allows for filtering of the caption text.
+* Enhancement: HTML is now allowed in lightbox image captions.
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 * Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.
 * Bugfix: If the same image is used for the featured image and the first image embedded into the post, it no longer shows up twice.

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -43,7 +43,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		$json     = json_decode( $export->perform(), true );
 		$this->assertEquals( 'photo', $json['components'][0]['components'][0]['role'] );
 		$this->assertEquals( wp_get_attachment_url( $image ), $json['components'][0]['components'][0]['URL'] );
-		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][0]['caption'] );
+		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][0]['caption']['text'] );
 		$this->assertEquals( 'caption', $json['components'][0]['components'][1]['role'] );
 		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][1]['text'] );
 	}

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -19,6 +19,35 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		return apple_news_is_exporting() ? 'is exporting' : 'is not exporting';
 	}
 
+	/**
+	 * Tests the ability to include a caption with a cover image.
+	 */
+	public function testCoverWithCaption() {
+
+		// Create dummy post and attachment.
+		$file    = dirname( dirname( dirname( __DIR__ ) ) ) . '/data/test-image.jpg';
+		$post_id = self::factory()->post->create();
+		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
+
+		// Add a caption to the image.
+		$image_post = get_post( $image );
+		$image_post->post_excerpt = 'Test Caption';
+		wp_update_post( $image_post );
+
+		// Set the image as the featured image for the post.
+		update_post_meta( $post_id, '_thumbnail_id', $image );
+
+		// Run the export and check the result.
+		$sections = \Admin_Apple_Sections::get_sections_for_post( $post_id );
+		$export   = new Export( $this->settings, $post_id, $sections );
+		$json     = json_decode( $export->perform(), true );
+		$this->assertEquals( 'photo', $json['components'][0]['components'][0]['role'] );
+		$this->assertEquals( wp_get_attachment_url( $image ), $json['components'][0]['components'][0]['URL'] );
+		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][0]['caption'] );
+		$this->assertEquals( 'caption', $json['components'][0]['components'][1]['role'] );
+		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][1]['text'] );
+	}
+
 	public function testHasExcerpt() {
 		$title = 'My Title';
 		$excerpt = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue...';

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -118,7 +118,7 @@ class Component_Tests extends WP_UnitTestCase {
 			'My Title',
 			'<p>Hello, World!</p>',
 			null,
-			$this->cover,
+			wp_get_attachment_url( $this->cover ),
 			'Author Name'
 		);
 		$this->styles = new Component_Text_Styles( $this->content, $this->settings );

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -165,7 +165,7 @@ class Component_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'headerPhotoLayout', $result[0]['layout'] );
 		$this->assertEquals( $cover_url, $result[0]['components'][0]['URL'] );
 		$this->assertEquals( 'photo', $result[0]['components'][0]['role'] );
-		$this->assertEquals( 'Test Caption', $result[0]['components'][0]['caption'] );
+		$this->assertEquals( 'Test Caption', $result[0]['components'][0]['caption']['text'] );
 		$this->assertEquals( 'caption', $result[0]['components'][1]['role'] );
 		$this->assertEquals( 'Test Caption', $result[0]['components'][1]['text'] );
 	}

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -168,6 +168,24 @@ class Component_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'Test Caption', $result[0]['components'][0]['caption']['text'] );
 		$this->assertEquals( 'caption', $result[0]['components'][1]['role'] );
 		$this->assertEquals( 'Test Caption', $result[0]['components'][1]['text'] );
+
+		// Test setting the caption from within the content rather than as part of the Exporter_Content config (featured image).
+		$content = new Exporter_Content(
+			1,
+			'My Title',
+			'<p>Hello, World!</p><figure class="wp-block-image size-full"><img src="' . $cover_url . '" alt="" class="wp-image-' . $this->cover . '"/><figcaption>Test caption!</figcaption></figure>',
+			null,
+			null,
+			'Author Name'
+		);
+		$builder = new Components( $content, $this->settings );
+		$result = $builder->to_array();
+		$this->assertEquals( 'header', $result[0]['role'] );
+		$this->assertEquals( 'headerPhotoLayout', $result[0]['layout'] );
+		$this->assertEquals( 'photo', $result[0]['components'][0]['role'] );
+		$this->assertEquals( 'headerPhotoLayoutWithCaption', $result[0]['components'][0]['layout'] );
+		$this->assertEquals( $cover_url, $result[0]['components'][0]['URL'] );
+		$this->assertEquals( 'Test caption!', $result[0]['components'][0]['caption']['text'] );
 	}
 
 	/**

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -143,6 +143,34 @@ class Component_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the ability to provide cover configuration as an array instead of
+	 * a URL, which lets us build cover images with captions.
+	 */
+	public function testCoverImageArrayConfig() {
+		$cover_url = wp_get_attachment_url( $this->cover );
+		$content   = new Exporter_Content(
+			1,
+			'My Title',
+			'<p>Hello, World!</p>',
+			null,
+			[
+				'caption' => 'Test Caption',
+				'url'     => $cover_url,
+			],
+			'Author Name'
+		);
+		$builder = new Components( $content, $this->settings );
+		$result  = $builder->to_array();
+		$this->assertEquals( 'header', $result[0]['role'] );
+		$this->assertEquals( 'headerPhotoLayout', $result[0]['layout'] );
+		$this->assertEquals( $cover_url, $result[0]['components'][0]['URL'] );
+		$this->assertEquals( 'photo', $result[0]['components'][0]['role'] );
+		$this->assertEquals( 'Test Caption', $result[0]['components'][0]['caption'] );
+		$this->assertEquals( 'caption', $result[0]['components'][1]['role'] );
+		$this->assertEquals( 'Test Caption', $result[0]['components'][1]['text'] );
+	}
+
+	/**
 	 * Tests the image deduping functionality of the Components class.
 	 *
 	 * Ensures that a featured image with the same source URL (minus any crops)

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -120,10 +120,27 @@ class Cover_Test extends Component_TestCase {
 			),
 			$component->to_array()
 		);
+	}
 
-		return;
+	/**
+	 * Tests the JSON generation for the Cover component when provided with image HTML and a caption.
+	 */
+	public function testGeneratedJSONFromHTMLWithCaption() {
+		$this->settings->set( 'use_remote_images', 'yes' );
 
-		// TODO: Caption.
+		// Create dummy post and attachment.
+		$file    = dirname( dirname( __DIR__ ) ) . '/data/test-image.jpg';
+		$post_id = self::factory()->post->create();
+		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
+
+		$component = new Cover(
+			do_shortcode( '[caption caption="Test Caption" width="300"]' . wp_get_attachment_image( $image, 'full' ) . '[/caption]' ),
+			new Workspace( $post_id ),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
 		$this->assertEquals(
 			array(
 				'role' => 'header',
@@ -131,20 +148,20 @@ class Cover_Test extends Component_TestCase {
 				'components' => array(
 					array(
 						'role'    => 'photo',
-						'URL'     => 'http://someurl.com/filename.jpg',
+						'URL'     => wp_get_attachment_url( $image ),
 						'layout'  => 'headerPhotoLayout',
+						'caption' => 'Test Caption',
 					),
 					array(
 						'role'      => 'caption',
-						'text'      => '#caption_text#',
+						'text'      => 'Test Caption',
 						'format'    => 'html',
 						'textStyle' => array(
-							'textAlignment' => '#text_alignment#',
-							'fontName'      => '#caption_font#',
-							'fontSize'      => '#caption_size#',
-							'tracking'      => '#caption_tracking#',
-							'lineHeight'    => '#caption_line_height#',
-							'textColor'     => '#caption_color#',
+							'fontName' => 'AvenirNext-Italic',
+              'fontSize' => 16,
+              'tracking' => 0,
+              'lineHeight' => 24.0,
+              'textColor' => '#4f4f4f',
 						),
 					),
 				),

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -33,17 +33,17 @@ class Cover_Test extends Component_TestCase {
 
 		$this->assertEquals(
 			array(
-				'role' => 'header',
-				'layout' => 'headerPhotoLayout',
+				'role'       => 'header',
+				'layout'     => 'headerPhotoLayout',
 				'components' => array(
 					array(
-						'role' => 'photo',
+						'role'   => 'photo',
 						'layout' => 'headerPhotoLayout',
-						'URL' => 'bundle://filename.jpg'
-						)
-					),
-				'behavior' => array(
-					'type' => 'parallax',
+						'URL'    => 'bundle://filename.jpg'
+					)
+				),
+				'behavior'   => array(
+					'type'   => 'parallax',
 					'factor' => 0.8
 				),
 			),
@@ -65,17 +65,17 @@ class Cover_Test extends Component_TestCase {
 
 		$this->assertEquals(
 			array(
-				'role' => 'header',
-				'layout' => 'headerPhotoLayout',
+				'role'       => 'header',
+				'layout'     => 'headerPhotoLayout',
 				'components' => array(
 					array(
-						'role' => 'photo',
+						'role'   => 'photo',
 						'layout' => 'headerPhotoLayout',
-						'URL' => 'http://someurl.com/filename.jpg'
+						'URL'    => 'http://someurl.com/filename.jpg'
 					)
 				),
-				'behavior' => array(
-					'type' => 'parallax',
+				'behavior'   => array(
+					'type'   => 'parallax',
 					'factor' => 0.8
 				),
 			),
@@ -146,8 +146,8 @@ class Cover_Test extends Component_TestCase {
 
 		$this->assertEquals(
 			array(
-				'role' => 'header',
-				'layout' => 'headerPhotoLayout',
+				'role'       => 'header',
+				'layout'     => 'headerPhotoLayout',
 				'components' => array(
 					array(
 						'role'    => 'photo',
@@ -163,16 +163,16 @@ class Cover_Test extends Component_TestCase {
 						'text'      => 'Test Caption',
 						'format'    => 'html',
 						'textStyle' => array(
-							'fontName' => 'AvenirNext-Italic',
-              'fontSize' => 16,
-              'tracking' => 0,
-              'lineHeight' => 24.0,
-              'textColor' => '#4f4f4f',
+							'fontName'   => 'AvenirNext-Italic',
+							'fontSize'   => 16,
+							'tracking'   => 0,
+							'lineHeight' => 24.0,
+							'textColor'  => '#4f4f4f',
 						),
 					),
 				),
-				'behavior' => array(
-					'type' => 'parallax',
+				'behavior'   => array(
+					'type'   => 'parallax',
 					'factor' => 0.8
 				),
 			),
@@ -193,22 +193,25 @@ class Cover_Test extends Component_TestCase {
 		$component = new Cover( 'http://someurl.com/filename.jpg',
 			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
 
-		add_filter( 'apple_news_cover_json', function( $json ) {
+		add_filter( 'apple_news_cover_json', function ( $json ) {
 			$json['behavior']['type'] = 'background_motion';
+
 			return $json;
 		} );
 
 		$this->assertEquals(
 			array(
-				'role' => 'header',
-				'layout' => 'headerPhotoLayout',
-				'components' => array( array(
-					'role' => 'photo',
-					'layout' => 'headerPhotoLayout',
-					'URL' => 'bundle://filename.jpg'
-				) ),
-				'behavior' => array(
-					'type' => 'background_motion',
+				'role'       => 'header',
+				'layout'     => 'headerPhotoLayout',
+				'components' => array(
+					array(
+						'role'   => 'photo',
+						'layout' => 'headerPhotoLayout',
+						'URL'    => 'bundle://filename.jpg'
+					)
+				),
+				'behavior'   => array(
+					'type'   => 'background_motion',
 					'factor' => 0.8
 				),
 			),

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -95,7 +95,7 @@ class Cover_Test extends Component_TestCase {
 		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
 
 		$component = new Cover(
-			wp_get_attachment_image( $image, 'full' ),
+			wp_get_attachment_url( $image ),
 			new Workspace( $post_id ),
 			$this->settings,
 			$this->styles,
@@ -134,7 +134,10 @@ class Cover_Test extends Component_TestCase {
 		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
 
 		$component = new Cover(
-			do_shortcode( '[caption caption="Test Caption" width="300"]' . wp_get_attachment_image( $image, 'full' ) . '[/caption]' ),
+			[
+				'caption' => 'Test Caption',
+				'url'     => wp_get_attachment_url( $image ),
+			],
 			new Workspace( $post_id ),
 			$this->settings,
 			$this->styles,

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -152,8 +152,11 @@ class Cover_Test extends Component_TestCase {
 					array(
 						'role'    => 'photo',
 						'URL'     => wp_get_attachment_url( $image ),
-						'layout'  => 'headerPhotoLayout',
-						'caption' => 'Test Caption',
+						'layout'  => 'headerPhotoLayoutWithCaption',
+						'caption' => array(
+							'format' => 'html',
+							'text'   => 'Test Caption',
+						),
 					),
 					array(
 						'role'      => 'caption',

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -118,7 +118,7 @@ HTML;
 		$this->assertContains( $json['components'], $json );
 		$this->assertEquals( 'photo', $json['components'][0]['role'] );
 		$this->assertEquals( 'https://placeimg.com/640/480/any', $json['components'][0]['URL'] );
-		$this->assertEquals( 'Sed <strong>ac metus</strong> sagittis <em>urna feugiat</em> interdum. Duis vel blandit nisi, id tempus sem. Credit: <a href="https://domain.suffix">Domain</a>', $json['components'][0]['caption'] );
+		$this->assertEquals( 'Sed <strong>ac metus</strong> sagittis <em>urna feugiat</em> interdum. Duis vel blandit nisi, id tempus sem. Credit: <a href="https://domain.suffix">Domain</a>', $json['components'][0]['caption']['text'] );
 	}
 
 	/**

--- a/tests/apple-exporter/test-class-exporter-content.php
+++ b/tests/apple-exporter/test-class-exporter-content.php
@@ -33,6 +33,28 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the ability to set a cover using an array configuration.
+	 */
+	public function testCompleteContentWithCoverConfig() {
+		$cover = [
+			'caption' => 'Test Caption',
+			'url'     => 'https://example.org/wp-content/uploads/2020/07/test-image.jpg',
+		];
+		$content  = new \Apple_Exporter\Exporter_Content(
+			3,
+			'Title',
+			'<p>Example content</p>',
+			'some intro',
+			$cover
+		);
+		$this->assertEquals( '3', $content->id() );
+		$this->assertEquals( 'Title', $content->title() );
+		$this->assertEquals( '<p>Example content</p>', $content->content() );
+		$this->assertEquals( 'some intro', $content->intro() );
+		$this->assertEquals( $cover, $content->cover() );
+	}
+
+	/**
 	 * Ensure we decode the HTML entities in URLs extracted from HTML attributes.[type]
 	 */
 	public function test_format_src_url() {


### PR DESCRIPTION
* Adds support for captions on cover images both in the lightbox and below the image.
* Adds support for HTML in image captions in the lightbox (APPLE-27).
* Adds test coverage for the new functionality.
* Adds a new filter for the cover caption.