### PR TITLE
APPLE-38 Refine component tests

### DIFF
--- a/tests/apple-exporter/components/class-component-testcase.php
+++ b/tests/apple-exporter/components/class-component-testcase.php
@@ -1,49 +1,31 @@
 <?php
+/**
+ * Publish to Apple News tests: Component_TestCase class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
-use Apple_Exporter\Exporter_Content as Exporter_Content;
-use Apple_Exporter\Settings as Settings;
-use Apple_Exporter\Builders\Component_Layouts as Component_Layouts;
-use Apple_Exporter\Builders\Component_Text_Styles as Component_Text_Styles;
-use Apple_Exporter\Builders\Component_Styles as Component_Styles;
-
-abstract class Component_TestCase extends WP_UnitTestCase {
-
-	protected $prophet;
-
-	/**
-	 * Actions to be run before every test.
-	 *
-	 * @access public
-	 */
-	public function setup() {
-		$themes = new Admin_Apple_Themes;
-		$themes->setup_theme_pages();
-		$this->prophet          = new \Prophecy\Prophet;
-		$this->settings         = new Settings();
-		$this->content          = new Exporter_Content( 1, __( 'My Title', 'apple-news' ), '<p>' . __( 'Hello, World!', 'apple-news' ) . '</p>' );
-		$this->styles           = new Component_Text_Styles( $this->content, $this->settings );
-		$this->layouts          = new Component_Layouts( $this->content, $this->settings );
-		$this->component_styles = new Component_Styles( $this->content, $this->settings );
-	}
+/**
+ * A base component class for Apple News tests.
+ *
+ * @package Apple_News
+ */
+abstract class Component_TestCase extends Apple_News_Testcase {
 
 	/**
-	 * Actions to be run after every test.
+	 * Parses HTML into a DOMNode.
 	 *
-	 * @access public
+	 * @param string $html The HTML to parse.
+	 *
+	 * @return DOMNode|null A DOMNode on success, or null on failure.
 	 */
-	public function tearDown() {
-		$this->prophet->checkPredictions();
-		$theme = new \Apple_Exporter\Theme();
-		$theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
-		$theme->save();
-	}
-
 	protected function build_node( $html ) {
 		// Because PHP's DomDocument doesn't like HTML5 tags, ignore errors.
 		$dom = new \DOMDocument();
 		libxml_use_internal_errors( true );
 		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $html );
-		libxml_clear_errors( true );
+		libxml_clear_errors();
 
 		// Find the first-level nodes of the body tag.
 		return $dom->getElementsByTagName( 'body' )->item( 0 )->childNodes->item( 0 );

--- a/tests/apple-exporter/components/test-class-advertisement.php
+++ b/tests/apple-exporter/components/test-class-advertisement.php
@@ -1,33 +1,60 @@
 <?php
+/**
+ * Publish to Apple News tests: Advertisement_Test class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
-require_once __DIR__ . '/class-component-testcase.php';
+use Apple_Exporter\Components\Advertisement;
 
-use Apple_Exporter\Components\Advertisement as Advertisement;
-
+/**
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Advertisement class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 class Advertisement_Test extends Component_TestCase {
 
+	/**
+	 * Tests basic JSON generation.
+	 */
 	public function testGeneratedJSON() {
-		$component = new Advertisement( null, null, $this->settings, $this->styles,
-			$this->layouts );
+		$component = new Advertisement(
+			null,
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 		$json = $component->to_array();
 
 		$this->assertEquals( 'banner_advertisement', $json['role'] );
 		$this->assertEquals( 'standard', $json['bannerType'] );
 	}
 
+	/**
+	 * Tests the behavior of the apple_news_advertisement_json filter.
+	 */
 	public function testFilter() {
-		$component = new Advertisement( null, null, $this->settings, $this->styles,
-			$this->layouts );
-		$json = $component->to_array();
+		$component = new Advertisement(
+			null,
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		add_filter( 'apple_news_advertisement_json', function( $json ) {
-			$json['bannerType'] = 'double_height';
-			return $json;
-		} );
+		add_filter(
+			'apple_news_advertisement_json',
+			function( $json ) {
+				$json['bannerType'] = 'double_height';
+				return $json;
+			}
+		);
 
 		$json = $component->to_array();
 		$this->assertEquals( 'double_height', $json['bannerType'] );
 	}
-
 }
-

--- a/tests/apple-exporter/components/test-class-audio.php
+++ b/tests/apple-exporter/components/test-class-audio.php
@@ -1,17 +1,33 @@
 <?php
-
-require_once __DIR__ . '/class-component-testcase.php';
+/**
+ * Publish to Apple News tests: Audio_Test class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
 use Apple_Exporter\Components\Audio;
 
+/**
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Audio class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 class Audio_Test extends Component_TestCase {
 
+	/**
+	 * Tests basic JSON generation.
+	 */
 	public function testGeneratedJSON() {
-		$workspace = $this->prophet->prophesize( '\Exporter\Workspace' );
-
-		// Pass the workspace as a dependency.
-		$component = new Audio( '<audio><source src="http://someurl.com/audio-file.mp3?some_query=string"></audio>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		$component = new Audio(
+			'<audio><source src="http://someurl.com/audio-file.mp3?some_query=string"></audio>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		$json = $component->to_array();
 		$this->assertEquals( 'audio', $json['role'] );
@@ -20,15 +36,15 @@ class Audio_Test extends Component_TestCase {
 
 	/**
 	 * Tests HTML formatting with captions.
-	 *
-	 * @access public
 	 */
 	public function testCaption() {
-		$workspace = $this->prophet->prophesize( '\Exporter\Workspace' );
-
-		// Pass the workspace as a dependency.
-		$component = new Audio( '<figure class="wp-block-audio"><audio controls="" src="https://www.someurl.com/Song-1.mp3"/><figcaption>caption</figcaption></figure>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		$component = new Audio(
+			'<figure class="wp-block-audio"><audio controls="" src="https://www.someurl.com/Song-1.mp3"/><figcaption>caption</figcaption></figure>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		// Test.
 		$this->assertEquals(
@@ -50,22 +66,28 @@ class Audio_Test extends Component_TestCase {
 		);
 	}
 
+	/**
+	 * Tests the behavior of the apple_news_audio_json filter.
+	 */
 	public function testFilter() {
-		$workspace = $this->prophet->prophesize( '\Exporter\Workspace' );
+		$component = new Audio(
+			'<audio><source src="http://someurl.com/audio-file.mp3?some_query=string"></audio>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		// Pass the workspace as a dependency.
-		$component = new Audio( '<audio><source src="http://someurl.com/audio-file.mp3?some_query=string"></audio>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
-
-		add_filter( 'apple_news_audio_json', function( $json ) {
-			$json['URL'] = 'http://someurl.com/audio-file.mp3?some_query=string';
-			return $json;
-		} );
+		add_filter(
+			'apple_news_audio_json',
+			function( $json ) {
+				$json['URL'] = 'http://someurl.com/audio-file.mp3?some_query=string';
+				return $json;
+			}
+		);
 
 		$json = $component->to_array();
 		$this->assertEquals( 'audio', $json['role'] );
 		$this->assertEquals( 'http://someurl.com/audio-file.mp3?some_query=string', $json['URL'] );
 	}
-
 }
-

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Publish to Apple News Tests: Body_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Body.
+ * Publish to Apple News tests: Body_Test class
  *
  * @package Apple_News
  * @subpackage Tests
@@ -15,7 +13,11 @@ use Apple_Exporter\Exporter;
 use Apple_Exporter\Exporter_Content;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Body class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Body class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Body_Test extends Component_TestCase {
 
@@ -57,7 +59,7 @@ class Body_Test extends Component_TestCase {
 		$html = '<p><a href="https://www.apple.com/">&nbsp;</a></p>';
 		$component = new Body(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -84,7 +86,7 @@ class Body_Test extends Component_TestCase {
 		$html = '<p>a</p><p>&nbsp;</p><p>b</p>';
 		$component = new Body(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -112,15 +114,10 @@ class Body_Test extends Component_TestCase {
 
 		// Setup.
 		$this->settings->html_support = 'no';
-		$theme = new \Apple_Exporter\Theme;
-		$theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
-		$theme->load();
-		$settings = $theme->all_settings();
-		$settings['initial_dropcap'] = 'no';
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings( [ 'initial_dropcap' => 'no' ] );
 		$component = new Body(
 			'<p>my text</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -152,7 +149,7 @@ class Body_Test extends Component_TestCase {
 		// Test before filter.
 		$component = new Body(
 			'<p>my text</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -175,7 +172,7 @@ class Body_Test extends Component_TestCase {
 		);
 		$component = new Body(
 			'<p>my text</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -215,7 +212,7 @@ class Body_Test extends Component_TestCase {
 HTML;
 		$component = new Body(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -247,7 +244,7 @@ HTML;
 HTML;
 		$component = new Body(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -277,7 +274,7 @@ HTML;
 		$this->settings->html_support = 'no';
 		$body_component = new Body(
 			'<p>my &amp; text</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -315,8 +312,7 @@ HTML;
 <li>item 3</li>
 </ul>
 HTML;
-		$file = dirname( dirname( __DIR__ ) ) . '/data/test-image.jpg';
-		$cover = $this->factory->attachment->create_upload_object( $file );
+		$cover = $this->get_new_attachment();
 		$content = new Exporter_Content( 3, 'Title', $content, null, $cover );
 
 		// Run the export.
@@ -370,23 +366,23 @@ HTML;
 		);
 
 		// Set body settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['body_font'] = 'AmericanTypewriter';
-		$settings['body_size'] = 20;
-		$settings['body_color'] = '#abcdef';
-		$settings['body_link_color'] = '#fedcba';
-		$settings['body_line_height'] = 28;
-		$settings['body_tracking'] = 50;
-		$settings['dropcap_background_color'] = '#abcabc';
-		$settings['dropcap_color'] = '#defdef';
-		$settings['dropcap_font'] = 'AmericanTypewriter-Bold';
-		$settings['dropcap_number_of_characters'] = 15;
-		$settings['dropcap_number_of_lines'] = 10;
-		$settings['dropcap_number_of_raised_lines'] = 5;
-		$settings['dropcap_padding'] = 20;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'body_font'                      => 'AmericanTypewriter',
+				'body_size'                      => 20,
+				'body_color'                     => '#abcdef',
+				'body_link_color'                => '#fedcba',
+				'body_line_height'               => 28,
+				'body_tracking'                  => 50,
+				'dropcap_background_color'       => '#abcabc',
+				'dropcap_color'                  => '#defdef',
+				'dropcap_font'                   => 'AmericanTypewriter-Bold',
+				'dropcap_number_of_characters'   => 15,
+				'dropcap_number_of_lines'        => 10,
+				'dropcap_number_of_raised_lines' => 5,
+				'dropcap_padding'                => 20,
+			]
+		);
 
 		// Run the export.
 		$exporter = new Exporter( $content, null, $this->settings );
@@ -464,11 +460,7 @@ HTML;
 		);
 
 		// Set body settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['body_line_height'] = 0;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings( [ 'body_line_height' => 0 ] );
 
 		// Run the export.
 		$exporter = new Exporter( $content, null, $this->settings );
@@ -494,7 +486,7 @@ HTML;
 		$this->settings->html_support = 'no';
 		$component = new Body(
 			'<p>my text</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -525,14 +517,10 @@ HTML;
 
 		// Setup.
 		$this->settings->html_support = 'no';
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['initial_dropcap'] = 'no';
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings( [ 'initial_dropcap' => 'no' ] );
 		$body_component = new Body(
 			'<p>my text</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -316,7 +316,7 @@ HTML;
 		$content = new Exporter_Content( 3, 'Title', $content, null, $cover );
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
@@ -385,7 +385,7 @@ HTML;
 		);
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
@@ -463,7 +463,7 @@ HTML;
 		$this->set_theme_settings( [ 'body_line_height' => 0 ] );
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );

--- a/tests/apple-exporter/components/test-class-byline.php
+++ b/tests/apple-exporter/components/test-class-byline.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Publish to Apple News Tests: Byline_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Byline.
+ * Publish to Apple News tests: Byline_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
-
-require_once __DIR__ . '/class-component-testcase.php';
 
 use Apple_Exporter\Components\Byline;
 use Apple_Exporter\Exporter;
 use Apple_Exporter\Exporter_Content;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Byline class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Byline class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Byline_Test extends Component_TestCase {
 
@@ -43,7 +43,7 @@ class Byline_Test extends Component_TestCase {
 		// Setup.
 		$component = new Byline(
 			'This is the byline',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -89,18 +89,18 @@ class Byline_Test extends Component_TestCase {
 		);
 
 		// Set byline settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['byline_font'] = 'AmericanTypewriter';
-		$settings['byline_size'] = 20;
-		$settings['byline_color'] = '#abcdef';
-		$settings['byline_line_height'] = 28;
-		$settings['byline_tracking'] = 50;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'byline_font'        => 'AmericanTypewriter',
+				'byline_size'        => 20,
+				'byline_color'       => '#abcdef',
+				'byline_line_height' => 28,
+				'byline_tracking'    => 50,
+			]
+		);
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
@@ -138,7 +138,7 @@ class Byline_Test extends Component_TestCase {
 		// Setup.
 		$component = new Byline(
 			'This is the byline',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -1,20 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Cover_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Cover.
+ * Publish to Apple News tests: Cover_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Cover;
-use Apple_Exporter\Workspace;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Cover class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Cover class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Cover_Test extends Component_TestCase {
 
@@ -24,12 +23,15 @@ class Cover_Test extends Component_TestCase {
 	public function testGeneratedJSON() {
 		$this->settings->set( 'use_remote_images', 'no' );
 
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		// get_file_contents and write_tmp_files must be caleld with the specified params
-		$workspace->bundle_source( 'filename.jpg', 'http://someurl.com/filename.jpg' )->shouldBeCalled();
+		$this->prophecized_workspace->bundle_source( 'filename.jpg', 'http://someurl.com/filename.jpg' )->shouldBeCalled();
 
-		$component = new Cover( 'http://someurl.com/filename.jpg',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		$component = new Cover(
+			'http://someurl.com/filename.jpg',
+			$this->prophecized_workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		$this->assertEquals(
 			array(
@@ -56,12 +58,16 @@ class Cover_Test extends Component_TestCase {
 	 */
 	public function testGeneratedJSONRemoteImages() {
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		// get_file_contents and write_tmp_files must be caleld with the specified params
-		$workspace->bundle_source( 'filename.jpg', 'http://someurl.com/filename.jpg' )->shouldNotBeCalled();
 
-		$component = new Cover( 'http://someurl.com/filename.jpg',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		$this->prophecized_workspace->bundle_source( 'filename.jpg', 'http://someurl.com/filename.jpg' )->shouldNotBeCalled();
+
+		$component = new Cover(
+			'http://someurl.com/filename.jpg',
+			$this->prophecized_workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		$this->assertEquals(
 			array(
@@ -90,13 +96,13 @@ class Cover_Test extends Component_TestCase {
 		$this->settings->set( 'use_remote_images', 'yes' );
 
 		// Create dummy post and attachment.
-		$file    = dirname( dirname( __DIR__ ) ) . '/data/test-image.jpg';
 		$post_id = self::factory()->post->create();
-		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
+		$image   = $this->get_new_attachment( $post_id );
+		$this->set_workspace_post_id( $post_id );
 
 		$component = new Cover(
 			wp_get_attachment_url( $image ),
-			new Workspace( $post_id ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -129,16 +135,16 @@ class Cover_Test extends Component_TestCase {
 		$this->settings->set( 'use_remote_images', 'yes' );
 
 		// Create dummy post and attachment.
-		$file    = dirname( dirname( __DIR__ ) ) . '/data/test-image.jpg';
 		$post_id = self::factory()->post->create();
-		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
+		$image   = $this->get_new_attachment( $post_id );
+		$this->set_workspace_post_id( $post_id );
 
 		$component = new Cover(
 			[
 				'caption' => 'Test Caption',
 				'url'     => wp_get_attachment_url( $image ),
 			],
-			new Workspace( $post_id ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -186,18 +192,24 @@ class Cover_Test extends Component_TestCase {
 	public function testFilter() {
 		$this->settings->set( 'use_remote_images', 'no' );
 
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		// get_file_contents and write_tmp_files must be caleld with the specified params
-		$workspace->bundle_source( 'filename.jpg', 'http://someurl.com/filename.jpg' )->shouldBeCalled();
+		$this->prophecized_workspace->bundle_source( 'filename.jpg', 'http://someurl.com/filename.jpg' )->shouldBeCalled();
 
-		$component = new Cover( 'http://someurl.com/filename.jpg',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		$component = new Cover(
+			'http://someurl.com/filename.jpg',
+			$this->prophecized_workspace->reveal(),
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		add_filter( 'apple_news_cover_json', function ( $json ) {
-			$json['behavior']['type'] = 'background_motion';
+		add_filter(
+			'apple_news_cover_json',
+			function ( $json ) {
+				$json['behavior']['type'] = 'background_motion';
 
-			return $json;
-		} );
+				return $json;
+			}
+		);
 
 		$this->assertEquals(
 			array(

--- a/tests/apple-exporter/components/test-class-divider.php
+++ b/tests/apple-exporter/components/test-class-divider.php
@@ -1,14 +1,33 @@
 <?php
+/**
+ * Publish to Apple News tests: Divider_Test class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
-require_once __DIR__ . '/class-component-testcase.php';
+use Apple_Exporter\Components\Divider;
 
-use Apple_Exporter\Components\Divider as Divider;
-
+/**
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Divider class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 class Divider_Test extends Component_TestCase {
 
+	/**
+	 * Ensures that an <hr/> tag gets converted to a Divider component.
+	 */
 	public function testBuildingRemovesTags() {
-		$component = new Divider( '<hr/>', null, $this->settings,
-			$this->styles, $this->layouts );
+		$component = new Divider(
+			'<hr/>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 		$result = $component->to_array();
 
 		$this->assertEquals( 'divider', $result['role'] );
@@ -16,18 +35,27 @@ class Divider_Test extends Component_TestCase {
 		$this->assertNotNull( $result['stroke'] );
 	}
 
+	/**
+	 * Tests the behavior of the apple_news_divider_json filter.
+	 */
 	public function testFilter() {
-		$component = new Divider( '<hr/>', null, $this->settings,
-			$this->styles, $this->layouts );
+		$component = new Divider(
+			'<hr/>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		add_filter( 'apple_news_divider_json', function( $json ) {
-			$json['layout'] = 'fancy-layout';
-			return $json;
-		} );
+		add_filter(
+			'apple_news_divider_json',
+			function( $json ) {
+				$json['layout'] = 'fancy-layout';
+				return $json;
+			}
+		);
 
 		$result = $component->to_array();
 		$this->assertEquals( 'fancy-layout', $result['layout'] );
 	}
-
 }
-

--- a/tests/apple-exporter/components/test-class-embed-generic.php
+++ b/tests/apple-exporter/components/test-class-embed-generic.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Embed_Generic class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Embed_Generic.
+ * Publish to Apple News tests: Embed_Generic_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Embed_Generic;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Embed_Generic class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Embed_Generic class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Embed_Generic_Test extends Component_TestCase {
 
@@ -584,9 +584,9 @@ HTML
 	 *
 	 * @access public
 	 * @return array The modified JSON.
-	 *
+	 */
 	public function filter_apple_news_embed_generic_json( $json ) {
-		$json['URL'] = 'https://www.embed_generic.com/test/posts/54321';
+		$json['URL'] = 'https://www.example.org/test/posts/54321';
 
 		return $json;
 	}
@@ -595,13 +595,13 @@ HTML
 	 * Test the `apple_news_embed_generic_json` filter.
 	 *
 	 * @access public
-	 *
+	 */
 	public function testFilter() {
 
 		// Setup.
 		$component = new Embed_Generic(
-			'https://www.embed_generic.com/test/posts/12345',
-			null,
+			'https://www.example.org/test/posts/12345',
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -614,7 +614,7 @@ HTML
 		// Test.
 		$result = $component->to_array();
 		$this->assertEquals(
-			'https://www.embed_generic.com/test/posts/54321',
+			'https://www.example.org/test/posts/54321',
 			$result['URL']
 		);
 
@@ -642,7 +642,7 @@ HTML
 		// Setup.
 		$component = new Embed_Generic(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-embed-web-video.php
+++ b/tests/apple-exporter/components/test-class-embed-web-video.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Embed_Web_Video_Test class
+ * Publish to Apple News tests: Embed_Web_Video_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
-use Apple_Exporter\Components\Embed_Web_Video as Embed_Web_Video;
+use Apple_Exporter\Components\Embed_Web_Video;
 
 /**
- * A class to test the behavior of the Embed_Web_Video component.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Embed_Web_Video class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Embed_Web_Video_Test extends Component_TestCase {
 
@@ -139,7 +141,7 @@ class Embed_Web_Video_Test extends Component_TestCase {
 		);
 		$component = new Embed_Web_Video(
 			'<p>https://vimeo.com/12819723</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -181,7 +183,7 @@ class Embed_Web_Video_Test extends Component_TestCase {
 		// Setup.
 		$component = new Embed_Web_Video(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -208,7 +210,7 @@ class Embed_Web_Video_Test extends Component_TestCase {
 		// Setup.
 		$component = new Embed_Web_Video(
 			'<iframe src="//player.notvimeo.com/video/12819723" width="560" height="315" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-end-of-article.php
+++ b/tests/apple-exporter/components/test-class-end-of-article.php
@@ -29,17 +29,18 @@ class Test_End_Of_Article extends Component_TestCase {
 	 */
 	public function testEndOfArticleContent() {
 		// Setup.
-		$settings = $this->theme->all_settings();
-		$settings['json_templates'] = array(
-			'end_of_article' => array(
-				'json' => array(
-					'role' => 'heading'
-				),
-				'layout' => array(),
-			),
+		$this->set_theme_settings(
+			[
+				'json_templates' => [
+					'end_of_article' => [
+						'json'   => [
+							'role' => 'heading',
+						],
+						'layout' => [],
+					],
+				],
+			]
 		);
-		$this->theme->load( $settings );
-		$this->assertTrue( $this->theme->save() );
 
 		$post_id = self::factory()->post->create();
 		$json    = $this->get_json_for_post( $post_id );

--- a/tests/apple-exporter/components/test-class-end-of-article.php
+++ b/tests/apple-exporter/components/test-class-end-of-article.php
@@ -13,7 +13,7 @@
  * @package Apple_News
  * @subpackage Tests
  */
-class Test_End_Of_Article extends Apple_News_Testcase {
+class Test_End_Of_Article extends Component_TestCase {
 
 	/**
 	 * Test default End Of Article behavior

--- a/tests/apple-exporter/components/test-class-facebook.php
+++ b/tests/apple-exporter/components/test-class-facebook.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Facebook_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Facebook.
+ * Publish to Apple News tests: Facebook_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Facebook;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Facebook class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Facebook class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Facebook_Test extends Component_TestCase {
 
@@ -60,7 +60,7 @@ class Facebook_Test extends Component_TestCase {
 		// Setup.
 		$component = new Facebook(
 			'https://www.facebook.com/test/posts/12345',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -98,7 +98,7 @@ class Facebook_Test extends Component_TestCase {
 		// Setup.
 		$component = new Facebook(
 			$url,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -132,7 +132,7 @@ class Facebook_Test extends Component_TestCase {
 
 		$component = new Facebook(
 			$wpcom_embed_html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-gallery.php
+++ b/tests/apple-exporter/components/test-class-gallery.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Gallery_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Gallery.
+ * Publish to Apple News tests: Gallery_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use \Apple_Exporter\Components\Gallery;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Gallery class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Gallery class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Gallery_Test extends Component_TestCase {
 
@@ -75,7 +75,7 @@ HTML;
 	public function testFilter() {
 
 		// Setup.
-		$component = $this->_setup_component( $this->_simple_html );
+		$component = $this->setup_component( $this->_simple_html );
 
 		// Add the filter and set a custom layout.
 		add_filter(
@@ -117,7 +117,7 @@ HTML;
 	public function testGeneratedJSON() {
 
 		// Setup.
-		$component = $this->_setup_component( $this->_simple_html );
+		$component = $this->setup_component( $this->_simple_html );
 
 		// Test for valid JSON.
 		$this->assertEquals(
@@ -147,7 +147,7 @@ HTML;
 	public function testGeneratedJSONComplex() {
 
 		// Setup.
-		$component = $this->_setup_component( $this->_complex_html );
+		$component = $this->setup_component( $this->_complex_html );
 
 		// Test for valid JSON.
 		$this->assertEquals(
@@ -184,18 +184,17 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'filename-1.jpg',
 			'http://someurl.com/filename-1.jpg'
 		)->shouldNotBeCalled();
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'another-filename-2.jpg',
 			'http://someurl.com/another-filename-2.jpg'
 		)->shouldNotBeCalled();
 		$component = new Gallery(
 			$this->_simple_html,
-			$workspace->reveal(),
+			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -229,23 +228,22 @@ HTML;
 	 * @access private
 	 * @return Gallery The Gallery component constructed from the content.
 	 */
-	private function _setup_component( $content ) {
+	private function setup_component( $content ) {
 
 		// Set up the workspace.
 		$this->settings->set( 'use_remote_images', 'no' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'filename-1.jpg',
 			'http://someurl.com/filename-1.jpg'
 		)->shouldBeCalled();
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'another-filename-2.jpg',
 			'http://someurl.com/another-filename-2.jpg'
 		)->shouldBeCalled();
 
 		return new Gallery(
 			$content,
-			$workspace->reveal(),
+			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-heading.php
+++ b/tests/apple-exporter/components/test-class-heading.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Publish to Apple News tests: Advertisement_Test class
+ * Publish to Apple News tests: Heading_Test class
  *
  * @package Apple_News
  * @subpackage Tests
@@ -13,7 +13,7 @@ use Apple_Exporter\Theme;
 
 /**
  * A class to test the behavior of the
- * Apple_Exporter\Components\Advertisement class.
+ * Apple_Exporter\Components\Heading class.
  *
  * @package Apple_News
  * @subpackage Tests

--- a/tests/apple-exporter/components/test-class-heading.php
+++ b/tests/apple-exporter/components/test-class-heading.php
@@ -1,23 +1,40 @@
 <?php
 /**
- * Publish to Apple News Tests: Heading_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Heading.
+ * Publish to Apple News tests: Advertisement_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Heading;
 use Apple_Exporter\Exporter;
 use Apple_Exporter\Exporter_Content;
+use Apple_Exporter\Theme;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Heading class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Advertisement class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Heading_Test extends Component_TestCase {
+
+	/**
+	 * A data provider for the testSettings function.
+	 *
+	 * @return array An array of arrays representing function arguments.
+	 */
+	public function data_headings() {
+		return [
+			[ 1, 'AmericanTypewriter', 10, '#111111', 11, 1 ],
+			[ 2, 'AmericanTypewriter', 20, '#222222', 22, 2 ],
+			[ 3, 'AmericanTypewriter', 30, '#222222', 33, 3 ],
+			[ 4, 'AmericanTypewriter', 40, '#222222', 44, 4 ],
+			[ 5, 'AmericanTypewriter', 50, '#222222', 55, 5 ],
+			[ 6, 'AmericanTypewriter', 60, '#222222', 66, 6 ],
+		];
+	}
 
 	/**
 	 * A filter function to modify the text style in the generated JSON.
@@ -43,7 +60,7 @@ class Heading_Test extends Component_TestCase {
 		// Setup.
 		$component = new Heading(
 			'<h1>This is a heading</h1>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -75,12 +92,11 @@ class Heading_Test extends Component_TestCase {
 		$content = <<<HTML
 <h2><a href="https://www.google.com/"><img src="/example-image.jpg" /></a></h2>
 HTML;
-		$file = dirname( dirname( __DIR__ ) ) . '/data/test-image.jpg';
-		$cover = $this->factory->attachment->create_upload_object( $file );
+		$cover   = $this->get_new_attachment();
 		$content = new Exporter_Content( 3, 'Title', $content, null, $cover );
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
@@ -106,7 +122,7 @@ HTML;
 		// Setup.
 		$component = new Heading(
 			'<p>This is not a heading</p>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -120,302 +136,69 @@ HTML;
 	}
 
 	/**
-	 * Tests heading 1 settings.
+	 * Tests settings.
+	 *
+	 * @dataProvider data_headings
+	 *
+	 * @param int    $level       Heading level. 1-6.
+	 * @param string $font        The font to use for the heading.
+	 * @param int    $size        The font size.
+	 * @param string $color       The hex color for the font.
+	 * @param int    $line_height The line height for the text.
+	 * @param int    $tracking    The tracking value for the text.
 	 *
 	 * @access public
 	 */
-	public function testSettings1() {
+	public function testSettings( $level, $font, $size, $color, $line_height, $tracking ) {
 
 		// Setup.
-		$content = new Exporter_Content( 3, 'Title', '<h1>Heading</h1>' );
+		$content = new Exporter_Content(
+			3,
+			'Title',
+			sprintf(
+				'<h%d>Heading</h%d>',
+				$level,
+				$level
+			)
+		);
 
 		// Set header settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['header1_font'] = 'AmericanTypewriter';
-		$settings['header1_size'] = 60;
-		$settings['header1_color'] = '#012345';
-		$settings['header1_line_height'] = 66;
-		$settings['header1_tracking'] = 6;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'header' . $level . '_font'        => $font,
+				'header' . $level . '_size'        => $size,
+				'header' . $level . '_color'       => $color,
+				'header' . $level . '_line_height' => $line_height,
+				'header' . $level . '_tracking'    => $tracking,
+			]
+		);
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
-		$json = $exporter->export();
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
+		$json     = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
 
 		// Validate header settings in generated JSON.
 		$this->assertEquals(
-			'AmericanTypewriter',
-			$json['componentTextStyles']['default-heading-1']['fontName']
+			$font,
+			$json['componentTextStyles']['default-heading-' . $level]['fontName']
 		);
 		$this->assertEquals(
-			60,
-			$json['componentTextStyles']['default-heading-1']['fontSize']
+			$size,
+			$json['componentTextStyles']['default-heading-' . $level]['fontSize']
 		);
 		$this->assertEquals(
-			'#012345',
-			$json['componentTextStyles']['default-heading-1']['textColor']
+			$color,
+			$json['componentTextStyles']['default-heading-' . $level]['textColor']
 		);
 		$this->assertEquals(
-			66,
-			$json['componentTextStyles']['default-heading-1']['lineHeight']
+			$line_height,
+			$json['componentTextStyles']['default-heading-' . $level]['lineHeight']
 		);
 		$this->assertEquals(
-			0.06,
-			$json['componentTextStyles']['default-heading-1']['tracking']
-		);
-	}
-
-	/**
-	 * Tests heading 2 settings.
-	 *
-	 * @access public
-	 */
-	public function testSettings2() {
-
-		// Setup.
-		$content = new Exporter_Content( 3, 'Title', '<h2>Heading</h2>' );
-
-		// Set header settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['header2_font'] = 'AmericanTypewriter';
-		$settings['header2_size'] = 50;
-		$settings['header2_color'] = '#123456';
-		$settings['header2_line_height'] = 55;
-		$settings['header2_tracking'] = 5;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
-
-		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
-		$json = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
-
-		// Validate header settings in generated JSON.
-		$this->assertEquals(
-			'AmericanTypewriter',
-			$json['componentTextStyles']['default-heading-2']['fontName']
-		);
-		$this->assertEquals(
-			50,
-			$json['componentTextStyles']['default-heading-2']['fontSize']
-		);
-		$this->assertEquals(
-			'#123456',
-			$json['componentTextStyles']['default-heading-2']['textColor']
-		);
-		$this->assertEquals(
-			55,
-			$json['componentTextStyles']['default-heading-2']['lineHeight']
-		);
-		$this->assertEquals(
-			0.05,
-			$json['componentTextStyles']['default-heading-2']['tracking']
-		);
-	}
-
-	/**
-	 * Tests heading 3 settings.
-	 *
-	 * @access public
-	 */
-	public function testSettings3() {
-
-		// Setup.
-		$content = new Exporter_Content( 3, 'Title', '<h3>Heading</h3>' );
-
-		// Set header settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['header3_font'] = 'AmericanTypewriter';
-		$settings['header3_size'] = 40;
-		$settings['header3_color'] = '#234567';
-		$settings['header3_line_height'] = 44;
-		$settings['header3_tracking'] = 4;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
-
-		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
-		$json = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
-
-		// Validate header settings in generated JSON.
-		$this->assertEquals(
-			'AmericanTypewriter',
-			$json['componentTextStyles']['default-heading-3']['fontName']
-		);
-		$this->assertEquals(
-			40,
-			$json['componentTextStyles']['default-heading-3']['fontSize']
-		);
-		$this->assertEquals(
-			'#234567',
-			$json['componentTextStyles']['default-heading-3']['textColor']
-		);
-		$this->assertEquals(
-			44,
-			$json['componentTextStyles']['default-heading-3']['lineHeight']
-		);
-		$this->assertEquals(
-			0.04,
-			$json['componentTextStyles']['default-heading-3']['tracking']
-		);
-	}
-
-	/**
-	 * Tests heading 4 settings.
-	 *
-	 * @access public
-	 */
-	public function testSettings4() {
-
-		// Setup.
-		$content = new Exporter_Content( 3, 'Title', '<h4>Heading</h4>' );
-
-		// Set header settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['header4_font'] = 'AmericanTypewriter';
-		$settings['header4_size'] = 30;
-		$settings['header4_color'] = '#345678';
-		$settings['header4_line_height'] = 33;
-		$settings['header4_tracking'] = 3;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
-
-		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
-		$json = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
-
-		// Validate header settings in generated JSON.
-		$this->assertEquals(
-			'AmericanTypewriter',
-			$json['componentTextStyles']['default-heading-4']['fontName']
-		);
-		$this->assertEquals(
-			30,
-			$json['componentTextStyles']['default-heading-4']['fontSize']
-		);
-		$this->assertEquals(
-			'#345678',
-			$json['componentTextStyles']['default-heading-4']['textColor']
-		);
-		$this->assertEquals(
-			33,
-			$json['componentTextStyles']['default-heading-4']['lineHeight']
-		);
-		$this->assertEquals(
-			0.03,
-			$json['componentTextStyles']['default-heading-4']['tracking']
-		);
-	}
-
-	/**
-	 * Tests heading 5 settings.
-	 *
-	 * @access public
-	 */
-	public function testSettings5() {
-
-		// Setup.
-		$content = new Exporter_Content( 3, 'Title', '<h5>Heading</h5>' );
-
-		// Set header settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['header5_font'] = 'AmericanTypewriter';
-		$settings['header5_size'] = 20;
-		$settings['header5_color'] = '#456789';
-		$settings['header5_line_height'] = 22;
-		$settings['header5_tracking'] = 2;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
-
-		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
-		$json = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
-
-		// Validate header settings in generated JSON.
-		$this->assertEquals(
-			'AmericanTypewriter',
-			$json['componentTextStyles']['default-heading-5']['fontName']
-		);
-		$this->assertEquals(
-			20,
-			$json['componentTextStyles']['default-heading-5']['fontSize']
-		);
-		$this->assertEquals(
-			'#456789',
-			$json['componentTextStyles']['default-heading-5']['textColor']
-		);
-		$this->assertEquals(
-			22,
-			$json['componentTextStyles']['default-heading-5']['lineHeight']
-		);
-		$this->assertEquals(
-			0.02,
-			$json['componentTextStyles']['default-heading-5']['tracking']
-		);
-	}
-
-	/**
-	 * Tests heading 6 settings.
-	 *
-	 * @access public
-	 */
-	public function testSettings6() {
-
-		// Setup.
-		$content = new Exporter_Content( 3, 'Title', '<h6>Heading</h6>' );
-
-		// Set header settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['header6_font'] = 'AmericanTypewriter';
-		$settings['header6_size'] = 10;
-		$settings['header6_color'] = '#567890';
-		$settings['header6_line_height'] = 11;
-		$settings['header6_tracking'] = 1;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
-
-		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
-		$json = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
-
-		// Validate header settings in generated JSON.
-		$this->assertEquals(
-			'AmericanTypewriter',
-			$json['componentTextStyles']['default-heading-6']['fontName']
-		);
-		$this->assertEquals(
-			10,
-			$json['componentTextStyles']['default-heading-6']['fontSize']
-		);
-		$this->assertEquals(
-			'#567890',
-			$json['componentTextStyles']['default-heading-6']['textColor']
-		);
-		$this->assertEquals(
-			11,
-			$json['componentTextStyles']['default-heading-6']['lineHeight']
-		);
-		$this->assertEquals(
-			0.01,
-			$json['componentTextStyles']['default-heading-6']['tracking']
+			$tracking / 100,
+			$json['componentTextStyles']['default-heading-' . $level]['tracking']
 		);
 	}
 
@@ -442,18 +225,18 @@ HTML;
 		update_option( Apple_News::$option_name, $wp_settings );
 
 		// Delete all themes to force recreation.
-		$themes = \Apple_Exporter\Theme::get_registry();
+		$themes = Theme::get_registry();
 		foreach ( $themes as $theme_name ) {
-			$theme = new \Apple_Exporter\Theme;
+			$theme = new Theme;
 			$theme->set_name( $theme_name );
 			$theme->delete();
 		}
 
 		// Delete the active theme by force.
-		$active_theme = \Apple_Exporter\Theme::get_active_theme_name();
-		$theme_key = \Apple_Exporter\Theme::theme_key( $active_theme );
+		$active_theme = Theme::get_active_theme_name();
+		$theme_key = Theme::theme_key( $active_theme );
 		delete_option( $theme_key );
-		delete_option( \Apple_Exporter\Theme::ACTIVE_KEY );
+		delete_option( Theme::ACTIVE_KEY );
 
 		// Run legacy settings through migrate script.
 		$apple_news = new Apple_News;
@@ -466,8 +249,8 @@ HTML;
 		$this->assertTrue( empty( $settings['header_line_height'] ) );
 
 		// Ensure legacy settings were applied to new values.
-		$theme = new \Apple_Exporter\Theme;
-		$theme->set_name( \Apple_Exporter\Theme::get_active_theme_name() );
+		$theme = new Theme;
+		$theme->set_name( Theme::get_active_theme_name() );
 		$this->assertTrue( $theme->load() );
 		$settings = $theme->all_settings();
 		$this->assertEquals( '#abcdef', $settings['header1_color'] );
@@ -500,7 +283,7 @@ HTML;
 		// Setup.
 		$component = new Heading(
 			'<h1>This is a heading</h1>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -10,7 +10,7 @@ use Apple_Exporter\Components\Image;
 
 /**
  * A class to test the behavior of the
- * Apple_Exporter\Components\Advertisement class.
+ * Apple_Exporter\Components\Image class.
  *
  * @package Apple_News
  * @subpackage Tests

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -1,22 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Image_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Image.
+ * Publish to Apple News tests: Image_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Image;
-use Apple_Exporter\Exporter;
-use Apple_Exporter\Exporter_Content;
-use Apple_Exporter\Workspace;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Image class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Advertisement class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Image_Test extends Component_TestCase {
 
@@ -48,7 +45,7 @@ class Image_Test extends Component_TestCase {
 
 		$component = new Image(
 			$html,
-			new Workspace( 1 ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -94,7 +91,7 @@ HTML;
 		// Assign an Image component.
 		$component = new Image(
 			$html_caption,
-			new Workspace( 1 ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -130,10 +127,9 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$workspace = new \Apple_Exporter\Workspace( 1 );
 		$component = new Image(
 			'<img src="" alt="Example" align="left" />',
-			$workspace,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -153,14 +149,13 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'no' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'filename.jpg',
 			'http://someurl.com/filename.jpg'
 		)->shouldBeCalled();
 		$component = new Image(
 			'<img src="http://someurl.com/filename.jpg" alt="Example" />',
-			$workspace->reveal(),
+			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -190,10 +185,9 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$workspace = new \Apple_Exporter\Workspace( 1 );
 		$component = new Image(
 			'<img src="#fragment" alt="Example" align="left" />',
-			$workspace,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -213,14 +207,13 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'no' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'filename.jpg',
 			'http://someurl.com/filename.jpg'
 		)->shouldBeCalled();
 		$component = new Image(
 			'<img src="http://someurl.com/filename.jpg" alt="Example" align="left" />',
-			$workspace->reveal(),
+			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -242,14 +235,13 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
-		$workspace->bundle_source(
+		$this->prophecized_workspace->bundle_source(
 			'filename.jpg',
 			'http://someurl.com/filename.jpg'
 		)->shouldNotBeCalled();
 		$component = new Image(
 			'<img src="http://someurl.com/filename.jpg" alt="Example" align="left" />',
-			$workspace->reveal(),
+			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -271,10 +263,9 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$workspace = new \Apple_Exporter\Workspace( 1 );
 		$component = new Image(
 			'<img src="/relative/path/to/image.jpg" alt="Example" align="left" />',
-			$workspace,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -295,16 +286,16 @@ HTML;
 	public function testSettings() {
 
 		// Setup.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
 		$this->settings->full_bleed_images = 'yes';
-		$settings['caption_color'] = '#abcdef';
-		$settings['caption_font'] = 'AmericanTypewriter';
-		$settings['caption_line_height'] = 28;
-		$settings['caption_size'] = 20;
-		$settings['caption_tracking'] = 50;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'caption_color'       => '#abcdef',
+				'caption_font'        => 'AmericanTypewriter',
+				'caption_line_height' => 28,
+				'caption_size'        => 20,
+				'caption_tracking'    => 50,
+			]
+		);
 		$html = <<<HTML
 <figure>
 	<img src="http://someurl.com/filename.jpg" alt="Example">
@@ -313,7 +304,7 @@ HTML;
 HTML;
 		$component = new Image(
 			$html,
-			new Workspace( 1 ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-instagram.php
+++ b/tests/apple-exporter/components/test-class-instagram.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Instagram_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Instagram.
+ * Publish to Apple News tests: Instagram_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Instagram;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Instagram class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Instagram class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Instagram_Test extends Component_TestCase {
 
@@ -26,7 +26,7 @@ class Instagram_Test extends Component_TestCase {
 	 * @access private
 	 * @var string
 	 */
-	private $_embed = <<<HTML
+	private $embed = <<<HTML
 <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-version="4" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%%; width:-webkit-calc(100%% - 2px); width:calc(100%% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50%% 0; text-align:center; width:100%%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="%s" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_top">Belén 1</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">Una foto publicada por @gosukiwi el <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2012-06-10T22:10:01+00:00">10 de Jun de 2012 a la(s) 3:10 PDT</time></p></div></blockquote>
 HTML;
 
@@ -72,8 +72,8 @@ HTML;
 
 		// Setup.
 		$component = new Instagram(
-			sprintf( $this->_embed, 'https://instagram.com/p/LtaiGnryiu/' ),
-			null,
+			sprintf( $this->embed, 'https://instagram.com/p/LtaiGnryiu/' ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -103,8 +103,8 @@ HTML;
 
 		// Setup.
 		$component = new Instagram(
-			sprintf( $this->_embed, 'invalid-content-no-url' ),
-			null,
+			sprintf( $this->embed, 'invalid-content-no-url' ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -132,14 +132,14 @@ HTML;
 		$components = array();
 		$components[] = new Instagram(
 			$url,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
 		);
 		$components[] = new Instagram(
-			sprintf( $this->_embed, $url ),
-			null,
+			sprintf( $this->embed, $url ),
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-intro.php
+++ b/tests/apple-exporter/components/test-class-intro.php
@@ -1,20 +1,20 @@
 <?php
 /**
- * Apple News Tests: Intro_Test class
+ * Publish to Apple News tests: Intro_Test class
  *
  * @package Apple_News
+ * @subpackage Tests
  */
-
-require_once __DIR__ . '/class-component-testcase.php';
 
 use Apple_Exporter\Components\Intro;
 use Apple_Actions\Index\Export;
-use Apple_Exporter\Settings;
 
 /**
- * A class to test the functionality of the Intro component.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Intro class.
  *
  * @package Apple_News
+ * @subpackage Tests
  */
 class Intro_Test extends Component_TestCase {
 
@@ -24,7 +24,7 @@ class Intro_Test extends Component_TestCase {
 	public function testBuild() {
 		$component = new Intro(
 			'Test intro text.',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -44,13 +44,21 @@ class Intro_Test extends Component_TestCase {
 	 * Tests the filter for intro content.
 	 */
 	public function testFilter() {
-		$component = new Intro( 'Test intro text.', null, $this->settings,
-			$this->styles, $this->layouts );
+		$component = new Intro(
+			'Test intro text.',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		add_filter( 'apple_news_intro_json', function( $json ) {
-			$json['textStyle'] = 'fancy-intro';
-			return $json;
-		} );
+		add_filter(
+			'apple_news_intro_json',
+			function( $json ) {
+				$json['textStyle'] = 'fancy-intro';
+				return $json;
+			}
+		);
 
 		$this->assertEquals(
 			array(
@@ -69,12 +77,7 @@ class Intro_Test extends Component_TestCase {
 	 */
 	public function testSkip() {
 		// Set up the theme to have a specific component order that includes the intro.
-		$settings_object                  = new Settings();
-		$theme                            = \Apple_Exporter\Theme::get_used();
-		$settings                         = $theme->all_settings();
-		$settings['meta_component_order'] = [ 'cover', 'title', 'byline', 'intro' ];
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings( [ 'meta_component_order' => [ 'cover', 'title', 'byline', 'intro' ] ] );
 
 		// Create an example post without a customized excerpt.
 		$sample_post = self::factory()->post->create(
@@ -85,7 +88,7 @@ class Intro_Test extends Component_TestCase {
 		);
 
 		// Run the exporter against the sample post and verify that the Intro component is not used, since there is no custom excerpt.
-		$export           = new Export( $settings_object, $sample_post );
+		$export           = new Export( $this->settings, $sample_post );
 		$exporter         = $export->fetch_exporter();
 		$exporter_content = $exporter->get_content();
 		$this->assertEquals( '', $exporter_content->intro() );
@@ -99,7 +102,7 @@ class Intro_Test extends Component_TestCase {
 		);
 
 		// Run the exporter against the sample post and verify that the Intro component is used, and matches the custom excerpt.
-		$export           = new Export( $settings_object, $sample_post );
+		$export           = new Export( $this->settings, $sample_post );
 		$exporter         = $export->fetch_exporter();
 		$exporter_content = $exporter->get_content();
 		$this->assertEquals( 'Sample excerpt', $exporter_content->intro() );
@@ -113,7 +116,7 @@ class Intro_Test extends Component_TestCase {
 		);
 
 		// Run the exporter against the sample post and verify that the Intro component is not used because it duplicates content from the main body.
-		$export           = new Export( $settings_object, $sample_post );
+		$export           = new Export( $this->settings, $sample_post );
 		$exporter         = $export->fetch_exporter();
 		$exporter_content = $exporter->get_content();
 		$this->assertEquals( '', $exporter_content->intro() );

--- a/tests/apple-exporter/components/test-class-link-button.php
+++ b/tests/apple-exporter/components/test-class-link-button.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Link_Button Class
+ * Publish to Apple News tests: Link_Button_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Link_Button;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Link_Button class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Link_Button class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Link_Button_Test extends Component_TestCase {
 
@@ -156,7 +158,7 @@ class Link_Button_Test extends Component_TestCase {
 		// Setup.
 		$component = new Link_Button(
 			$html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts,

--- a/tests/apple-exporter/components/test-class-quote.php
+++ b/tests/apple-exporter/components/test-class-quote.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Publish to Apple News Tests: Quote_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Quote.
+ * Publish to Apple News tests: Quote_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
-
-require_once __DIR__ . '/class-component-testcase.php';
 
 use Apple_Exporter\Components\Quote;
 use Apple_Exporter\Exporter;
 use Apple_Exporter\Exporter_Content;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Quote class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Quote class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Quote_Test extends Component_TestCase {
 
@@ -71,11 +71,7 @@ class Quote_Test extends Component_TestCase {
 	public function testFilterHangingPunctuation() {
 
 		// Setup.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['pullquote_hanging_punctuation'] = 'yes';
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings( [ 'pullquote_hanging_punctuation' => 'yes' ] );
 		add_filter(
 			'apple_news_apply_hanging_punctuation',
 			array( $this, 'filter_apple_news_apply_hanging_punctuation' ),
@@ -84,7 +80,7 @@ class Quote_Test extends Component_TestCase {
 		);
 		$component = new Quote(
 			'<blockquote class="apple-news-pullquote"><p>my quote</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -114,7 +110,7 @@ class Quote_Test extends Component_TestCase {
 		// Setup.
 		$component = new Quote(
 			'<blockquote><p>my quote</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -150,22 +146,22 @@ class Quote_Test extends Component_TestCase {
 		);
 
 		// Set quote settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['blockquote_font'] = 'AmericanTypewriter';
-		$settings['blockquote_size'] = 20;
-		$settings['blockquote_color'] = '#abcdef';
-		$settings['blockquote_line_height'] = 28;
-		$settings['blockquote_tracking'] = 50;
-		$settings['blockquote_background_color'] = '#fedcba';
-		$settings['blockquote_border_color'] = '#012345';
-		$settings['blockquote_border_style'] = 'dashed';
-		$settings['blockquote_border_width'] = 10;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'blockquote_font'             => 'AmericanTypewriter',
+				'blockquote_size'             => 20,
+				'blockquote_color'            => '#abcdef',
+				'blockquote_line_height'      => 28,
+				'blockquote_tracking'         => 50,
+				'blockquote_background_color' => '#fedcba',
+				'blockquote_border_color'     => '#012345',
+				'blockquote_border_style'     => 'dashed',
+				'blockquote_border_width'     => 10,
+			]
+		);
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
@@ -224,20 +220,20 @@ class Quote_Test extends Component_TestCase {
 		);
 
 		// Set quote settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['pullquote_font'] = 'AmericanTypewriter';
-		$settings['pullquote_size'] = 20;
-		$settings['pullquote_color'] = '#abcdef';
-		$settings['pullquote_hanging_punctuation'] = 'yes';
-		$settings['pullquote_line_height'] = 28;
-		$settings['pullquote_tracking'] = 50;
-		$settings['pullquote_transform'] = 'uppercase';
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'pullquote_font'                => 'AmericanTypewriter',
+				'pullquote_size'                => 20,
+				'pullquote_color'               => '#abcdef',
+				'pullquote_hanging_punctuation' => 'yes',
+				'pullquote_line_height'         => 28,
+				'pullquote_tracking'            => 50,
+				'pullquote_transform'           => 'uppercase',
+			]
+		);
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
@@ -282,7 +278,7 @@ class Quote_Test extends Component_TestCase {
 		// Setup.
 		$component = new Quote(
 			'<blockquote><p>my quote</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -309,7 +305,7 @@ class Quote_Test extends Component_TestCase {
 		// Setup.
 		$componentLeft = new Quote(
 			'<blockquote style="text-align:left" class="wp-block-quote"><p>Quote Text</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -317,7 +313,7 @@ class Quote_Test extends Component_TestCase {
 
 		$componentCenter = new Quote(
 			'<blockquote style="text-align:center" class="wp-block-quote"><p>Quote Text</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -325,7 +321,7 @@ class Quote_Test extends Component_TestCase {
 
 		$componentRight = new Quote(
 			'<blockquote style="text-align:right" class="wp-block-quote"><p>Quote Text</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -375,7 +371,7 @@ class Quote_Test extends Component_TestCase {
 		// Setup.
 		$componentLeft = new Quote(
 			'<figure class="wp-block-pullquote alignleft"><blockquote><p>Quote Text</p></blockquote></figure>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -383,7 +379,7 @@ class Quote_Test extends Component_TestCase {
 
 		$componentCenter = new Quote(
 			'<figure class="wp-block-pullquote alignwide"><blockquote><p>Quote Text</p></blockquote></figure>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -391,7 +387,7 @@ class Quote_Test extends Component_TestCase {
 
 		$componentRight = new Quote(
 			'<figure class="wp-block-pullquote alignright"><blockquote><p>Quote Text</p></blockquote></figure>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
@@ -445,14 +441,10 @@ class Quote_Test extends Component_TestCase {
 	public function testTransformPullquote( $text, $expected, $hanging_punctuation ) {
 
 		// Setup.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['pullquote_hanging_punctuation'] = $hanging_punctuation;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings( [ 'pullquote_hanging_punctuation' => $hanging_punctuation ] );
 		$component = new Quote(
 			'<blockquote class="apple-news-pullquote"><p>' . $text . '</p></blockquote>',
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts

--- a/tests/apple-exporter/components/test-class-table.php
+++ b/tests/apple-exporter/components/test-class-table.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Publish to Apple News Tests: Table_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Table.
+ * Publish to Apple News tests: Table_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
-
-require_once __DIR__ . '/class-component-testcase.php';
 
 use Apple_Exporter\Exporter;
 use Apple_Exporter\Exporter_Content;
 use Apple_Exporter\Components\Table;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Table class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Table class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Table_Test extends Component_TestCase {
 
@@ -28,8 +28,6 @@ class Table_Test extends Component_TestCase {
 
 		// Run the parent setup function (not done automatically).
 		parent::setup();
-
-		// Turn on HTML support globally in the
 
 		// Create an example table to use in tests.
 		$this->html = <<<HTML
@@ -66,7 +64,7 @@ HTML;
 	public function testCaptions() {
 		$component = new Table(
 			$this->html_caption,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts,
@@ -106,7 +104,7 @@ HTML;
 		// Setup.
 		$component = new Table(
 			$this->html,
-			null,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts,
@@ -141,34 +139,34 @@ HTML;
 		);
 
 		// Set table settings.
-		$theme = \Apple_Exporter\Theme::get_used();
-		$settings = $theme->all_settings();
-		$settings['table_border_color'] = '#abcdef';
-		$settings['table_border_style'] = 'dashed';
-		$settings['table_border_width'] = 5;
-		$settings['table_body_background_color'] = '#fedcba';
-		$settings['table_body_color'] = '#123456';
-		$settings['table_body_font'] = 'AmericanTypewriter';
-		$settings['table_body_horizontal_alignment'] = 'center';
-		$settings['table_body_line_height'] = 1;
-		$settings['table_body_padding'] = 2;
-		$settings['table_body_size'] = 3;
-		$settings['table_body_tracking'] = 4;
-		$settings['table_body_vertical_alignment'] = 'bottom';
-		$settings['table_header_background_color'] = '#654321';
-		$settings['table_header_color'] = '#987654';
-		$settings['table_header_font'] = 'Menlo-Regular';
-		$settings['table_header_horizontal_alignment'] = 'right';
-		$settings['table_header_line_height'] = 5;
-		$settings['table_header_padding'] = 6;
-		$settings['table_header_size'] = 7;
-		$settings['table_header_tracking'] = 8;
-		$settings['table_header_vertical_alignment'] = 'top';
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
+		$this->set_theme_settings(
+			[
+				'table_border_color'                => '#abcdef',
+				'table_border_style'                => 'dashed',
+				'table_border_width'                => 5,
+				'table_body_background_color'       => '#fedcba',
+				'table_body_color'                  => '#123456',
+				'table_body_font'                   => 'AmericanTypewriter',
+				'table_body_horizontal_alignment'   => 'center',
+				'table_body_line_height'            => 1,
+				'table_body_padding'                => 2,
+				'table_body_size'                   => 3,
+				'table_body_tracking'               => 4,
+				'table_body_vertical_alignment'     => 'bottom',
+				'table_header_background_color'     => '#654321',
+				'table_header_color'                => '#987654',
+				'table_header_font'                 => 'Menlo-Regular',
+				'table_header_horizontal_alignment' => 'right',
+				'table_header_line_height'          => 5,
+				'table_header_padding'              => 6,
+				'table_header_size'                 => 7,
+				'table_header_tracking'             => 8,
+				'table_header_vertical_alignment'   => 'top',
+			]
+		);
 
 		// Run the export.
-		$exporter = new Exporter( $content, null, $this->settings );
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
 		$json = $exporter->export();
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );

--- a/tests/apple-exporter/components/test-class-title.php
+++ b/tests/apple-exporter/components/test-class-title.php
@@ -1,14 +1,33 @@
 <?php
+/**
+ * Publish to Apple News tests: Title_Test class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
-require_once __DIR__ . '/class-component-testcase.php';
+use Apple_Exporter\Components\Title;
 
-use Apple_Exporter\Components\Title as Title;
-
+/**
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Title class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 class Title_Test extends Component_TestCase {
 
+	/**
+	 * Tests a basic build.
+	 */
 	public function testBuildingRemovesTags() {
-		$body_component = new Title( 'Example Title', null, $this->settings,
-			$this->styles, $this->layouts );
+		$body_component = new Title(
+			'Example Title',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		$this->assertEquals(
 			array(
@@ -22,14 +41,25 @@ class Title_Test extends Component_TestCase {
 		);
 	}
 
+	/**
+	 * Tests the behavior of the apple_news_title_json filter.
+	 */
 	public function testFilter() {
-		$body_component = new Title( 'Example Title', null, $this->settings,
-			$this->styles, $this->layouts );
+		$body_component = new Title(
+			'Example Title',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		add_filter( 'apple_news_title_json', function( $json ) {
-			$json['textStyle'] = 'fancy-title';
-			return $json;
-		} );
+		add_filter(
+			'apple_news_title_json',
+			function ( $json ) {
+				$json['textStyle'] = 'fancy-title';
+				return $json;
+			}
+		);
 
 		$this->assertEquals(
 			array(
@@ -42,6 +72,4 @@ class Title_Test extends Component_TestCase {
 			$body_component->to_array()
 		);
 	}
-
 }
-

--- a/tests/apple-exporter/components/test-class-tweet.php
+++ b/tests/apple-exporter/components/test-class-tweet.php
@@ -1,103 +1,118 @@
 <?php
+/**
+ * Publish to Apple News tests: Tweet_Test class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 
-require_once __DIR__ . '/class-component-testcase.php';
+use Apple_Exporter\Components\Tweet;
 
-use Apple_Exporter\Components\Tweet as Tweet;
-
+/**
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Tweet class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
 class Tweet_Test extends Component_TestCase {
 
+	/**
+	 * A data provider for the testComponent function.
+	 *
+	 * @return array An array of arrays of function arguments.
+	 */
+	public function data_tweets() {
+		return [
+			[
+				'<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Swift will be open source later this year, available for iOS, OS X, and Linux. <a href="http://t.co/yQhyzxukTn">http://t.co/yQhyzxukTn</a></p>&mdash; Federico Ramirez (@gosukiwi) <a href="https://twitter.com/gosukiwi/status/608069908044390400">June 9, 2015</a></blockquote>',
+				'https://twitter.com/gosukiwi/status/608069908044390400',
+			],
+			[
+				'<blockquote class="twitter-tweet" lang="en">WordPress.com (@wordpressdotcom) <a href="http://twitter.com/#!/wordpressdotcom/status/204557548249026561" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+				'https://twitter.com/wordpressdotcom/status/204557548249026561',
+			],
+			[
+				'<blockquote class="twitter-tweet" lang="en">WordPress.com (@wordpressdotcom) <a href="https://www.twitter.com/#!/wordpressdotcom/status/204557548249026561" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+				'https://twitter.com/wordpressdotcom/status/204557548249026561',
+			],
+			[
+				'<blockquote class="twitter-tweet" lang="en">WordPress.com (@wordpressdotcom) <a href="https://twitter.com/#!/wordpressdotcom/statuses/204557548249026561" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+				'https://twitter.com/wordpressdotcom/status/204557548249026561',
+			],
+			[
+				'<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash; <br />WordPress.com (@wordpressdotcom) <a href="http://twitter.com/#!/wordpressdotcom/status/123" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+				'https://twitter.com/wordpressdotcom/status/123',
+			],
+		];
+	}
+
+	/**
+	 * Given HTML and an expected URL value, tests the component.
+	 *
+	 * @dataProvider data_tweets
+	 *
+	 * @param string $html The HTML to be fed to the component.
+	 * @param string $url  The expected URL of the Twitter component.
+	 */
+	public function testComponent( $html, $url ) {
+		$component = new Tweet(
+			$html,
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		$result = $component->to_array();
+		$this->assertEquals( 'tweet', $result['role'] );
+		$this->assertEquals( $url, $result['URL'] );
+	}
+
+	/**
+	 * Ensures invalid Twitter embeds are not converted.
+	 */
 	public function testInvalidMarkup() {
-		$component = new Tweet( '<blockquote class="twitter-tweet" lang="en">Invalid content. No URL.</blockquote>',
-			null, $this->settings, $this->styles, $this->layouts );
+		$component = new Tweet(
+			'<blockquote class="twitter-tweet" lang="en">Invalid content. No URL.</blockquote>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
 		$this->assertEquals( null, $component->to_array() );
 	}
 
+	/**
+	 * Tests the behavior of an oEmbed.
+	 */
 	public function testMatchesASingleURL() {
 		$node = $this->build_node( 'https://twitter.com/gosukiwi/status/608069908044390400' );
 		$this->assertNotNull( Tweet::node_matches( $node ) );
 	}
 
-	public function testGetsURLFromNewFormat() {
-		$component = new Tweet( '<blockquote class="twitter-tweet"
-			lang="en"><p lang="en" dir="ltr">Swift will be open source later this
-			year, available for iOS, OS X, and Linux. <a
-			href="http://t.co/yQhyzxukTn">http://t.co/yQhyzxukTn</a></p>&mdash;
-		Federico Ramirez (@gosukiwi) <a
-			href="https://twitter.com/gosukiwi/status/608069908044390400">June 9,
-			2015</a></blockquote>', null, $this->settings, $this->styles, $this->layouts );
-
-		$result = $component->to_array();
-		$this->assertEquals( 'tweet', $result['role'] );
-		$this->assertEquals( 'https://twitter.com/gosukiwi/status/608069908044390400', $result['URL'] );
-	}
-
-	public function testGetsURLFromOldFormat() {
-		$component = new Tweet( '<blockquote class="twitter-tweet"
-			lang="en">WordPress.com (@wordpressdotcom) <a
-			href="http://twitter.com/#!/wordpressdotcom/status/204557548249026561"
-			data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
-			null, $this->settings, $this->styles, $this->layouts );
-
-		$result = $component->to_array();
-		$this->assertEquals( 'tweet', $result['role'] );
-		$this->assertEquals( 'https://twitter.com/wordpressdotcom/status/204557548249026561', $result['URL'] );
-	}
-
-	public function testGetUsingWWW() {
-		$component = new Tweet( '<blockquote class="twitter-tweet"
-			lang="en">WordPress.com (@wordpressdotcom) <a
-			href="https://www.twitter.com/#!/wordpressdotcom/status/204557548249026561"
-			data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
-			null, $this->settings, $this->styles, $this->layouts );
-
-		$result = $component->to_array();
-		$this->assertEquals( 'tweet', $result['role'] );
-		$this->assertEquals( 'https://twitter.com/wordpressdotcom/status/204557548249026561', $result['URL'] );
-	}
-
-	public function testGetUsingStatuses() {
-		$component = new Tweet( '<blockquote class="twitter-tweet"
-			lang="en">WordPress.com (@wordpressdotcom) <a
-			href="https://twitter.com/#!/wordpressdotcom/statuses/204557548249026561"
-			data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
-			null, $this->settings, $this->styles, $this->layouts );
-
-		$result = $component->to_array();
-		$this->assertEquals( 'tweet', $result['role'] );
-		$this->assertEquals( 'https://twitter.com/wordpressdotcom/status/204557548249026561', $result['URL'] );
-	}
-
-	public function testGetLastLink() {
-		$component = new Tweet( '<blockquote class="twitter-tweet"
-			lang="en"><p><a
-			href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash;
-		<br />WordPress.com (@wordpressdotcom) <a
-			href="http://twitter.com/#!/wordpressdotcom/status/123"
-			data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
-			null, $this->settings, $this->styles, $this->layouts );
-
-		$result = $component->to_array();
-		$this->assertEquals( 'tweet', $result['role'] );
-		$this->assertEquals( 'https://twitter.com/wordpressdotcom/status/123', $result['URL'] );
-	}
-
+	/**
+	 * Tests the behavior of the apple_news_tweet_json filter.
+	 */
 	public function testFilter() {
-		$component = new Tweet( '<blockquote class="twitter-tweet"
-			lang="en"><p><a
-			href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash;
-		<br />WordPress.com (@wordpressdotcom) <a
-			href="http://twitter.com/#!/wordpressdotcom/status/123"
-			data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
-			null, $this->settings, $this->styles, $this->layouts );
+		$component = new Tweet(
+			'<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash; <br />WordPress.com (@wordpressdotcom) <a href="http://twitter.com/#!/wordpressdotcom/status/123" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
 
-		add_filter( 'apple_news_tweet_json', function( $json ) {
-			$json['URL'] = 'https://twitter.com/alleydev/status/123';
-			return $json;
-		} );
+		add_filter(
+			'apple_news_tweet_json',
+			function( $json ) {
+				$json['URL'] = 'https://twitter.com/alleydev/status/123';
+				return $json;
+			}
+		);
 
 		$result = $component->to_array();
 		$this->assertEquals( 'https://twitter.com/alleydev/status/123', $result['URL'] );
 	}
 }
-

--- a/tests/apple-exporter/components/test-class-video.php
+++ b/tests/apple-exporter/components/test-class-video.php
@@ -1,20 +1,19 @@
 <?php
 /**
- * Publish to Apple News Tests: Quote_Test class
- *
- * Contains a class which is used to test Apple_Exporter\Components\Quote.
+ * Publish to Apple News tests: Video_Test class
  *
  * @package Apple_News
  * @subpackage Tests
  */
 
-require_once __DIR__ . '/class-component-testcase.php';
-
 use Apple_Exporter\Components\Video;
-use Apple_Exporter\Workspace;
 
 /**
- * A class which is used to test the Apple_Exporter\Components\Video class.
+ * A class to test the behavior of the
+ * Apple_Exporter\Components\Video class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
 class Video_Test extends Component_TestCase {
 
@@ -24,7 +23,7 @@ class Video_Test extends Component_TestCase {
 	 * @access private
 	 * @var string
 	 */
-	private $_content = <<<HTML
+	private $video_content = <<<HTML
 <video class="wp-video-shortcode" id="video-71-1" width="525" height="295" poster="https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg" preload="metadata" controls="controls">
 	<source type="video/mp4" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1" />
 	<a href="https://example.com/wp-content/uploads/2017/02/example-video.mp4">https://example.com/wp-content/uploads/2017/02/example-video.mp4</a>
@@ -53,7 +52,7 @@ HTML;
 	public function testFilter() {
 
 		// Setup.
-		$component = $this->_get_component();
+		$component = $this->get_component();
 		add_filter(
 			'apple_news_video_json',
 			array( $this, 'filter_apple_news_video_json' )
@@ -79,11 +78,7 @@ HTML;
 	 * @access public
 	 */
 	public function testCaption() {
-		$workspace = $this->prophet->prophesize( '\Exporter\Workspace' );
-
-		// Pass the workspace as a dependency.
-		$component = new Video( '<figure class="wp-block-video"><video controls="" src="http://www.url.com/test.mp4"/><figcaption>caption</figcaption></figure>',
-			$workspace->reveal(), $this->settings, $this->styles, $this->layouts );
+		$component = $this->get_component( '<figure class="wp-block-video"><video controls="" src="http://www.url.com/test.mp4"/><figcaption>caption</figcaption></figure>' );
 
 		// Test.
 		$this->assertEquals(
@@ -103,7 +98,6 @@ HTML;
 			),
 			$component->to_array()
 		);
-		$html = '';
 	}
 
 	/**
@@ -115,7 +109,7 @@ HTML;
 
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'yes' );
-		$component = $this->_get_component();
+		$component = $this->get_component();
 
 		// Test.
 		$result = $component->to_array();
@@ -136,25 +130,18 @@ HTML;
 	/**
 	 * A function to get a basic component for testing using defined content.
 	 *
+	 * @param string $content HTML for the component.
+	 *
 	 * @access private
 	 * @return Video A Video object containing the specified content.
 	 */
-	private function _get_component( $content = '' ) {
-
-		// Negotiate content.
-		if ( empty( $content ) ) {
-			$content = $this->_content;
-		}
-
-		// Build the component.
-		$component = new Video(
-			$content,
-			new Workspace( 1 ),
+	private function get_component( $content = '' ) {
+		return new Video(
+			! empty( $content ) ? $content : $this->video_content,
+			$this->workspace,
 			$this->settings,
 			$this->styles,
 			$this->layouts
 		);
-
-		return $component;
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,3 +33,5 @@ tests_add_filter( 'apple_news_block_editor_is_active', '__return_false' );
 require $_tests_dir . '/includes/bootstrap.php';
 
 require_once __DIR__ . '/class-apple-news-testcase.php';
+
+require_once __DIR__ . '/apple-exporter/components/class-component-testcase.php';

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -14,6 +14,13 @@
 abstract class Apple_News_Testcase extends WP_UnitTestCase {
 
 	/**
+	 * Contains an instance of the Apple_Exporter\Builders\Component_Styles class for use in tests.
+	 *
+	 * @var Apple_Exporter\Builders\Component_Styles
+	 */
+	protected $component_styles;
+
+	/**
 	 * Contains an instance of the Apple_Exporter\Exporter_Content class for use in tests.
 	 *
 	 * @var Apple_Exporter\Exporter_Content
@@ -28,11 +35,32 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	protected $content_settings;
 
 	/**
+	 * Contains an instance of the Apple_Exporter\Builders\Component_Layouts class for use in tests.
+	 *
+	 * @var Apple_Exporter\Builders\Component_Layouts
+	 */
+	protected $layouts;
+
+	/**
+	 * An instance of Prophet for use in tests.
+	 *
+	 * @var Prophecy\Prophet
+	 */
+	protected $prophet;
+
+	/**
 	 * Contains an instance of the Apple_Exporter\Settings class for use in tests.
 	 *
 	 * @var Apple_Exporter\Settings
 	 */
 	protected $settings;
+
+	/**
+	 * Contains an instance of the Apple_Exporter\Builders\Component_Text_Styles class for use in tests.
+	 *
+	 * @var Apple_Exporter\Builders\Component_Text_Styles
+	 */
+	protected $styles;
 
 	/**
 	 * Contains an instance of the Apple_Exporter\Theme class for use in tests.
@@ -42,12 +70,19 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	protected $theme;
 
 	/**
+	 * Contains an instance of the Apple_Exporter\Workspace class for use in tests.
+	 *
+	 * @var Apple_Exporter\Workspace
+	 */
+	protected $workspace;
+
+	/**
 	 * A function containing operations to be run before each test function.
 	 *
 	 * @access public
 	 */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 
 		// Create some dummy content and save it for future use.
 		$this->content = new Apple_Exporter\Exporter_Content(
@@ -62,10 +97,43 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 		// Create a new instance of the Exporter_Content_Settings object and save it for future use.
 		$this->content_settings = new Apple_Exporter\Exporter_Content_Settings();
 
+		// Create a new instance of Prophet for future use.
+		$this->prophet = new Prophecy\Prophet();
+
+		// Create a workspace for future use. Default it to use post ID 1, but this can be overridden at the test level.
+		$this->workspace = new Apple_Exporter\Workspace( 1 );
+
 		// Create a new theme and save it for future use.
 		$this->theme = new Apple_Exporter\Theme();
 		$this->theme->save();
 		$this->theme->set_active();
+
+		// Create styles for future use.
+		$this->styles = new Apple_Exporter\Builders\Component_Text_Styles(
+			$this->content,
+			$this->content_settings
+		);
+
+		// Create layouts for future use.
+		$this->layouts = new Apple_Exporter\Builders\Component_Layouts(
+			$this->content,
+			$this->content_settings
+		);
+
+		// Create component styles for future use.
+		$this->component_styles = new Apple_Exporter\Builders\Component_Styles(
+			$this->content,
+			$this->content_settings
+		);
+	}
+
+	/**
+	 * Actions to be run after every test.
+	 *
+	 * @access public
+	 */
+	public function tearDown() {
+		$this->prophet->checkPredictions();
 	}
 
 	/**


### PR DESCRIPTION
* Streamlines component tests by using the new Apple_News_Testcase base class, which provides boilerplate and reusable functions to reduce verbosity in component tests.
* Ensures all component tests have appropriate docblocks.
* Cleans up PHP formatting in component tests generally, with a view toward being able to enable phpcs on tests in the future.