### PR TITLE
APPLE-7 Add explicit error banner for DATE_NOT_RECENT API error

### DIFF
--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -311,7 +311,7 @@ class Request {
 	 * @param array  $data Optional. Data to send along with the request. Only applies to POST requests.
 	 *
 	 * @return mixed The parsed response from the API.
-	 * @throws Request_Exception
+	 * @throws Request_Exception If the request fails.
 	 */
 	private function request( $verb, $url, $data = [] ) {
 		// If this is a POST request, build the content.
@@ -366,7 +366,7 @@ class Request {
 						\Admin_Apple_Notice::error(
 							__(
 								'The date and time on your server does not match the date and time on the Apple server. All API requests will fail until you synchronize your server clock.',
-							'apple-news'
+								'apple-news'
 							)
 						);
 						break;

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -92,31 +92,16 @@ class Request {
 	 * @throws Request_Exception If the request fails.
 	 */
 	public function post( $url, $article, $bundles = array(), $meta = null, $post_id = null ) {
-		// Assemble the content to send.
-		$content = $this->build_content( $article, $bundles, $meta, $post_id );
-
-		// Build the post request args.
-		$args = array(
-			'headers' => array(
-				'Authorization'  => $this->sign( $url, 'POST', $content ),
-				'Content-Length' => strlen( $content ),
-				'Content-Type'   => 'multipart/form-data; boundary=' . $this->mime_builder->boundary(),
-			),
-			'body'    => $content,
-			'timeout' => 30, // Required because we need to package all images.
+		return $this->request(
+			'POST',
+			$url,
+			[
+				'article' => $article,
+				'bundles' => $bundles,
+				'meta'    => $meta,
+				'post_id' => $post_id,
+			]
 		);
-
-		// Allow filtering and merge with the default args.
-		$args = apply_filters( 'apple_news_post_args', wp_parse_args( $args, $this->default_args ), $post_id );
-
-		// Perform the request.
-		$response = wp_safe_remote_post( esc_url_raw( $url ), $args );
-
-		// Build a debug version of the MIME content for the debug email.
-		$debug_mime_request = $this->mime_builder->get_debug_content( $args );
-
-		// Parse and return the response.
-		return $this->parse_response( $response, true, 'post', $meta, $bundles, $article, $debug_mime_request );
 	}
 
 	/**
@@ -129,27 +114,7 @@ class Request {
 	 * @throws Request_Exception If the request fails.
 	 */
 	public function delete( $url ) {
-		// Build the delete request args.
-		$args = array(
-			'headers' => array(
-				'Authorization' => $this->sign( $url, 'DELETE' ),
-			),
-			'method'  => 'DELETE',
-		);
-
-		// Allow filtering and merge with the default args.
-		$args = apply_filters( 'apple_news_delete_args', wp_parse_args( $args, $this->default_args ) );
-
-		// Perform the delete.
-		$response = wp_safe_remote_request( esc_url_raw( $url ), $args );
-
-		// NULL is a valid response for DELETE.
-		if ( is_null( $response ) ) {
-			return null;
-		}
-
-		// Parse and return the response.
-		return $this->parse_response( $response, true, 'delete' );
+		return $this->request( 'DELETE', $url );
 	}
 
 	/**
@@ -162,21 +127,7 @@ class Request {
 	 * @throws Request_Exception If the request fails.
 	 */
 	public function get( $url ) {
-		// Build the get request args.
-		$args = array(
-			'headers' => array(
-				'Authorization' => $this->sign( $url, 'GET' ),
-			),
-		);
-
-		// Allow filtering and merge with the default args.
-		$args = apply_filters( 'apple_news_get_args', wp_parse_args( $args, $this->default_args ) );
-
-		// Perform the get.
-		$response = wp_safe_remote_get( esc_url_raw( $url ), $args );
-
-		// Parse and return the response.
-		return $this->parse_response( $response, true, 'get' );
+		return $this->request( 'GET', $url );
 	}
 
 	/**
@@ -350,6 +301,96 @@ class Request {
 		$content .= $this->mime_builder->close();
 
 		return $content;
+	}
+
+	/**
+	 * A generic request method for handling requests to the API.
+	 *
+	 * @param string $verb The HTTP verb to use. One of GET, POST, DELETE.
+	 * @param string $url  The URL against which to make the request.
+	 * @param array  $data Optional. Data to send along with the request. Only applies to POST requests.
+	 *
+	 * @return mixed The parsed response from the API.
+	 * @throws Request_Exception
+	 */
+	private function request( $verb, $url, $data = [] ) {
+		// If this is a POST request, build the content.
+		$content = 'POST' === $verb
+			? $this->build_content( $data['article'], $data['bundles'], $data['meta'], $data['post_id'] )
+			: null;
+
+		// Build the request args.
+		$args = array(
+			'headers' => array(
+				'Authorization' => $this->sign( $url, $verb, $content ),
+			),
+			'method'  => $verb,
+		);
+
+		// If this is a POST request, add the content to it.
+		if ( 'POST' === $verb ) {
+			$args['headers']['Content-Length'] = strlen( $content );
+			$args['headers']['Content-Type']   = 'multipart/form-data; boundary=' . $this->mime_builder->boundary();
+			$args['body']                      = $content;
+			$args['timeout']                   = 30; // Required because we need to package and send all images.
+		}
+
+		/**
+		 * Allow filtering of the default arguments for the request.
+		 *
+		 * The verb will be dynamically inserted in the hook name, so this hook
+		 * will support the following permutations:
+		 *
+		 *    apple_news_delete_args
+		 *    apple_news_get_args
+		 *    apple_news_post_args
+		 *
+		 * @param array $args    Arguments to be filtered.
+		 * @param int   $post_id The post ID, if this is a POST request.
+		 */
+		$args = apply_filters(
+			'apple_news_' . strtolower( $verb ) . '_args',
+			wp_parse_args( $args, $this->default_args ),
+			! empty( $data['post_id'] ) ? $data['post_id'] : 0
+		);
+
+		// Perform the request.
+		$response = wp_safe_remote_request( esc_url_raw( $url ), $args );
+
+		// Check for DATE_NOT_RECENT error and add a warning for it explicitly.
+		if ( ! empty( $response['body'] ) && false !== strpos( $response['body'], 'DATE_NOT_RECENT' ) ) {
+			$response_body = json_decode( $response['body'], true );
+			if ( ! empty( $response_body['errors'] ) && is_array( $response_body['errors'] ) ) {
+				foreach ( $response_body['errors'] as $error ) {
+					if ( ! empty( $error['code'] ) && 'DATE_NOT_RECENT' === $error['code'] ) {
+						\Admin_Apple_Notice::error(
+							__(
+								'The date and time on your server does not match the date and time on the Apple server. All API requests will fail until you synchronize your server clock.',
+							'apple-news'
+							)
+						);
+						break;
+					}
+				}
+			}
+		}
+		// NULL is a valid response for DELETE.
+		if ( 'DELETE' === $verb && is_null( $response ) ) {
+			return null;
+		}
+
+		// Parse the response.
+		$response = $this->parse_response(
+			$response,
+			true,
+			strtolower( $verb ),
+			! empty( $data['meta'] ) ? $data['meta'] : null,
+			! empty( $data['bundles'] ) ? $data['bundles'] : null,
+			! empty( $data['article'] ) ? $data['article'] : '',
+			'POST' === $verb ? $this->mime_builder->get_debug_content( $args ) : ''
+		);
+
+		return $response;
 	}
 
 	/**

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -374,6 +374,7 @@ class Request {
 				}
 			}
 		}
+
 		// NULL is a valid response for DELETE.
 		if ( 'DELETE' === $verb && is_null( $response ) ) {
 			return null;

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Enhancement: Allows configuration of cover images in the sidebar / metabox explicitly, rather than pulling them out of the featured image or main content.
 * Enhancement: Adds support for Brightcove videos via the Brightcove Video Connect plugin for videos added via either the Gutenberg block or the shortcode. Note that this feature will only work if you contact Apple support to link your Brightcove account with your Apple News channel.
 * Enhancement: Replaces usage of the deprecated `advertisingSettings` object with the new `autoplacement.advertising` object. Bumps default advertisement frequency from 1 to 5 (out of 10).
+* Enhancement: Adds an error to the notice bar if the `DATE_NOT_RECENT` API error is encountered advising the user to synchronize the time on their server to restore API connectivity.
 * Bugfix: Removes Cover Art configuration, as Cover Art is no longer used by Apple.
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 * Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.


### PR DESCRIPTION
We frequently get issue reports from users where API requests from the plugin have failed due to the server clock being out of sync with an NTP server, and the request failing Apple's API validation system, which uses the timestamp of the request as one of its checks. If the time is off by more than 5 minutes, Apple will reject the request with an error of `DATE_NOT_RECENT`.

This specific error can be hard to track down. Not all error messages generated by Apple News for which this error could be a cause specify that this error in particular caused the failure to publish (or anything else happening over the API). In particular, sometimes the error with publishing is actually due to the plugin's inability to fetch a list of sections before preparing the data to publish the article. This change does two things:

1. Centralizes all API requests through a single private method (`request`). The `delete`, `get`, and `post` methods all use the new `request` method to send their requests to the API and receive the response. This not only cuts down on a lot of duplicated code, it also allows us a mechanism by which to check the error code from the API and take an action.
2. If an error code of `DATE_NOT_RECENT` was returned by the API, a new error is added, which is visible on all Apple News screens, indicating the cause of the error and a (generic) method of resolution. The specific method of resolution is going to be different from server to server.

Ideally, this message either cuts down on issue reports due to this error, or makes those issue reports more targeted (e.g., I'm getting this message and don't know how to resolve it).