### PR TITLE
APPLE-7 Final phpcs fixes for version 2.1.0

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -252,7 +252,7 @@ class Export extends Action {
 			preg_match( '/#(.*?)#/', $byline, $matches );
 			if ( ! empty( $matches[1] ) && ! empty( $date ) ) {
 				// Set the date using the custom format.
-				$byline = str_replace( $matches[0], date( $matches[1], strtotime( $date ) ), $byline );
+				$byline = str_replace( $matches[0], apple_news_date( $matches[1], strtotime( $date ) ), $byline );
 			}
 
 			// Replace the temporary placeholder with the actual byline.
@@ -263,7 +263,7 @@ class Export extends Action {
 			$byline = sprintf(
 				'by %1$s | %2$s',
 				$author,
-				date( $date_format, strtotime( $date ) )
+				apple_news_date( $date_format, strtotime( $date ) )
 			);
 		}
 

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -55,9 +55,7 @@ class Export extends Action {
 		parent::__construct( $settings );
 		$this->set_theme( $sections );
 		$this->id = $id;
-
-		// Assign instance of an active Jetpack tiled gallery installation.
-		$jetpack_tiled_gallery = Jetpack_Tiled_Gallery::instance();
+		Jetpack_Tiled_Gallery::instance();
 	}
 
 	/**

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -97,6 +97,8 @@ class Admin_Apple_Index_Page extends Apple_News {
 
 		switch ( $action ) {
 			case self::namespace_action( 'push' ):
+				/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+
 				$section = new Apple_Actions\Index\Section( $this->settings );
 				try {
 					$sections = $section->get_sections();
@@ -106,6 +108,9 @@ class Admin_Apple_Index_Page extends Apple_News {
 
 				$post      = get_post( $id );
 				$post_meta = get_post_meta( $id );
+
+				/* phpcs:enable */
+
 				include plugin_dir_path( __FILE__ ) . 'partials/page-single-push.php';
 				break;
 			default:
@@ -368,8 +373,6 @@ class Admin_Apple_Index_Page extends Apple_News {
 
 		// Save fields.
 		\Admin_Apple_Meta_Boxes::save_post_meta( $id );
-
-		$message = __( 'Settings saved.', 'apple-news' );
 
 		// Push the post.
 		$action = new Apple_Actions\Index\Push( $this->settings, $id );

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -165,6 +165,8 @@ class Admin_Apple_JSON extends Apple_News {
 			wp_die( esc_html__( 'You do not have permissions to access this page.', 'apple-news' ) );
 		}
 
+		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+
 		// Get components for the dropdown.
 		$components = $this->list_components();
 
@@ -185,6 +187,8 @@ class Admin_Apple_JSON extends Apple_News {
 		$specs = ( ! empty( $selected_component ) )
 			? $this->get_specs( $selected_component )
 			: array();
+
+		/* phpcs:enable */
 
 		// Load the template.
 		include plugin_dir_path( __FILE__ ) . 'partials/page-json.php';

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -272,6 +272,8 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 */
 	public function publish_meta_box( $post ) {
 
+		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+
 		// Only show the publish feature if the user is authorized and auto sync is not enabled.
 		// Also check if the post has been previously published and/or deleted.
 		$api_id             = get_post_meta( $post->ID, 'apple_news_api_id', true );
@@ -292,6 +294,8 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Create local copies of values to pass into the partial.
 		$publish_action = self::PUBLISH_ACTION;
+
+		/* phpcs:enable */
 
 		include plugin_dir_path( __FILE__ ) . 'partials/metabox-publish.php';
 	}

--- a/admin/class-admin-apple-news-list-table.php
+++ b/admin/class-admin-apple-news-list-table.php
@@ -92,7 +92,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 		$updated_at = get_post_meta( $post->ID, 'apple_news_api_modified_at', true );
 
 		if ( $updated_at ) {
-			return get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $updated_at ) ), 'F j, h:i a' );
+			return get_date_from_gmt( gmdate( 'Y-m-d H:i:s', strtotime( $updated_at ) ), 'F j, h:i a' );
 		}
 
 		return __( 'Never', 'apple-news' );
@@ -136,7 +136,7 @@ class Admin_Apple_News_List_Table extends WP_List_Table {
 		}
 
 		$updated = get_post_meta( $post->ID, 'apple_news_api_modified_at', true );
