### PR TITLE
APPLE-40 phpcs fixes

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -101,7 +101,7 @@ class Export extends Action {
 		 * Fetch WP_Post object, and all required post information to fill up the
 		 * Exporter_Content instance.
 		 */
-		$post = get_post( $this->id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+		$post = get_post( $this->id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// Only include excerpt if exists.
 		$excerpt = has_excerpt( $post ) ? wp_strip_all_tags( $post->post_excerpt ) : '';

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -390,9 +390,7 @@ class Push extends API_Action {
 		$alert_message = '';
 
 		// Get the current user id.
-		if ( empty( $user_id ) ) {
-			$user_id = get_current_user_id();
-		}
+		$user_id = get_current_user_id();
 
 		// Build the component alert error message, if required.
 		if ( ! empty( $errors[0]['component_errors'] ) ) {

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -85,7 +85,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 	public function build_page() {
 		$ids = isset( $_GET['ids'] ) ? sanitize_text_field( wp_unslash( $_GET['ids'] ) ) : null; // phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.Recommended
 		if ( ! $ids ) {
-			wp_safe_redirect( esc_url_raw( menu_page_url( $this->plugin_slug . '_index', false ) ) );
+			wp_safe_redirect( esc_url_raw( menu_page_url( $this->plugin_slug . '_index', false ) ) ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit
 			if ( ! defined( 'APPLE_NEWS_UNIT_TESTS' ) || ! APPLE_NEWS_UNIT_TESTS ) {
 				exit;
 			}

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -148,7 +148,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 						$ids  = is_array( $_GET['article'] ) ? array_map( 'absint', $_GET['article'] ) : absint( $_GET['article'] ); //  phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.Recommended
 						$url .= '&ids=' . implode( '.', $ids );
 					}
-					wp_safe_redirect( esc_url_raw( $url ) );
+					wp_safe_redirect( esc_url_raw( $url ) ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit
 					if ( ! defined( 'APPLE_NEWS_UNIT_TESTS' ) || ! APPLE_NEWS_UNIT_TESTS ) {
 						exit;
 					}
@@ -189,7 +189,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	 */
 	private function do_redirect() {
 		// Perform the redirect.
-		wp_safe_redirect( esc_url_raw( self::action_query_params( '', menu_page_url( $this->plugin_slug . '_index', false ) ) ) );
+		wp_safe_redirect( esc_url_raw( self::action_query_params( '', menu_page_url( $this->plugin_slug . '_index', false ) ) ) ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit
 		if ( ! defined( 'APPLE_NEWS_UNIT_TESTS' ) || ! APPLE_NEWS_UNIT_TESTS ) {
 			exit;
 		}

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -559,9 +559,9 @@ class Admin_Apple_Themes extends Apple_News {
 		check_admin_referer( $this->valid_actions[ $action ]['nonce'] );
 
 		// Attempt to get the name of the theme from postdata.
-		if ( empty( $name ) && ! empty( $_POST['apple_news_theme'] ) ) {
-			$name = sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) );
-		}
+		$name = ! empty( $_POST['apple_news_theme'] )
+			? sanitize_text_field( wp_unslash( $_POST['apple_news_theme'] ) )
+			: '';
 
 		// Ensure a name was provided.
 		if ( empty( $name ) ) {

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -61,6 +61,7 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		<label for="apple-news-maturity-rating">
 			<select id="apple-news-maturity-rating" name="apple_news_maturity_rating">
 				<option value=""></option>
+				<?php // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.SelfOutsideClass ?>
 				<?php foreach ( self::$maturity_ratings as $apple_rating ) : ?>
 					<option value="<?php echo esc_attr( $apple_rating ); ?>" <?php selected( $maturity_rating, $apple_rating ); ?>><?php echo esc_html( ucwords( strtolower( $apple_rating ) ) ); ?></option>
 				<?php endforeach; ?>

--- a/admin/partials/page-bulk-export.php
+++ b/admin/partials/page-bulk-export.php
@@ -11,10 +11,10 @@
 	<p><?php esc_html_e( "The following articles will be published to Apple News. Once started, it might take a while, please don't close the browser window.", 'apple-news' ); ?></p>
 	<?php do_action( 'apple_news_before_bulk_export_table' ); ?>
 	<ul class="bulk-export-list" data-nonce="<?php echo esc_attr( wp_create_nonce( Admin_Apple_Bulk_Export_Page::ACTION ) ); ?>">
-		<?php foreach ( $articles as $post ) : ?>
-		<li class="bulk-export-list-item" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
+		<?php foreach ( $articles as $apple_post ) : ?>
+		<li class="bulk-export-list-item" data-post-id="<?php echo esc_attr( $apple_post->ID ); ?>">
 			<span class="bulk-export-list-item-title">
-				<?php echo esc_html( $post->post_title ); ?>
+				<?php echo esc_html( $apple_post->post_title ); ?>
 			</span>
 			<span class="bulk-export-list-item-status pending">
 				<?php esc_html_e( 'Pending', 'apple-news' ); ?>

--- a/admin/partials/page-index.php
+++ b/admin/partials/page-index.php
@@ -5,7 +5,7 @@
  * @package Apple_News
  */
 
-$current_screen = get_current_screen(); ?>
+$apple_current_screen = get_current_screen(); ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Apple News', 'apple-news' ); ?></h1>
 	<?php if ( ! \Apple_News::is_initialized() ) : ?>
@@ -22,8 +22,8 @@ $current_screen = get_current_screen(); ?>
 	<?php else : ?>
 		<form method="get">
 			<?php do_action( 'apple_news_before_index_table' ); ?>
-			<?php if ( ! empty( $current_screen->parent_base ) ) : ?>
-			<input type="hidden" name="page" value="<?php echo esc_attr( $current_screen->parent_base ); ?>">
+			<?php if ( ! empty( $apple_current_screen->parent_base ) ) : ?>
+			<input type="hidden" name="page" value="<?php echo esc_attr( $apple_current_screen->parent_base ); ?>">
 			<?php endif; ?>
 			<?php
 				$table->search_box( __( 'Search', 'apple-news' ), 'apple-news-search' );

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -56,11 +56,11 @@
 					<td>
 						<ul class="apple-news-section-taxonomy-mapping-list">
 						<?php if ( ! empty( $taxonomy_mappings[ $apple_section_id ] ) ) : ?>
-							<?php foreach ( $taxonomy_mappings[ $apple_section_id ] as $term ) : ?>
+							<?php foreach ( $taxonomy_mappings[ $apple_section_id ] as $apple_taxonomy_term ) : ?>
 								<?php $apple_taxonomy_id = 'apple-news-section-mapping-' . ( ++ $apple_count ); ?>
 								<li>
 									<label for="<?php echo esc_attr( $apple_taxonomy_id ); ?>" class="screen-reader-text"><?php echo esc_html( $taxonomy->labels->singular_name ); ?></label>
-									<input name="taxonomy-mapping-<?php echo esc_attr( $apple_section_id ); ?>[]" id="<?php echo esc_attr( $apple_taxonomy_id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $term ); ?>" />
+									<input name="taxonomy-mapping-<?php echo esc_attr( $apple_section_id ); ?>[]" id="<?php echo esc_attr( $apple_taxonomy_id ); ?>" type="text" class="apple-news-section-taxonomy-autocomplete" value="<?php echo esc_attr( $apple_taxonomy_term ); ?>" />
 									<button type="button" class="apple-news-section-taxonomy-remove"><span class="apple-news-section-taxonomy-remove-icon" aria-hidden="true"></span><span class="screen-reader-text"><?php esc_html_e( 'Remove mapping', 'apple-news' ); ?></span></button>
 								</li>
 							<?php endforeach; ?>

--- a/admin/partials/page-theme-edit.php
+++ b/admin/partials/page-theme-edit.php
@@ -66,8 +66,8 @@
 				</table>
 			</div>
 			<?php
-				$preview = new Admin_Apple_Preview();
-				$preview->get_preview_html( $theme->get_name() );
+				$apple_preview = new Admin_Apple_Preview();
+				$apple_preview->get_preview_html( $theme->get_name() );
 			?>
 		</div>
 		<p class="apple-news-theme-edit-buttons">

--- a/includes/apple-exporter/autoload.php
+++ b/includes/apple-exporter/autoload.php
@@ -15,7 +15,7 @@ spl_autoload_register(
 		$path = realpath( __DIR__ . '/../' . $path );
 
 		if ( file_exists( $path ) ) {
-			require_once $path;
+			require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		}
 	}
 );

--- a/includes/apple-push-api/autoload.php
+++ b/includes/apple-push-api/autoload.php
@@ -15,7 +15,7 @@ spl_autoload_register(
 		$path = realpath( __DIR__ . '/../' . $path );
 
 		if ( file_exists( $path ) ) {
-			require_once $path;
+			require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		}
 	}
 );

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -255,7 +255,7 @@ class Request {
 
 			// Send the email.
 			if ( ! empty( $body ) ) {
-				wp_mail(
+				wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
 					$admin_email,
 					esc_html__( 'Apple News Notification', 'apple-news' ),
 					$body,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -111,9 +111,6 @@
 	<rule ref="WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout">
 		<severity>0</severity>
 	</rule>
-	<rule ref="WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -117,9 +117,6 @@
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.SelfOutsideClass">
 		<severity>0</severity>
 	</rule>
-	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UndefinedVariable">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,12 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPress.Security.NonceVerification.NoNonceVerification">
-		<severity>0</severity>
-	</rule>
-	<rule ref="WordPressVIPMinimum.Files.IncludingFile.UsingVariable">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,9 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -123,7 +123,4 @@
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>
-  <rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
-    <severity>0</severity>
-  </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -114,9 +114,6 @@
 	<rule ref="WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit">
 		<severity>0</severity>
 	</rule>
-	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.SelfOutsideClass">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>


### PR DESCRIPTION
Re-enable sniffs and address issues for the following:

* WordPress.Security.NonceVerification.NoNonceVerification
* WordPressVIPMinimum.Files.IncludingFile.UsingVariable
* WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
* WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit
* WordPressVIPMinimum.Variables.VariableAnalysis.SelfOutsideClass
* WordPressVIPMinimum.Variables.VariableAnalysis.UndefinedVariable
* WordPress.WP.GlobalVariablesOverride.Prohibited