### PR TITLE
APPLE-7 Upgrade advertisement settings definition, set default frequency to 5

### DIFF
--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -51,7 +51,7 @@
 				sprintf(
 					// translators: first argument is an opening <a> tag, second argument is </a>.
 					__( 'For more information on the Apple News format options for each component, please read the %1$sApple News Format Reference%2$s.', 'apple-news' ),
-					'<a href="https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/Component.html#//apple_ref/doc/uid/TP40015408-CH5-SW1">',
+					'<a href="https://developer.apple.com/documentation/apple_news/apple_news_format">',
 					'</a>'
 				),
 				array(

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -58,7 +58,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'description' => sprintf(
 					// Translators: Placeholder 1 is an opening <a> tag, placeholder 2 is </a>.
 					__( 'If set to no, certain text fields will use Markdown instead of %1$sApple News HTML format%2$s. As of version 1.4.0, HTML format is the preferred output format. Support for Markdown may be removed in the future.', 'apple-news' ),
-					'<a href="' . esc_url( 'https://developer.apple.com/library/content/documentation/General/Conceptual/Apple_News_Format_Ref/HTMLMarkupforAppleNewsFormat.html' ) . '">',
+					'<a href="' . esc_url( 'https://developer.apple.com/documentation/apple_news/apple_news_format/components/using_html_with_apple_news_format' ) . '">',
 					'</a>'
 				),
 			),