-		$updated = strtotime( get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $updated ) ) ) );
+		$updated = strtotime( get_date_from_gmt( gmdate( 'Y-m-d H:i:s', strtotime( $updated ) ) ) );
 		$local   = strtotime( $post->post_modified );
 
 		if ( $local > $updated ) {

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -67,7 +67,7 @@ class Admin_Apple_Notice {
 		$updated = false;
 		$notices = array_filter(
 			array_map(
-				function ( $notice ) use ( $notifications, &$updated ) {
+				function ( $notice ) use ( $notifications, &$updated ) { // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 					ksort( $notice );
 					if ( in_array( wp_json_encode( $notice ), $notifications, true ) ) {
 						$updated = true;

--- a/admin/class-admin-apple-preview.php
+++ b/admin/class-admin-apple-preview.php
@@ -48,28 +48,30 @@ class Admin_Apple_Preview extends Apple_News {
 		?>
 		<div class="apple-news-preview">
 			<?php
-				// Build sample content.
-				$title = sprintf(
-					'<h1 class="apple-news-title apple-news-component apple-news-meta-component">%s</h1>',
-					__( 'Sample Article', 'apple-news' )
-				);
+			/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
 
-				$cover = sprintf(
-					'<div class="apple-news-cover apple-news-meta-component">%s</div>',
-					__( 'Cover', 'apple-news' )
-				);
+			// Build sample content.
+			$title = sprintf(
+				'<h1 class="apple-news-title apple-news-component apple-news-meta-component">%s</h1>',
+				__( 'Sample Article', 'apple-news' )
+			);
 
-				// Build the byline.
-				$author = __( 'John Doe', 'apple-news' );
-				$date   = date( 'M j, Y g:i A' );
-				$export = new Apple_Actions\Index\Export( $settings );
-				$byline = sprintf(
-					'<div class="apple-news-byline apple-news-component apple-news-meta-component">%s</div>',
-					$export->format_byline( null, $author, $date )
-				);
+			$cover = sprintf(
+				'<div class="apple-news-cover apple-news-meta-component">%s</div>',
+				__( 'Cover', 'apple-news' )
+			);
 
-				// Get the order of the top components.
-				$meta_component_order = $theme->get_value( 'meta_component_order' );
+			// Build the byline.
+			$author = __( 'John Doe', 'apple-news' );
+			$date   = date( 'M j, Y g:i A' );
+			$export = new Apple_Actions\Index\Export( $settings );
+			$byline = sprintf(
+				'<div class="apple-news-byline apple-news-component apple-news-meta-component">%s</div>',
+				$export->format_byline( null, $author, $date )
+			);
+
+			// Get the order of the top components.
+			$meta_component_order = $theme->get_value( 'meta_component_order' );
 			if ( ! is_array( $meta_component_order ) ) {
 				$meta_component_order = array();
 			}
@@ -78,6 +80,8 @@ class Admin_Apple_Preview extends Apple_News {
 					echo wp_kses( $$component, Admin_Apple_Settings_Section::$allowed_html );
 				}
 			}
+
+			/* phpcs:enable */
 			?>
 			<div class="apple-news-component">
 			<p><span class="apple-news-dropcap">L</span>orem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sagittis, libero nulla pellentesque quam, non venenatis massa odio id dolor.</p>

--- a/admin/class-admin-apple-preview.php
+++ b/admin/class-admin-apple-preview.php
@@ -63,7 +63,7 @@ class Admin_Apple_Preview extends Apple_News {
 
 			// Build the byline.
 			$author = __( 'John Doe', 'apple-news' );
-			$date   = date( 'M j, Y g:i A' );
+			$date   = apple_news_date( 'M j, Y g:i A' );
 			$export = new Apple_Actions\Index\Export( $settings );
 			$byline = sprintf(
 				'<div class="apple-news-byline apple-news-component apple-news-meta-component">%s</div>',

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -361,10 +361,12 @@ class Admin_Apple_Sections extends Apple_News {
 			}
 		}
 
+		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
 		$theme_mappings  = get_option( self::THEME_MAPPING_KEY );
 		$theme_obj       = new Admin_Apple_Themes();
 		$theme_admin_url = add_query_arg( 'page', $theme_obj->theme_page_name, admin_url( 'admin.php' ) );
 		$themes          = \Apple_Exporter\Theme::get_registry();
+		/* phpcs:enable */
 
 		// Load the partial with the form.
 		include plugin_dir_path( __FILE__ ) . 'partials/page-sections.php';

--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -149,7 +149,7 @@ class Admin_Apple_Settings extends Apple_News {
 			wp_die( esc_html__( 'You do not have permissions to access this page.', 'apple-news' ) );
 		}
 
-		$sections = $this->sections;
+		$sections = $this->sections; // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 		include plugin_dir_path( __FILE__ ) . 'partials/page-options.php';
 	}
 

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -261,6 +261,8 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	public function page_theme_edit_render() {
 
+		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+
 		// Ensure the user has permission to load this screen.
 		if ( ! current_user_can( apply_filters( 'apple_news_settings_capability', 'manage_options' ) ) ) {
 			wp_die( esc_html__( 'You do not have permissions to access this page.', 'apple-news' ) );
@@ -286,6 +288,8 @@ class Admin_Apple_Themes extends Apple_News {
 
 		// Get information about theme options.
 		$theme_options = \Apple_Exporter\Theme::get_options();
+
+		/* phpcs:enable */
 
 		// Load the edit page.
 		include plugin_dir_path( __FILE__ ) . 'partials/page-theme-edit.php';

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -119,9 +119,9 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		$apple_state       = \Admin_Apple_News::get_post_status( $post->ID );
 		$apple_share_url   = get_post_meta( $post->ID, 'apple_news_api_share_url', true );
 		$apple_created_at  = get_post_meta( $post->ID, 'apple_news_api_created_at', true );
-		$apple_created_at  = empty( $apple_created_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $apple_created_at ) ), 'F j, h:i a' );
+		$apple_created_at  = empty( $apple_created_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( gmdate( 'Y-m-d H:i:s', strtotime( $apple_created_at ) ), 'F j, h:i a' );
 		$apple_modified_at = get_post_meta( $post->ID, 'apple_news_api_modified_at', true );
-		$apple_modified_at = empty( $apple_modified_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $apple_modified_at ) ), 'F j, h:i a' );
+		$apple_modified_at = empty( $apple_modified_at ) ? __( 'None', 'apple-news' ) : get_date_from_gmt( gmdate( 'Y-m-d H:i:s', strtotime( $apple_modified_at ) ), 'F j, h:i a' );
 		?>
 	<div id="apple-news-metabox-pullquote" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
 		<h3><?php esc_html_e( 'Apple News Publish Information', 'apple-news' ); ?></h3>

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -234,7 +234,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 * @return mixed The result of the callback, if provided.
 	 */
 	public function render_field( $args ) {
-		list( $name, $default_value, $callback ) = $args;
+		list( $name, , $callback ) = $args;
 
 		$type = $this->get_type_for( $name );
 

--- a/apple-news.php
+++ b/apple-news.php
@@ -45,7 +45,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/apple-exporter/class-settings.ph
  */
 function apple_news_uninstall_wp_plugin() {
 	$settings = new Apple_Exporter\Settings();
-	foreach ( $settings->all() as $name => $value ) {
+	foreach ( array_keys( $settings->all() ) as $name ) {
 		delete_option( $name );
 	}
 }

--- a/apple-news.php
+++ b/apple-news.php
@@ -21,6 +21,25 @@
  * Domain Path: lang/
  */
 
+/**
+ * A shim for wp_date, if it is not defined.
+ *
+ * @param string       $format    PHP date format.
+ * @param int          $timestamp Optional. Unix timestamp. Defaults to current time.
+ * @param DateTimeZone $timezone  Optional. Timezone to output result in. Defaults to timezone from site settings.
+ *
+ * @return string|false The date, translated if locale specifies it. False on invalid timestamp input.
+ */
+function apple_news_date( $format, $timestamp = null, $timezone = null ) {
+	// If wp_date exists (WP >= 5.3.0) use it.
+	if ( function_exists( 'wp_date' ) ) {
+		return wp_date( $format, $timestamp, $timezone );
+	}
+
+	// Fall back to using the date function if wp_date does not exist, to preserve backwards compatibility.
+	return date( $format, $timestamp ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+}
+
 require_once plugin_dir_path( __FILE__ ) . './includes/meta.php';
 
 if ( ! defined( 'WPINC' ) ) {

--- a/assets/js/cover-image.js
+++ b/assets/js/cover-image.js
@@ -47,7 +47,7 @@
         $imgIdInput.val( '' );
 
         // Add the image and ID, swap visibility of add and remove buttons.
-        $imgContainer.append( '<img src="' + imgUrl + '" alt="" />' );
+        $imgContainer.append( '<img src="' + imgUrl + '" alt="" />' ); // phpcs:ignore WordPressVIPMinimum.JS.StringConcat.Found, WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
         $imgIdInput.val( attachment.id );
         $addImgButton.addClass( 'hidden' );
         $delImgButton.removeClass( 'hidden' );

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -108,7 +108,7 @@
 		}
 
 		// Remove existing dropcap.
-		dropcapParagraph.html(
+		dropcapParagraph.html( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
 			dropcapParagraph.html().replace( /<span[^>]*>([^<]+)<\/span>/, '$1' )
 		);
 
@@ -116,9 +116,9 @@
 		if ( 'yes' === $( '#initial_dropcap' ).val() ) {
 
 			// Create the dropcap span with the specified number of characters.
-			dropcapParagraph.html(
-				'<span class="apple-news-dropcap">' +
-				dropcapParagraph.html().substr( 0, dropcapCharacters ) +
+			dropcapParagraph.html( // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
+				'<span class="apple-news-dropcap">' + // phpcs:ignore WordPressVIPMinimum.JS.StringConcat.Found
+				dropcapParagraph.html().substr( 0, dropcapCharacters ) + // phpcs:ignore WordPressVIPMinimum.JS.StringConcat.Found
 				'</span>' +
 				dropcapParagraph.html().substr( dropcapCharacters )
 			);

--- a/assets/js/sections.js
+++ b/assets/js/sections.js
@@ -26,7 +26,7 @@
 							$input;
 
 						// Copy the HTML from the template.
-						$item.html( $template.html() );
+						$item.html( $template.html() ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
 
 						// Create a unique ID on the input and map it to the label.
 						$input = $item.find( 'input' );
@@ -37,7 +37,7 @@
 						$input.attr( 'name', 'taxonomy-mapping-' + $( this ).attr( 'data-section-id' ) + '[]' );
 
 						// Add the item to the list.
-						$( this ).siblings( '.apple-news-section-taxonomy-mapping-list' ).append( $item );
+						$( this ).siblings( '.apple-news-section-taxonomy-mapping-list' ).append( $item ); // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 
 						// Activate autocomplete.
 						apple_news_sections.enable_autocomplete();

--- a/assets/js/themes.js
+++ b/assets/js/themes.js
@@ -50,7 +50,7 @@
 	});
 
 	function appleNewsThemesShowError( selector, message ) {
-		$( selector ).append( $( '<p>' )
+		$( selector ).append( $( '<p>' ) // phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
 			.attr( 'id', 'apple_news_theme_error' )
 			.addClass( 'error-message' )
 			.text( message )

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -51,8 +51,8 @@ class Metadata extends Builder {
 		 */
 		$post = get_post( $this->content_id() );
 		if ( ! empty( $post ) ) {
-			$post_date     = date( 'c', strtotime( get_gmt_from_date( $post->post_date ) ) );
-			$post_modified = date( 'c', strtotime( get_gmt_from_date( $post->post_modified ) ) );
+			$post_date     = gmdate( 'c', strtotime( get_gmt_from_date( $post->post_date ) ) );
+			$post_modified = gmdate( 'c', strtotime( get_gmt_from_date( $post->post_modified ) ) );
 
 			$meta['dateCreated']   = $post_date;
 			$meta['dateModified']  = $post_modified;

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -490,7 +490,7 @@ class Theme {
 
 		// Get inactive components.
 		$options             = self::get_options();
-		$inactive_components = array_diff(
+		$inactive_components = array_diff( // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 			$options['meta_component_order']['default'],
 			$component_order
 		);
@@ -1162,7 +1162,7 @@ class Theme {
 		// Loop through options and compile an array of all options with values.
 		$all_settings = array();
 		$options      = self::get_options();
-		foreach ( $options as $option_key => $option ) {
+		foreach ( array_keys( $options ) as $option_key ) {
 			$all_settings[ $option_key ] = $this->get_value( $option_key );
 		}
 

--- a/includes/apple-exporter/components/class-table.php
+++ b/includes/apple-exporter/components/class-table.php
@@ -205,9 +205,6 @@ class Table extends Component {
 		// Add the JSON for this component.
 		$this->register_json( $table_spec, $values );
 
-		// Get information about the currently loaded theme.
-		$theme = \Apple_Exporter\Theme::get_used();
-
 		// Register the layout for the table.
 		$this->register_layout( 'table-layout', 'table-layout' );
 

--- a/includes/apple-push-api/class-mime-builder.php
+++ b/includes/apple-push-api/class-mime-builder.php
@@ -135,12 +135,14 @@ class MIME_Builder {
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
 			$request = vip_safe_wp_remote_get( $filepath );
 		} else {
-			$request = wp_remote_get( $filepath );
+			$request = wp_remote_get( $filepath ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		}
 
 		if ( is_wp_error( $request ) ) {
-			// Try file_get_contents instead. This could be a local path.
-			$contents = file_get_contents( $filepath ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			// Try file_get_contents if this is a local path.
+			if ( 0 === validate_file( $filepath ) && file_exists( $filepath ) ) {
+				$contents = file_get_contents( $filepath ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+			}
 		} else {
 			$contents = wp_remote_retrieve_body( $request );
 		}

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -363,7 +363,7 @@ class Request {
 	 * @return string The signature string for use in signing API requests.
 	 */
 	private function sign( $url, $verb, $content = null ) {
-		$current_date = date( 'c' );
+		$current_date = gmdate( 'c' );
 
 		$request_info = $verb . $url . $current_date;
 		if ( 'POST' === $verb ) {

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -332,7 +332,17 @@ class Request {
 			$args['headers']['Content-Length'] = strlen( $content );
 			$args['headers']['Content-Type']   = 'multipart/form-data; boundary=' . $this->mime_builder->boundary();
 			$args['body']                      = $content;
-			$args['timeout']                   = 30; // Required because we need to package and send all images.
+
+			/*
+			 * If the remote images setting is off, increase the timeout to 30s so
+			 * there is enough time to send the bundled images.
+			 */
+			$settings = get_option( 'apple_news_settings' );
+			if ( ! empty( $settings['use_remote_images'] )
+				&& 'no' === $settings['use_remote_images']
+			) {
+				$args['timeout'] = 30; // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			}
 		}
 
 		/**

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -73,7 +73,7 @@ class Request {
 			'apple_news_request_args',
 			array(
 				'reject_unsafe_urls' => true,
-				'timeout'            => 5,
+				'timeout'            => 3,
 			)
 		);
 	}
@@ -103,7 +103,7 @@ class Request {
 				'Content-Type'   => 'multipart/form-data; boundary=' . $this->mime_builder->boundary(),
 			),
 			'body'    => $content,
-			'timeout' => 30, // Required because we need to package all images.
+			'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 		);
 
 		// Allow filtering and merge with the default args.

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -843,8 +843,7 @@ class Apple_News {
 			}
 
 			// Load the theme data from the JSON configuration file.
-			$filename = dirname( __DIR__ ) . '/assets/themes/' . $slug . '.json';
-			$options  = json_decode( file_get_contents( $filename ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$options = json_decode( file_get_contents( dirname( __DIR__ ) . '/assets/themes/' . $slug . '.json' ), true ); // phpcs:ignore
 
 			// Negotiate screenshot URL.
 			$options['screenshot_url'] = plugins_url(

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -352,7 +352,7 @@ class Apple_News {
 		$options        = \Apple_Exporter\Theme::get_options();
 		$wp_settings    = get_option( self::$option_name, array() );
 		$theme_settings = array();
-		foreach ( $options as $option_key => $option ) {
+		foreach ( array_keys( $options ) as $option_key ) {
 			if ( isset( $wp_settings[ $option_key ] ) ) {
 				$theme_settings[ $option_key ] = $wp_settings[ $option_key ];
 			}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,15 +93,6 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get">
-		<severity>0</severity>
-	</rule>
-	<rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
-		<severity>0</severity>
-	</rule>
-	<rule ref="WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -96,15 +96,6 @@
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get">
 		<severity>0</severity>
 	</rule>
-	<rule ref="WordPressVIPMinimum.JS.HTMLExecutingFunctions.append">
-		<severity>0</severity>
-	</rule>
-	<rule ref="WordPressVIPMinimum.JS.HTMLExecutingFunctions.html">
-		<severity>0</severity>
-	</rule>
-	<rule ref="WordPressVIPMinimum.JS.StringConcat.Found">
-		<severity>0</severity>
-	</rule>
 	<rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown">
 		<severity>0</severity>
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -87,10 +87,4 @@
   <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
     <severity>0</severity>
   </rule>
-
-  <!-- Turn off a few newly added or renamed rules until we put fixes in place. -->
-	<!-- We will target version 2.1.0 for these fixes. -->
-  <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
-    <severity>0</severity>
-  </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,7 +93,4 @@
   <rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
     <severity>0</severity>
   </rule>
-	<rule ref="WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable">
-		<severity>0</severity>
-	</rule>
 </ruleset>


### PR DESCRIPTION
Re-enables the following sniffs and either ignores valid usages or fixes found problems:

* WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
* WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
* WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
* WordPressVIPMinimum.JS.StringConcat.Found
* WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
* WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
* WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable