### PR TITLE
APPLE-12 Upgrade PHPUnit versions in use for PHP 5.6 and 7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,12 @@ before_script:
   - |
     case "$TRAVIS_PHP_VERSION" in
       7.*)
-        echo "Using PHPUnit 6.1"
-        composer global require "phpunit/phpunit=6.1.*"
+        echo "Using PHPUnit 6.5"
+        composer global require "phpunit/phpunit=6.5.*"
         ;;
       *)
-        echo "Using PHPUnit 4.8"
-        composer global require "phpunit/phpunit=4.8.*"
+        echo "Using PHPUnit 5.7"
+        composer global require "phpunit/phpunit=5.7.*"
         ;;
     esac
 


### PR DESCRIPTION
* Bump version of phpunit for PHP 5.6 to 5.7.*
* Bump version of phpunit for PHP 7+ to 6.5.*