### PR TITLE
APPLE-40 Add Brightcove support

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -303,10 +303,29 @@ class Export extends Action {
 			}
 		}
 
+		// Replace Brightcove shortcodes with plain video tags with a specially-formatted Brightcove source URL.
+		$bc_video_regex = '/' . get_shortcode_regex( [ 'bc_video' ] ) . '/';
+		if ( preg_match_all( $bc_video_regex, $content, $matches ) ) {
+			foreach ( $matches[0] as $match ) {
+				$atts = shortcode_parse_atts( $match );
+				if ( ! empty( $atts['account_id'] ) && ! empty( $atts['video_id'] ) ) {
+					$content = str_replace(
+						$match,
+						sprintf(
+							'<video controls src="https://edge.api.brightcove.com/playback/v1/accounts/%s/videos/%s"></video>',
+							$atts['account_id'],
+							$atts['video_id']
+						),
+						$content
+					);
+				}
+			}
+		}
+
 		return $content;
 	}
 
-		/**
+	/**
 	 * Gets the content
 	 *
 	 * @since 1.4.0

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -273,6 +273,40 @@ class Export extends Action {
 	}
 
 	/**
+	 * Converts Brightcove Gutenberg blocks and shortcodes to video tags that
+	 * can be handled by Apple News. Requires that Apple connect the Brightcove
+	 * account to the Apple News channel.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $content The post content to filter.
+	 *
+	 * @return string The modified content.
+	 */
+	private function format_brightcove( $content ) {
+
+		// Replace Brightcove Gutenberg blocks with Gutenberg video blocks with a specially-formatted Brightcove source URL.
+		if ( preg_match_all( '/<!-- wp:bc\/brightcove ({.+?}) \/-->/', $content, $matches ) ) {
+			foreach ( $matches[0] as $index => $match ) {
+				$atts = json_decode( $matches[1][ $index ], true );
+				if ( ! empty( $atts['account_id'] ) && ! empty( $atts['video_id'] ) ) {
+					$content = str_replace(
+						$match,
+						sprintf(
+							'<!-- wp:video -->' . "\n" . '<figure class="wp-block-video"><video controls src="https://edge.api.brightcove.com/playback/v1/accounts/%s/videos/%s"></video></figure>' . "\n" . '<!-- /wp:video -->',
+							$atts['account_id'],
+							$atts['video_id']
+						),
+						$content
+					);
+				}
+			}
+		}
+
+		return $content;
+	}
+
+		/**
 	 * Gets the content
 	 *
 	 * @since 1.4.0
@@ -288,6 +322,7 @@ class Export extends Action {
 		 * HTML. We use 'the_content' filter for that.
 		 */
 		$content = apply_filters( 'apple_news_exporter_content_pre', $post->post_content, $post->ID );
+		$content = $this->format_brightcove( $content );
 		$content = apply_filters( 'the_content', $content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$content = $this->remove_tags( $content );
 		$content = $this->remove_entities( $content );

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -23,6 +23,18 @@
 			?>
 		<?php endforeach; ?>
 
+		<?php if ( is_plugin_active( 'brightcove-video-connect/brightcove-video-connect.php' ) ) : ?>
+			<h3><?php esc_html_e( 'Brightcove Support', 'apple-news' ); ?></h3>
+			<p>
+				<?php
+					esc_html_e(
+						'Brightcove support was added in version 2.1.0 for users of the Brightcove Video Connect plugin. However, you will need to contact Apple Support to connect your Brightcove account to your Apple News channel for this feature to work properly.',
+						'apple-news'
+					);
+				?>
+			</p>
+		<?php endif; ?>
+
 		<?php submit_button(); ?>
 	</form>
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -50,6 +50,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Enhancement: The cover component now supports captions. If a featured image is used for the cover, the caption will come from the attachment itself in the database. If the first image from the content is used, the caption will be read from the HTML. There is also a new filter, apple_news_exporter_cover_caption, which allows for filtering of the caption text.
 * Enhancement: HTML is now allowed in lightbox image captions.
 * Enhancement: Allows configuration of cover images in the sidebar / metabox explicitly, rather than pulling them out of the featured image or main content.
+* Enhancement: Adds support for Brightcove videos via the Brightcove Video Connect plugin for videos added via either the Gutenberg block or the shortcode. Note that this feature will only work if you contact Apple support to link your Brightcove account with your Apple News channel.
 * Bugfix: Removes Cover Art configuration, as Cover Art is no longer used by Apple.
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 * Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.


### PR DESCRIPTION
* Adds Brightcove support for users of the Brightcove Video Connect plugin for both the Gutenberg block and the shortcode.
* Note that support requires Apple to connect your Brightcove account to your Apple News channel.