--- a/assets/themes/classic.json
+++ b/assets/themes/classic.json
@@ -1,5 +1,5 @@
 {
-    "ad_frequency": 1,
+    "ad_frequency": 5,
     "ad_margin": 15,
     "blockquote_background_color": "#d3d3d3",
     "blockquote_border_color": "#000000",

--- a/assets/themes/colorful.json
+++ b/assets/themes/colorful.json
@@ -1,5 +1,5 @@
 {
-    "ad_frequency": 1,
+    "ad_frequency": 5,
     "ad_margin": 15,
     "blockquote_background_color": "#ffff00",
     "blockquote_border_color": "#3045ca",

--- a/assets/themes/dark.json
+++ b/assets/themes/dark.json
@@ -1,5 +1,5 @@
 {
-    "ad_frequency": 1,
+    "ad_frequency": 5,
     "ad_margin": 15,
     "blockquote_background_color": "",
     "blockquote_border_color": "#ffe890",

--- a/assets/themes/default.json
+++ b/assets/themes/default.json
@@ -1,5 +1,5 @@
 {
-    "ad_frequency": 1,
+    "ad_frequency": 5,
     "ad_margin": 15,
     "blockquote_background_color": "#e1e1e1",
     "blockquote_border_color": "#4f4f4f",

--- a/assets/themes/modern.json
+++ b/assets/themes/modern.json
@@ -1,5 +1,5 @@
 {
-    "ad_frequency": 1,
+    "ad_frequency": 5,
     "ad_margin": 15,
     "blockquote_background_color": "#e6f7ff",
     "blockquote_border_color": "#30bcff",

--- a/assets/themes/pastel.json
+++ b/assets/themes/pastel.json
@@ -1,5 +1,5 @@
 {
-    "ad_frequency": 1,
+    "ad_frequency": 5,
     "ad_margin": 15,
     "blockquote_background_color": "#ffebe0",
     "blockquote_border_color": "#ffffff",

--- a/includes/apple-exporter/builders/class-advertising-settings.php
+++ b/includes/apple-exporter/builders/class-advertising-settings.php
@@ -47,6 +47,23 @@ class Advertising_Settings extends Builder {
 			}
 		}
 
-		return apply_filters( 'apple_news_advertising_settings', $advertising_settings, $this->content_id() );
+		/**
+		 * Filters the advertisement settings.
+		 *
+		 * @since 0.4.0
+		 *
+		 * @param array $advertising_settings The advertising settings to be modified.
+		 */
+		$advertising_settings = apply_filters( 'apple_news_advertising_settings', $advertising_settings, $this->content_id() );
+
+		// If there are no advertising settings, bail out.
+		if ( empty( $advertising_settings ) ) {
+			return [];
+		}
+
+		// Wrap the advertising settings in the advertisement key.
+		return [
+			'advertisement' => $advertising_settings,
+		];
 	}
 }

--- a/includes/apple-exporter/builders/class-advertising-settings.php
+++ b/includes/apple-exporter/builders/class-advertising-settings.php
@@ -21,7 +21,7 @@ class Advertising_Settings extends Builder {
 	 * @access protected
 	 */
 	protected function build() {
-		$advertising_settings = array();
+		$advertising_settings = [];
 
 		// Get advertising settings from the theme.
 		$theme                = \Apple_Exporter\Theme::get_used();
@@ -29,15 +29,21 @@ class Advertising_Settings extends Builder {
 		$ad_frequency         = intval( $theme->get_value( 'ad_frequency' ) );
 
 		if ( 'yes' === $enable_advertisement && $ad_frequency > 0 ) {
-			$advertising_settings['frequency'] = $ad_frequency;
-			$ad_margin                         = intval( $theme->get_value( 'ad_margin' ) );
+
+			// Build basic advertisement configuration settings.
+			$advertising_settings = [
+				'bannerType'        => 'any',
+				'distanceFromMedia' => '10vh',
+				'enabled'           => true,
+				'frequency'         => $ad_frequency,
+			];
+
+			// Add the ad margin, if defined.
+			$ad_margin = intval( $theme->get_value( 'ad_margin' ) );
 			if ( ! empty( $ad_margin ) ) {
-				$advertising_settings['layout'] = array(
-					'margin' => array(
-						'top'    => $ad_margin,
-						'bottom' => $ad_margin,
-					),
-				);
+				$advertising_settings['layout'] = [
+					'margin' => $ad_margin,
+				];
 			}
 		}
 

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -92,7 +92,7 @@ class Exporter {
 			$this->register_builder( 'textStyles', new Builders\Text_Styles( $this->content, $this->settings ) );
 			$this->register_builder( 'componentLayouts', new Builders\Component_Layouts( $this->content, $this->settings ) );
 			$this->register_builder( 'metadata', new Builders\Metadata( $this->content, $this->settings ) );
-			$this->register_builder( 'advertisingSettings', new Builders\Advertising_Settings( $this->content, $this->settings ) );
+			$this->register_builder( 'autoplacement', new Builders\Advertising_Settings( $this->content, $this->settings ) );
 		}
 
 		Component_Factory::initialize(

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -556,7 +556,7 @@ class Theme {
 		self::$options = array(
 			'ad_frequency'                      => array(
 				'default'     => 5,
-				'description' => __( 'A number between 1 and 10 defining the frequency for automatically inserting Banner Advertisement components into articles. For more information, see the <a href="https://developer.apple.com/library/ios/documentation/General/Conceptual/Apple_News_Format_Ref/AdvertisingSettings.html#//apple_ref/doc/uid/TP40015408-CH93-SW1" target="_blank">Apple News Format Reference</a>.', 'apple-news' ),
+				'description' => __( 'A number between 1 and 10 defining the frequency for automatically inserting dynamic advertisements into articles. For more information, see the <a href="https://developer.apple.com/documentation/apple_news/advertisementautoplacement" target="_blank">Apple News Format Reference</a>.', 'apple-news' ),
 				'label'       => __( 'Ad Frequency', 'apple-news' ),
 				'type'        => 'integer',
 			),

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -555,7 +555,7 @@ class Theme {
 	private static function initialize_options() {
 		self::$options = array(
 			'ad_frequency'                      => array(
-				'default'     => 1,
+				'default'     => 5,
 				'description' => __( 'A number between 1 and 10 defining the frequency for automatically inserting Banner Advertisement components into articles. For more information, see the <a href="https://developer.apple.com/library/ios/documentation/General/Conceptual/Apple_News_Format_Ref/AdvertisingSettings.html#//apple_ref/doc/uid/TP40015408-CH93-SW1" target="_blank">Apple News Format Reference</a>.', 'apple-news' ),
 				'label'       => __( 'Ad Frequency', 'apple-news' ),
 				'type'        => 'integer',

--- a/includes/apple-exporter/components/class-facebook.php
+++ b/includes/apple-exporter/components/class-facebook.php
@@ -21,7 +21,7 @@ class Facebook extends Component {
 	/**
 	 * A list of regular expression patterns for allowlisted Facebook oEmbed formats.
 	 *
-	 * @see https://developer.apple.com/library/prerelease/content/documentation/General/Conceptual/Apple_News_Format_Ref/FacebookPost.html#//apple_ref/doc/uid/TP40015408-CH106-SW1
+	 * @see https://developer.apple.com/documentation/apple_news/facebookpost
 	 * @see https://developers.facebook.com/docs/plugins/oembed-endpoints/
 	 */
 	const FACEBOOK_MATCH = '/(?:https?:\/\/)?(?:www\.)?(?:facebook|fb|m\.facebook)\.(?:com|me)\/(?:(?:\w)*#!\/)?(?:pages\/)?(?:[\w\-]*\/)*([\w\-\.]+)(?:\/)?/i';

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Enhancement: HTML is now allowed in lightbox image captions.
 * Enhancement: Allows configuration of cover images in the sidebar / metabox explicitly, rather than pulling them out of the featured image or main content.
 * Enhancement: Adds support for Brightcove videos via the Brightcove Video Connect plugin for videos added via either the Gutenberg block or the shortcode. Note that this feature will only work if you contact Apple support to link your Brightcove account with your Apple News channel.
+* Enhancement: Replaces usage of the deprecated `advertisingSettings` object with the new `autoplacement.advertising` object. Bumps default advertisement frequency from 1 to 5 (out of 10).
 * Bugfix: Removes Cover Art configuration, as Cover Art is no longer used by Apple.
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 * Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -6,8 +6,6 @@
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/../../../class-apple-news-testcase.php';
-
 use \Apple_Actions\Index\Export as Export;
 
 /**

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -1,13 +1,22 @@
 <?php
+/**
+ * Publish to Apple News tests: Admin_Action_Index_Export_Test class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+require_once __DIR__ . '/../../../class-apple-news-testcase.php';
 
 use \Apple_Actions\Index\Export as Export;
-use \Apple_Exporter\Settings as Settings;
 
-class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
-
-	public function setup() {
-		$this->settings = new Settings();
-	}
+/**
+ * A class to test the functionality of the Apple_Actions\Index\Export class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 
 	/**
 	 * Returns an array of arrays representing function arguments to the
@@ -42,14 +51,12 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 	 * @dataProvider dataProviderBrightcoveVideo
 	 */
 	public function testBrightcoveVideo( $post_content ) {
-		$post_id  = self::factory()->post->create(
+		$post_id = self::factory()->post->create(
 			[
 				'post_content' => $post_content,
 			]
 		);
-		$sections = \Admin_Apple_Sections::get_sections_for_post( $post_id );
-		$export   = new Export( $this->settings, $post_id, $sections );
-		$json     = json_decode( $export->perform(), true );
+		$json    = $this->get_json_for_post( $post_id );
 		$this->assertEquals( 'video', $json['components'][3]['role'] );
 		$this->assertEquals( 'https://edge.api.brightcove.com/playback/v1/accounts/1234567890/videos/1234567890123', $json['components'][3]['URL'] );
 	}
@@ -73,9 +80,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		update_post_meta( $post_id, '_thumbnail_id', $image );
 
 		// Run the export and check the result.
-		$sections = \Admin_Apple_Sections::get_sections_for_post( $post_id );
-		$export   = new Export( $this->settings, $post_id, $sections );
-		$json     = json_decode( $export->perform(), true );
+		$json = $this->get_json_for_post( $post_id );
 		$this->assertEquals( 'photo', $json['components'][0]['components'][0]['role'] );
 		$this->assertEquals( wp_get_attachment_url( $image ), $json['components'][0]['components'][0]['URL'] );
 		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][0]['caption']['text'] );
@@ -86,8 +91,7 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		$image2 = self::factory()->attachment->create_upload_object( $file );
 		update_post_meta( $post_id, 'apple_news_coverimage', $image2 );
 		update_post_meta( $post_id, 'apple_news_coverimage_caption', 'Test Caption 2' );
-		$export   = new Export( $this->settings, $post_id, $sections );
-		$json     = json_decode( $export->perform(), true );
+		$json = $this->get_json_for_post( $post_id );
 		$this->assertEquals( 'photo', $json['components'][0]['components'][0]['role'] );
 		$this->assertEquals( wp_get_attachment_url( $image2 ), $json['components'][0]['components'][0]['URL'] );
 		$this->assertEquals( 'Test Caption 2', $json['components'][0]['components'][0]['caption']['text'] );
@@ -343,15 +347,10 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		);
 
 		// Get sections for the post.
-		$sections = \Admin_Apple_Sections::get_sections_for_post( $post_id );
-		$export = new Export( $this->settings, $post_id, $sections );
-		$exporter = $export->fetch_exporter();
-		$exporter->generate();
-		$json = $exporter->get_json();
-		$settings = json_decode( $json );
+		$json = $this->get_json_for_post( $post_id );
 
 		$this->assertEquals(
-			$settings->componentTextStyles->dropcapBodyStyle->textColor,
+			$json['componentTextStyles']['dropcapBodyStyle']['textColor'],
 			$test_settings['body_color']
 		);
 
@@ -388,12 +387,10 @@ class Admin_Action_Index_Export_Test extends WP_UnitTestCase {
 		);
 
 		// Get sections for the post.
-		$sections = \Admin_Apple_Sections::get_sections_for_post( $post_id );
-		$export = new Export( $this->settings, $post_id, $sections );
-		$json = json_decode( $export->perform() );
+		$json = $this->get_json_for_post( $post_id );
 		$this->assertEquals(
 			'<p>is exporting</p>',
-			$json->components[3]->text
+			$json['components'][3]['text']
 		);
 
 		// Ensure is_exporting returns false after exporting.

--- a/tests/apple-exporter/builders/test-class-advertising-settings.php
+++ b/tests/apple-exporter/builders/test-class-advertising-settings.php
@@ -22,12 +22,18 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 	 */
 	public function testDefaultAdSettings() {
 		$builder = new Advertising_Settings( $this->content, $this->content_settings );
-		$result = $builder->to_array();
-		$this->assertEquals( 2, count( $result ) );
-		$this->assertEquals( 5, $result['frequency'] );
-		$this->assertEquals( 1, count( $result['layout'] ) );
-		$this->assertEquals( 15, $result['layout']['margin']['top'] );
-		$this->assertEquals( 15, $result['layout']['margin']['bottom'] );
+		$this->assertEquals(
+			[
+				'bannerType'        => 'any',
+				'distanceFromMedia' => '10vh',
+				'enabled'           => true,
+				'frequency'         => 5,
+				'layout'            => [
+					'margin'          => 15,
+				],
+			],
+			$builder->to_array()
+		);
 	}
 
 	/**
@@ -60,12 +66,18 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 
 		// Test.
 		$builder = new Advertising_Settings( $this->content, $this->content_settings );
-		$result  = $builder->to_array();
-		$this->assertEquals( 2, count( $result ) );
-		$this->assertEquals( 10, $result['frequency'] );
-		$this->assertEquals( 1, count( $result['layout'] ) );
-		$this->assertEquals( 15, $result['layout']['margin']['top'] );
-		$this->assertEquals( 15, $result['layout']['margin']['bottom'] );
+		$this->assertEquals(
+			[
+				'bannerType'        => 'any',
+				'distanceFromMedia' => '10vh',
+				'enabled'           => true,
+				'frequency'         => 10,
+				'layout'            => [
+					'margin'          => 15,
+				],
+			],
+			$builder->to_array()
+		);
 	}
 
 	/**
@@ -81,11 +93,17 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 
 		// Test.
 		$builder = new Advertising_Settings( $this->content, $this->content_settings );
-		$result  = $builder->to_array();
-		$this->assertEquals( 2, count( $result ) );
-		$this->assertEquals( 5, $result['frequency'] );
-		$this->assertEquals( 1, count( $result['layout'] ) );
-		$this->assertEquals( 20, $result['layout']['margin']['top'] );
-		$this->assertEquals( 20, $result['layout']['margin']['bottom'] );
+		$this->assertEquals(
+			[
+				'bannerType'        => 'any',
+				'distanceFromMedia' => '10vh',
+				'enabled'           => true,
+				'frequency'         => 5,
+				'layout'            => [
+					'margin'          => 20,
+				],
+			],
+			$builder->to_array()
+		);
 	}
 }

--- a/tests/apple-exporter/builders/test-class-advertising-settings.php
+++ b/tests/apple-exporter/builders/test-class-advertising-settings.php
@@ -24,12 +24,14 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$this->assertEquals(
 			[
-				'bannerType'        => 'any',
-				'distanceFromMedia' => '10vh',
-				'enabled'           => true,
-				'frequency'         => 5,
-				'layout'            => [
-					'margin'          => 15,
+				'advertisement' => [
+					'bannerType'        => 'any',
+					'distanceFromMedia' => '10vh',
+					'enabled'           => true,
+					'frequency'         => 5,
+					'layout'            => [
+						'margin'          => 15,
+					],
 				],
 			],
 			$builder->to_array()
@@ -68,12 +70,14 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$this->assertEquals(
 			[
-				'bannerType'        => 'any',
-				'distanceFromMedia' => '10vh',
-				'enabled'           => true,
-				'frequency'         => 10,
-				'layout'            => [
-					'margin'          => 15,
+				'advertisement' => [
+					'bannerType'        => 'any',
+					'distanceFromMedia' => '10vh',
+					'enabled'           => true,
+					'frequency'         => 10,
+					'layout'            => [
+						'margin'          => 15,
+					],
 				],
 			],
 			$builder->to_array()
@@ -95,15 +99,39 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$this->assertEquals(
 			[
-				'bannerType'        => 'any',
-				'distanceFromMedia' => '10vh',
-				'enabled'           => true,
-				'frequency'         => 5,
-				'layout'            => [
-					'margin'          => 20,
+				'advertisement' => [
+					'bannerType'        => 'any',
+					'distanceFromMedia' => '10vh',
+					'enabled'           => true,
+					'frequency'         => 5,
+					'layout'            => [
+						'margin'          => 20,
+					],
 				],
 			],
 			$builder->to_array()
+		);
+	}
+
+	/**
+	 * Tests the article-level automatic advertisement settings.
+	 */
+	public function testAutoplacement() {
+		$post_id = self::factory()->post->create();
+		$json    = $this->get_json_for_post( $post_id );
+		$this->assertEquals(
+			[
+				'advertisement' => [
+					'bannerType'        => 'any',
+					'distanceFromMedia' => '10vh',
+					'enabled'           => true,
+					'frequency'         => 5,
+					'layout'            => [
+						'margin'          => 15,
+					],
+				],
+			],
+			$json['autoplacement']
 		);
 	}
 }

--- a/tests/apple-exporter/builders/test-class-advertising-settings.php
+++ b/tests/apple-exporter/builders/test-class-advertising-settings.php
@@ -1,10 +1,23 @@
 <?php
+/**
+ * Publish to Apple News tests: Test_Class_Advertising_Settings class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
 use Apple_Exporter\Exporter_Content as Exporter_Content;
 use Apple_Exporter\Settings as Settings;
 use Apple_Exporter\Builders\Advertising_Settings as Advertising_Settings;
 
-class Test_Class_Advertising_Settings extends WP_UnitTestCase {
+/**
+ * A class to test the behavior of the
+ * Apple_Exporter\Builders\Advertising_Settings class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 
 	public function setup() {
 		$themes = new Admin_Apple_Themes;

--- a/tests/apple-exporter/builders/test-class-advertising-settings.php
+++ b/tests/apple-exporter/builders/test-class-advertising-settings.php
@@ -6,9 +6,7 @@
  * @subpackage Tests
  */
 
-use Apple_Exporter\Exporter_Content as Exporter_Content;
-use Apple_Exporter\Settings as Settings;
-use Apple_Exporter\Builders\Advertising_Settings as Advertising_Settings;
+use Apple_Exporter\Builders\Advertising_Settings;
 
 /**
  * A class to test the behavior of the
@@ -19,29 +17,11 @@ use Apple_Exporter\Builders\Advertising_Settings as Advertising_Settings;
  */
 class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 
-	public function setup() {
-		$themes = new Admin_Apple_Themes;
-		$themes->setup_theme_pages();
-		$this->theme = new \Apple_Exporter\Theme;
-		$this->theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
-		$this->theme->load();
-		$this->settings = new Settings();
-		$this->content = new Exporter_Content( 1, 'My Title', '<p>Hello, World!</p>' );
-	}
-
 	/**
-	 * Cleanup to be run after every execution.
-	 *
-	 * @access public
+	 * Tests the default advertising settings.
 	 */
-	public function tearDown() {
-		$this->theme = new \Apple_Exporter\Theme;
-		$this->theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
-		$this->assertTrue( $this->theme->save() );
-	}
-
 	public function testDefaultAdSettings() {
-		$builder = new Advertising_Settings( $this->content, $this->settings );
+		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$result = $builder->to_array();
 		$this->assertEquals( 2, count( $result ) );
 		$this->assertEquals( 5, $result['frequency'] );
@@ -50,6 +30,9 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 		$this->assertEquals( 15, $result['layout']['margin']['bottom'] );
 	}
 
+	/**
+	 * Tests the behavior of the component when advertisements are disabled.
+	 */
 	public function testNoAds() {
 
 		// Setup.
@@ -59,29 +42,35 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 		$this->assertTrue( $this->theme->save() );
 
 		// Test.
-		$builder = new Advertising_Settings( $this->content, $this->settings );
+		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$result = $builder->to_array();
 		$this->assertEquals( 0, count( $result ) );
 	}
 
+	/**
+	 * Tests the ability to customize ad frequency.
+	 */
 	public function testCustomAdFrequency() {
 
 		// Setup.
 		$settings = $this->theme->all_settings();
-		$settings['ad_frequency'] = 5;
+		$settings['ad_frequency'] = 10;
 		$this->theme->load( $settings );
 		$this->assertTrue( $this->theme->save() );
 
 		// Test.
-		$builder = new Advertising_Settings( $this->content, $this->settings );
+		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$result  = $builder->to_array();
 		$this->assertEquals( 2, count( $result ) );
-		$this->assertEquals( 5, $result['frequency'] );
+		$this->assertEquals( 10, $result['frequency'] );
 		$this->assertEquals( 1, count( $result['layout'] ) );
 		$this->assertEquals( 15, $result['layout']['margin']['top'] );
 		$this->assertEquals( 15, $result['layout']['margin']['bottom'] );
 	}
 
+	/**
+	 * Tests the ability to customize the ad margin.
+	 */
 	public function testCustomAdMargin() {
 
 		// Setup.
@@ -91,7 +80,7 @@ class Test_Class_Advertising_Settings extends Apple_News_Testcase {
 		$this->assertTrue( $this->theme->save() );
 
 		// Test.
-		$builder = new Advertising_Settings( $this->content, $this->settings );
+		$builder = new Advertising_Settings( $this->content, $this->content_settings );
 		$result  = $builder->to_array();
 		$this->assertEquals( 2, count( $result ) );
 		$this->assertEquals( 5, $result['frequency'] );

--- a/tests/apple-exporter/builders/test-class-advertising-settings.php
+++ b/tests/apple-exporter/builders/test-class-advertising-settings.php
@@ -31,7 +31,7 @@ class Test_Class_Advertising_Settings extends WP_UnitTestCase {
 		$builder = new Advertising_Settings( $this->content, $this->settings );
 		$result = $builder->to_array();
 		$this->assertEquals( 2, count( $result ) );
-		$this->assertEquals( 1, $result['frequency'] );
+		$this->assertEquals( 5, $result['frequency'] );
 		$this->assertEquals( 1, count( $result['layout'] ) );
 		$this->assertEquals( 15, $result['layout']['margin']['top'] );
 		$this->assertEquals( 15, $result['layout']['margin']['bottom'] );
@@ -81,7 +81,7 @@ class Test_Class_Advertising_Settings extends WP_UnitTestCase {
 		$builder = new Advertising_Settings( $this->content, $this->settings );
 		$result  = $builder->to_array();
 		$this->assertEquals( 2, count( $result ) );
-		$this->assertEquals( 1, $result['frequency'] );
+		$this->assertEquals( 5, $result['frequency'] );
 		$this->assertEquals( 1, count( $result['layout'] ) );
 		$this->assertEquals( 20, $result['layout']['margin']['top'] );
 		$this->assertEquals( 20, $result['layout']['margin']['bottom'] );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,3 +31,5 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 tests_add_filter( 'apple_news_block_editor_is_active', '__return_false' );
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+require_once __DIR__ . '/class-apple-news-testcase.php';

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Publish to Apple News tests: Apple_News_Testcase class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+/**
+ * A base class for Apple News tests.
+ *
+ * @package Apple_News
+ */
+abstract class Apple_News_Testcase extends WP_UnitTestCase {
+
+	/**
+	 * Contains an instance of the Apple_Exporter\Settings class for use in tests.
+	 *
+	 * @var Apple_Exporter\Settings
+	 */
+	protected $settings;
+
+	/**
+	 * A function containing operations to be run before each test function.
+	 *
+	 * @access public
+	 */
+	public function setUp() {
+		parent::setup();
+		$this->settings = new Apple_Exporter\Settings();
+	}
+
+	/**
+	 * A helper function that generates JSON for a given post ID.
+	 *
+	 * @param int $post_id The for which to perform the export.
+	 *
+	 * @return array The JSON for the post, converted to an associative array.
+	 */
+	protected function get_json_for_post( $post_id ) {
+		$export = new Apple_Actions\Index\Export(
+			$this->settings,
+			$post_id,
+			Admin_Apple_Sections::get_sections_for_post( $post_id )
+		);
+
+		return json_decode( $export->perform(), true );
+	}
+}

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -14,11 +14,32 @@
 abstract class Apple_News_Testcase extends WP_UnitTestCase {
 
 	/**
+	 * Contains an instance of the Apple_Exporter\Exporter_Content class for use in tests.
+	 *
+	 * @var Apple_Exporter\Exporter_Content
+	 */
+	protected $content;
+
+	/**
+	 * Contains an instance of the Apple_Exporter\Exporter_Content_Settings class for use in tests.
+	 *
+	 * @var Apple_Exporter\Exporter_Content_Settings
+	 */
+	protected $content_settings;
+
+	/**
 	 * Contains an instance of the Apple_Exporter\Settings class for use in tests.
 	 *
 	 * @var Apple_Exporter\Settings
 	 */
 	protected $settings;
+
+	/**
+	 * Contains an instance of the Apple_Exporter\Theme class for use in tests.
+	 *
+	 * @var Apple_Exporter\Theme
+	 */
+	protected $theme;
 
 	/**
 	 * A function containing operations to be run before each test function.
@@ -27,7 +48,24 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setup();
+
+		// Create some dummy content and save it for future use.
+		$this->content = new Apple_Exporter\Exporter_Content(
+			1,
+			'My Title',
+			'<p>Hello, World!</p>'
+		);
+
+		// Create a new instance of the Settings object and save it for future use.
 		$this->settings = new Apple_Exporter\Settings();
+
+		// Create a new instance of the Exporter_Content_Settings object and save it for future use.
+		$this->content_settings = new Apple_Exporter\Exporter_Content_Settings();
+
+		// Create a new theme and save it for future use.
+		$this->theme = new Apple_Exporter\Theme();
+		$this->theme->save();
+		$this->theme->set_active();
 	}
 
 	/**

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -8,8 +8,6 @@
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-apple-news-testcase.php';
-
 /**
  * A class which is used to test the Apple_News class.
  *

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -8,22 +8,14 @@
  * @subpackage Tests
  */
 
-use \Apple_Exporter\Settings;
+require_once __DIR__ . '/class-apple-news-testcase.php';
 
 /**
  * A class which is used to test the Apple_News class.
+ *
+ * @package Apple_News
  */
-class Apple_News_Test extends WP_UnitTestCase {
-
-	/**
-	 * A function containing operations to be run before each test function.
-	 *
-	 * @access public
-	 */
-	public function setUp() {
-		parent::setup();
-		$this->settings = new Settings();
-	}
+class Apple_News_Test extends Apple_News_Testcase {
 
 	/**
 	 * Ensures that the get_filename function properly returns an image filename.


### PR DESCRIPTION
* Update the definition of advertisement settings from the deprecated `advertisingSettings` to the new `autoplacement.advertisement` setting.
* Bump the default advertisement frequency from 1 to 5 everywhere.
* Create a new abstract test class to house commonly-used setup functions and test data as well as a new function to make the process of exporting an article from the database via a post ID significantly easier. Begins the process of converting test classes to this new abstract class base.
* Update references to Apple documentation to use the correct URLs.