### PR TITLE
AN-12: padding after cover image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,12 @@ before_script:
   - |
     case "$TRAVIS_PHP_VERSION" in
       7.*)
-        echo "Using PHPUnit 6.1"
-        composer global require "phpunit/phpunit=6.1.*"
+        echo "Using PHPUnit 6.5"
+        composer global require "phpunit/phpunit=6.5.*"
         ;;
       *)
-        echo "Using PHPUnit 4.8"
-        composer global require "phpunit/phpunit=4.8.*"
+        echo "Using PHPUnit 5.7"
+        composer global require "phpunit/phpunit=5.7.*"
         ;;
     esac
 

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -190,7 +190,7 @@ class Admin_Apple_Sections extends Apple_News {
 		 * @param int    $post_id       The post ID.
 		 * @param string $format        The section format (e.g., 'url').
 		 */
-		return apply_filters( 'get_sections_for_post', $post_sections, $post_id, $format );
+		return apply_filters( 'apple_news_get_sections_for_post', $post_sections, $post_id, $format );
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -86,6 +86,19 @@ class Embed_Web_Video extends Component {
 				'role'        => 'embedwebvideo',
 				'aspectRatio' => '#aspect_ratio#',
 				'URL'         => '#url#',
+				'layout'      => 'embed-web-video-layout',
+			)
+		);
+
+		// Register the JSON for the link button layout.
+		$this->register_spec(
+			'embed-web-video-layout',
+			__( 'Web Embed Layout', 'apple-news' ),
+			array(
+				'margin' => array(
+					'bottom' => 18,
+					'top'    => 18,
+				),
 			)
 		);
 	}
@@ -129,5 +142,8 @@ class Embed_Web_Video extends Component {
 				'#url#'          => $src,
 			)
 		);
+
+		// Register the layout for the link button.
+		$this->register_layout( 'embed-web-video-layout', 'embed-web-video-layout' );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Bugfix: Removed extra space between an image and its caption.
 * Bugfix: If a custom excerpt is used, but the custom excerpt repeats text in its entirety from elsewhere in the article (e.g., the first paragraph), then the Intro component will be skipped. This prevents an issue where Apple will flag articles that contain repeated text due to the Intro component using a custom excerpt suitable in a WordPress context but not an Apple News context.
 * Bugfix: Select menus are no longer oversized on the settings page.
+* Updated filter name for `get_sections_for_post` to `apple_news_get_sections_for_post`.
 
 = 2.0.8 =
 * Enhancement: Adds styles for Button elements that are links which are added by the Gutenberg editor.

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Enhancement: Adds support for Brightcove videos via the Brightcove Video Connect plugin for videos added via either the Gutenberg block or the shortcode. Note that this feature will only work if you contact Apple support to link your Brightcove account with your Apple News channel.
 * Enhancement: Replaces usage of the deprecated `advertisingSettings` object with the new `autoplacement.advertising` object. Bumps default advertisement frequency from 1 to 5 (out of 10).
 * Enhancement: Adds an error to the notice bar if the `DATE_NOT_RECENT` API error is encountered advising the user to synchronize the time on their server to restore API connectivity.
+* Enhancement: Adds padding above and below `EmbedWebVideo` components.
 * Bugfix: Removes Cover Art configuration, as Cover Art is no longer used by Apple.
 * Bugfix: Fixes the logic in the default theme checker to properly check the configured values against the defaults and prompt the user if they are using the default theme that ships with Apple News without modification.
 * Bugfix: Fixes a bug where renaming a theme would not carry over any changes made to the theme, and renaming the active theme would make it no longer active.

--- a/tests/apple-exporter/components/test-class-embed-web-video.php
+++ b/tests/apple-exporter/components/test-class-embed-web-video.php
@@ -153,6 +153,7 @@ class Embed_Web_Video_Test extends Component_TestCase {
 				'role'        => 'embedwebvideo',
 				'URL'         => 'https://player.vimeo.com/video/12819723',
 				'aspectRatio' => '1.4',
+				'layout'      => 'embed-web-video-layout',
 			),
 			$component->to_array()
 		);
@@ -195,6 +196,7 @@ class Embed_Web_Video_Test extends Component_TestCase {
 				'role'        => 'embedwebvideo',
 				'URL'         => $final_url,
 				'aspectRatio' => '1.777',
+				'layout'      => 'embed-web-video-layout'
 			),
 			$component->to_array()
 		);


### PR DESCRIPTION
Closes: https://alleyinteractive.atlassian.net/browse/APPLE-12

- Updated filter name for `get_sections_for_post` to `apple_news_get_sections_for_post`.
- Adds padding above and below `EmbedWebVideo` components.
- Updates unit test.
- Updates readme to reflect the above.