### PR TITLE
APPLE-30 Wire up cover image curation

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -109,22 +109,35 @@ class Export extends Action {
 		// Get the cover configuration.
 		$post_thumb    = null;
 		$cover_meta_id = get_post_meta( $this->id, 'apple_news_coverimage', true );
+		$cover_caption = get_post_meta( $this->id, 'apple_news_coverimage_caption', true );
 		if ( ! empty( $cover_meta_id ) ) {
-			$cover_meta_caption = get_post_meta( $this->id, 'apple_news_coverimage_caption', true );
-			$post_thumb         = [
-				'caption' => ! empty( $cover_meta_caption ) ? $cover_meta_caption : '',
+			if ( empty( $cover_caption ) ) {
+				$cover_caption = wp_get_attachment_caption( $cover_meta_id );
+			}
+			$post_thumb = [
+				'caption' => ! empty( $cover_caption ) ? $cover_caption : '',
 				'url'     => wp_get_attachment_url( $cover_meta_id ),
 			];
 		} else {
 			$thumb_id       = get_post_thumbnail_id( $this->id );
 			$post_thumb_url = wp_get_attachment_url( $thumb_id );
+			if ( empty( $cover_caption ) ) {
+				$cover_caption = wp_get_attachment_caption( $thumb_id );
+			}
 			if ( ! empty( $post_thumb_url ) ) {
-				$caption    = wp_get_attachment_caption( $thumb_id );
 				$post_thumb = [
-					'caption' => ! empty( $caption ) ? $caption : '',
+					'caption' => ! empty( $cover_caption ) ? $cover_caption : '',
 					'url'     => $post_thumb_url,
 				];
 			}
+		}
+
+		// If there is a cover caption but not a cover image URL, preserve it, so it can take precedence later.
+		if ( empty( $post_thumb ) && ! empty( $cover_caption ) ) {
+			$post_thumb = [
+				'caption' => $cover_caption,
+				'url'     => '',
+			];
 		}
 
 		// Build the byline.

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -106,17 +106,25 @@ class Export extends Action {
 		// Only include excerpt if exists.
 		$excerpt = has_excerpt( $post ) ? wp_strip_all_tags( $post->post_excerpt ) : '';
 
-		// Get the post thumbnail.
-		$thumb_id   = get_post_thumbnail_id( $this->id );
-		$post_thumb = wp_get_attachment_url( $thumb_id );
-		if ( empty( $post_thumb ) ) {
-			$post_thumb = null;
-		} else {
-			$caption    = wp_get_attachment_caption( $thumb_id );
-			$post_thumb = [
-				'caption' => ! empty( $caption ) ? $caption : '',
-				'url'     => $post_thumb,
+		// Get the cover configuration.
+		$post_thumb    = null;
+		$cover_meta_id = get_post_meta( $this->id, 'apple_news_coverimage', true );
+		if ( ! empty( $cover_meta_id ) ) {
+			$cover_meta_caption = get_post_meta( $this->id, 'apple_news_coverimage_caption', true );
+			$post_thumb         = [
+				'caption' => ! empty( $cover_meta_caption ) ? $cover_meta_caption : '',
+				'url'     => wp_get_attachment_url( $cover_meta_id ),
 			];
+		} else {
+			$thumb_id       = get_post_thumbnail_id( $this->id );
+			$post_thumb_url = wp_get_attachment_url( $thumb_id );
+			if ( ! empty( $post_thumb_url ) ) {
+				$caption    = wp_get_attachment_caption( $thumb_id );
+				$post_thumb = [
+					'caption' => ! empty( $caption ) ? $caption : '',
+					'url'     => $post_thumb_url,
+				];
+			}
 		}
 
 		// Build the byline.

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -209,6 +209,20 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			$pullquote_position = 'middle';
 		}
 		update_post_meta( $post_id, 'apple_news_pullquote_position', $pullquote_position );
+
+		if ( ! empty( (int) $_POST['apple_news_coverimage'] ) ) {
+			$cover_image = (int) $_POST['apple_news_coverimage'];
+		} else {
+			$cover_image = '';
+		}
+		update_post_meta( $post_id, 'apple_news_coverimage', $cover_image );
+
+		if ( ! empty( $_POST['apple_news_coverimage_caption'] ) ) {
+			$cover_image_caption = sanitize_textarea_field( wp_unslash( $_POST['apple_news_coverimage_caption'] ) );
+		} else {
+			$cover_image_caption = '';
+		}
+		update_post_meta( $post_id, 'apple_news_coverimage_caption', $cover_image_caption );
 	}
 
 	/**

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -210,8 +210,8 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		}
 		update_post_meta( $post_id, 'apple_news_pullquote_position', $pullquote_position );
 
-		if ( ! empty( (int) $_POST['apple_news_coverimage'] ) ) {
-			$cover_image = (int) $_POST['apple_news_coverimage'];
+		if ( ! empty( $_POST['apple_news_coverimage'] ) ) {
+			$cover_image = ! empty( (int) $_POST['apple_news_coverimage'] ) ? (int) $_POST['apple_news_coverimage'] : '';
 		} else {
 			$cover_image = '';
 		}

--- a/admin/partials/cover-image.php
+++ b/admin/partials/cover-image.php
@@ -5,38 +5,38 @@
  * @package Apple_News
  */
 
-$cover_image_id      = get_post_meta( $post->ID, 'apple_news_coverimage', true );
-$cover_image_caption = get_post_meta( $post->ID, 'apple_news_coverimage_caption', true );
+$apple_cover_image_id      = get_post_meta( $post->ID, 'apple_news_coverimage', true );
+$apple_cover_image_caption = get_post_meta( $post->ID, 'apple_news_coverimage_caption', true );
 
 ?>
 <div class="apple-news-coverimage-image-container">
 	<div class="apple-news-coverimage-image">
 		<?php
-			if ( ! empty( $cover_image_id ) ) {
-				echo wp_get_attachment_image( $cover_image_id, 'medium' );
-				$add_hidden    = 'hidden';
-				$remove_hidden = '';
-			} else {
-				$add_hidden    = '';
-				$remove_hidden = 'hidden';
-			}
+		if ( ! empty( $apple_cover_image_id ) ) {
+			echo wp_get_attachment_image( $apple_cover_image_id, 'medium' );
+			$apple_add_hidden    = 'hidden';
+			$apple_remove_hidden = '';
+		} else {
+			$apple_add_hidden    = '';
+			$apple_remove_hidden = 'hidden';
+		}
 		?>
 	</div>
 	<input name="apple_news_coverimage"
-				 class="apple-news-coverimage-id"
-	       type="hidden"
-	       value="<?php echo esc_attr( $cover_image_id ); ?>"
+		class="apple-news-coverimage-id"
+		type="hidden"
+		value="<?php echo esc_attr( $apple_cover_image_id ); ?>"
 	/>
 	<input type="button"
-	       class="button-primary apple-news-coverimage-add <?php echo esc_attr( $add_hidden ); ?>"
-	       value="<?php esc_attr_e( 'Add image', 'apple-news' ); ?>"
+		class="button-primary apple-news-coverimage-add <?php echo esc_attr( $apple_add_hidden ); ?>"
+		value="<?php esc_attr_e( 'Add image', 'apple-news' ); ?>"
 	/>
 	<input type="button"
-	       class="button-primary apple-news-coverimage-remove <?php echo esc_attr( $remove_hidden ); ?>"
-	       value="<?php esc_attr_e( 'Remove image', 'apple-news' ); ?>"
+		class="button-primary apple-news-coverimage-remove <?php echo esc_attr( $apple_remove_hidden ); ?>"
+		value="<?php esc_attr_e( 'Remove image', 'apple-news' ); ?>"
 	/>
 </div>
 <div>
 	<label for="apple-news-coverimage-caption"><?php esc_html_e( 'Cover Image Caption:', 'apple-news' ); ?></label>
-	<textarea id="apple-news-coverimage-caption" name="apple_news_coverimage_caption"><?php echo esc_textarea( $cover_image_caption ); ?></textarea>
+	<textarea id="apple-news-coverimage-caption" name="apple_news_coverimage_caption"><?php echo esc_textarea( $apple_cover_image_caption ); ?></textarea>
 </div>

--- a/admin/partials/cover-image.php
+++ b/admin/partials/cover-image.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Publish to Apple News partials: Cover Image template
+ *
+ * @package Apple_News
+ */
+
+$cover_image_id      = get_post_meta( $post->ID, 'apple_news_coverimage', true );
+$cover_image_caption = get_post_meta( $post->ID, 'apple_news_coverimage_caption', true );
+
+?>
+<div class="apple-news-coverimage-image-container">
+	<div class="apple-news-coverimage-image">
+		<?php
+			if ( ! empty( $cover_image_id ) ) {
+				echo wp_get_attachment_image( $cover_image_id, 'medium' );
+				$add_hidden    = 'hidden';
+				$remove_hidden = '';
+			} else {
+				$add_hidden    = '';
+				$remove_hidden = 'hidden';
+			}
+		?>
+	</div>
+	<input name="apple-news-coverimage"
+	       type="hidden"
+	       value="<?php echo esc_attr( $cover_image_id ); ?>"
+	/>
+	<input type="button"
+	       class="button-primary apple-news-coverimage-add <?php echo esc_attr( $add_hidden ); ?>"
+	       value="<?php esc_attr_e( 'Add image', 'apple-news' ); ?>"
+	/>
+	<input type="button"
+	       class="button-primary apple-news-coverimage-remove <?php echo esc_attr( $remove_hidden ); ?>"
+	       value="<?php esc_attr_e( 'Remove image', 'apple-news' ); ?>"
+	/>
+</div>
+<div>
+	<label for="apple-news-coverimage-caption"><?php esc_html_e( 'Cover Image Caption:', 'apple-news' ); ?></label>
+	<textarea id="apple-news-coverimage-caption" name="apple-news-coverimage-caption">
+		<?php echo esc_textarea( $cover_image_caption ); ?>
+	</textarea>
+</div>

--- a/admin/partials/cover-image.php
+++ b/admin/partials/cover-image.php
@@ -22,7 +22,8 @@ $cover_image_caption = get_post_meta( $post->ID, 'apple_news_coverimage_caption'
 			}
 		?>
 	</div>
-	<input name="apple-news-coverimage"
+	<input name="apple_news_coverimage"
+				 class="apple-news-coverimage-id"
 	       type="hidden"
 	       value="<?php echo esc_attr( $cover_image_id ); ?>"
 	/>
@@ -37,7 +38,5 @@ $cover_image_caption = get_post_meta( $post->ID, 'apple_news_coverimage_caption'
 </div>
 <div>
 	<label for="apple-news-coverimage-caption"><?php esc_html_e( 'Cover Image Caption:', 'apple-news' ); ?></label>
-	<textarea id="apple-news-coverimage-caption" name="apple-news-coverimage-caption">
-		<?php echo esc_textarea( $cover_image_caption ); ?>
-	</textarea>
+	<textarea id="apple-news-coverimage-caption" name="apple_news_coverimage_caption"><?php echo esc_textarea( $cover_image_caption ); ?></textarea>
 </div>

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -81,6 +81,10 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		</select>
 		<p class="description"><?php esc_html_e( 'The position in the article where the pull quote will appear.', 'apple-news' ); ?></p>
 	</div>
+	<div id="apple-news-metabox-coverimage" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
+		<h3><?php esc_html_e( 'Cover Image', 'apple-news' ); ?></h3>
+		<?php include plugin_dir_path( __FILE__ ) . 'cover-image.php'; ?>
+	</div>
 	<?php
 	if ( 'yes' !== $this->settings->get( 'api_autosync' )
 		&& current_user_can( apply_filters( 'apple_news_publish_capability', Apple_News::get_capability_for_post_type( 'publish_posts', $post->post_type ) ) )

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -83,7 +83,7 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 	</div>
 	<div id="apple-news-metabox-coverimage" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
 		<h3><?php esc_html_e( 'Cover Image', 'apple-news' ); ?></h3>
-		<?php include plugin_dir_path( __FILE__ ) . 'cover-image.php'; ?>
+		<?php require plugin_dir_path( __FILE__ ) . 'cover-image.php'; ?>
 	</div>
 	<?php
 	if ( 'yes' !== $this->settings->get( 'api_autosync' )

--- a/assets/js/cover-image.js
+++ b/assets/js/cover-image.js
@@ -1,0 +1,60 @@
+(function ( $, window, undefined ) {
+  'use strict';
+
+  // Set up add and remove image functionality.
+  $( '.apple-news-coverimage-image-container' ).each( function () {
+    var $this = $( this ),
+      $addImgButton = $this.find( '.apple-news-coverimage-add' ),
+      $delImgButton = $this.find( '.apple-news-coverimage-remove' ),
+      $imgContainer = $this.find( '.apple-news-coverimage-image' ),
+      $imgIdInput = $this.find( '.apple-news-coverimage-id' ),
+      frame;
+
+    // Set up handler for remove image functionality.
+    $delImgButton.on( 'click', function() {
+      $imgContainer.empty();
+      $addImgButton.removeClass( 'hidden' );
+      $delImgButton.addClass( 'hidden' );
+      $imgIdInput.val( '' );
+    } );
+
+    // Set up handler for add image functionality.
+    $addImgButton.on( 'click', function () {
+
+      // Open frame, if it already exists.
+      if ( frame ) {
+        frame.open();
+        return;
+      }
+
+      // Set configuration for media frame.
+      frame = wp.media( { multiple: false } );
+
+      // Set up handler for image selection.
+      frame.on( 'select', function () {
+
+        // Get information about the attachment.
+        var attachment = frame.state().get( 'selection' ).first().toJSON(),
+          imgUrl = attachment.url;
+
+        // Set image URL to medium size, if available.
+        if ( attachment.sizes.medium && attachment.sizes.medium.url ) {
+          imgUrl = attachment.sizes.medium.url;
+        }
+
+        // Clear current values.
+        $imgContainer.empty();
+        $imgIdInput.val( '' );
+
+        // Add the image and ID, swap visibility of add and remove buttons.
+        $imgContainer.append( '<img src="' + imgUrl + '" alt="" />' );
+        $imgIdInput.val( attachment.id );
+        $addImgButton.addClass( 'hidden' );
+        $delImgButton.removeClass( 'hidden' );
+      } );
+
+      // Open the media frame.
+      frame.open();
+    } );
+  } );
+})( jQuery, window );

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -189,7 +189,7 @@ class Components extends Builder {
 
 			// If the normalized URL for the first image is different than the URL for the featured image, use the featured image.
 			$cover_config   = $this->content_cover();
-			$cover_url      = $this->get_image_full_size_url( ! empty( $cover_config['url'] ) ? $cover_config['url'] : $cover_config );
+			$cover_url      = $this->get_image_full_size_url( isset( $cover_config['url'] ) ? $cover_config['url'] : $cover_config );
 			$normalized_url = $this->get_image_full_size_url( $original_url );
 			if ( ! empty( $cover_url ) && $normalized_url !== $cover_url ) {
 				return;
@@ -209,7 +209,7 @@ class Components extends Builder {
 			$this->set_content_property(
 				'cover',
 				[
-					'caption' => $cover_caption,
+					'caption' => ! empty( $cover_config['caption'] ) ? $cover_config['caption'] : $cover_caption,
 					'url'     => $original_url,
 				]
 			);

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -40,7 +40,7 @@ class Metadata extends Builder {
 		$content_cover = $this->content_cover();
 		if ( ! empty( $content_cover ) ) {
 			$meta['thumbnailURL'] = $this->maybe_bundle_source(
-				! empty( $content_cover['url'] ) ? $content_cover['url'] : $content_cover
+				isset( $content_cover['url'] ) ? $content_cover['url'] : $content_cover
 			);
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -259,6 +259,15 @@ class Apple_News {
 
 		// Ensure media modal assets are enqueued.
 		wp_enqueue_media();
+
+		// Enqueue the script for cover images in the classic editor.
+		wp_enqueue_script(
+			$this->plugin_slug . '_cover_image_js',
+			plugin_dir_url( __FILE__ ) . '../assets/js/cover-image.js',
+			array( 'jquery' ),
+			self::$version,
+			true
+		);
 	}
 
 	/**

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -46,6 +46,18 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][0]['caption']['text'] );
 		$this->assertEquals( 'caption', $json['components'][0]['components'][1]['role'] );
 		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][1]['text'] );
+
+		// Set cover image and caption via postmeta and ensure it takes priority.
+		$image2 = self::factory()->attachment->create_upload_object( $file );
+		update_post_meta( $post_id, 'apple_news_coverimage', $image2 );
+		update_post_meta( $post_id, 'apple_news_coverimage_caption', 'Test Caption 2' );
+		$export   = new Export( $this->settings, $post_id, $sections );
+		$json     = json_decode( $export->perform(), true );
+		$this->assertEquals( 'photo', $json['components'][0]['components'][0]['role'] );
+		$this->assertEquals( wp_get_attachment_url( $image2 ), $json['components'][0]['components'][0]['URL'] );
+		$this->assertEquals( 'Test Caption 2', $json['components'][0]['components'][0]['caption']['text'] );
+		$this->assertEquals( 'caption', $json['components'][0]['components'][1]['role'] );
+		$this->assertEquals( 'Test Caption 2', $json['components'][0]['components'][1]['text'] );
 	}
 
 	public function testHasExcerpt() {

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -343,6 +343,36 @@ class Component_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'photo', $result[1]['components'][3]['role'] );
 		$this->assertEquals( $image2_thumbnail, $result[1]['components'][3]['URL'] );
 		$this->assertEquals( 4, count( $result[1]['components'] ) );
+
+		/*
+		 * Scenario 7:
+		 * - No featured image is set.
+		 * - Images in the content.
+		 * - Caption set via postmeta.
+		 * Expected: The first image from the content is set as the cover image and the first image from the content has been removed, but the caption from postmeta is used.
+		 */
+		$content = new Exporter_Content(
+			1,
+			'My Title',
+			'<p>Hello, World!</p>' . wp_get_attachment_image( $this->cover ) . wp_get_attachment_image( $this->image2 ),
+			null,
+			[
+				'caption' => 'Test caption from postmeta',
+				'url'     => '',
+			],
+			'Author Name'
+		);
+		$builder = new Components( $content, $this->settings );
+		$result = $builder->to_array();
+		$this->assertEquals( 'header', $result[0]['role'] );
+		$this->assertEquals( 'headerPhotoLayout', $result[0]['layout'] );
+		$this->assertEquals( 'photo', $result[0]['components'][0]['role'] );
+		$this->assertEquals( 'Test caption from postmeta', $result[0]['components'][0]['caption']['text'] );
+		$this->assertEquals( 'headerPhotoLayoutWithCaption', $result[0]['components'][0]['layout'] );
+		$this->assertEquals( $image1_thumbnail, $result[0]['components'][0]['URL'] );
+		$this->assertEquals( 'photo', $result[1]['components'][3]['role'] );
+		$this->assertEquals( $image2_thumbnail, $result[1]['components'][3]['URL'] );
+		$this->assertEquals( 4, count( $result[1]['components'] ) );
 	}
 
 	/**


### PR DESCRIPTION
* Hook up postmeta added in the plugin sidebar for cover images to the article output.
* Add back-compat for configuring cover images via metaboxes.

Note to reviewer: much of this code was ported from the (now deleted) Cover Art feature, found here:

https://github.com/alleyinteractive/apple-news/blob/develop/assets/js/cover-art.js

https://github.com/alleyinteractive/apple-news/blob/develop/admin/partials/cover-art.php