### PR TITLE
APPLE-46 Add image lightbox caption fonts

### DIFF
--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -58,8 +58,11 @@ class Cover extends Component {
 						'layout'  => 'headerPhotoLayoutWithCaption',
 						'URL'     => '#url#',
 						'caption' => array(
-							'format' => 'html',
-							'text'   => '#caption#',
+							'format'    => 'html',
+							'text'      => '#caption#',
+							'textStyle' => array(
+								'fontName' => '#caption_font#',
+							),
 						),
 					),
 					array(

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -8,8 +8,6 @@
 
 namespace Apple_Exporter\Components;
 
-use Apple_Exporter\Components\Component;
-
 /**
  * Represents a simple image.
  *
@@ -79,8 +77,11 @@ class Image extends Component {
 						'URL'     => '#url#',
 						'layout'  => '#layout#',
 						'caption' => array(
-							'format' => 'html',
-							'text'   => '#caption#',
+							'format'    => 'html',
+							'text'      => '#caption#',
+							'textStyle' => array(
+								'fontName' => '#caption_font#',
+							),
 						),
 					),
 					array(

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -160,8 +160,11 @@ class Cover_Test extends Component_TestCase {
 						'URL'     => wp_get_attachment_url( $image ),
 						'layout'  => 'headerPhotoLayoutWithCaption',
 						'caption' => array(
-							'format' => 'html',
-							'text'   => 'Test Caption',
+							'format'    => 'html',
+							'text'      => 'Test Caption',
+							'textStyle' => array(
+								'fontName' => 'AvenirNext-Italic',
+							),
 						),
 					),
 					array(
@@ -228,6 +231,29 @@ class Cover_Test extends Component_TestCase {
 				),
 			),
 			$component->to_array()
+		);
+	}
+
+	/**
+	 * Ensures that the lightbox font is set to the same font face as the image caption.
+	 */
+	public function testLightboxFont() {
+		$this->set_theme_settings( [ 'caption_font' => 'Menlo-Regular' ] );
+
+		// Create an image and give it a caption.
+		$image_id = $this->get_new_attachment( 0, 'Test Caption!' );
+
+		// Create a test post.
+		$post_id = self::factory()->post->create();
+
+		// Set the featured image for the post.
+		set_post_thumbnail( $post_id, $image_id );
+
+		// Ensure that the font set on the lightbox is the same as the font set on the caption above.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals(
+			'Menlo-Regular',
+			$json['components'][0]['components'][0]['caption']['textStyle']['fontName']
 		);
 	}
 }

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -347,7 +347,7 @@ HTML;
 		);
 
 		// Create an image and give it a caption.
-		$image_id = $this->get_new_attachment(0, 'Test Caption!');
+		$image_id = $this->get_new_attachment( 0, 'Test Caption!' );
 
 		// Create a test post with the image with the caption.
 		$post_id = self::factory()->post->create(

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -334,4 +334,33 @@ HTML;
 			$result['components'][1]['textStyle']['tracking']
 		);
 	}
+
+	/**
+	 * Ensures that the lightbox font is set to the same font face as the image caption.
+	 */
+	public function testLightboxFont() {
+		$this->set_theme_settings(
+			[
+				'caption_font'         => 'Menlo-Regular',
+				'meta_component_order' => [ 'title', 'byline' ],
+			]
+		);
+
+		// Create an image and give it a caption.
+		$image_id = $this->get_new_attachment(0, 'Test Caption!');
+
+		// Create a test post with the image with the caption.
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => $this->get_image_with_caption( $image_id ),
+			]
+		);
+
+		// Ensure that the font set on the lightbox is the same as the font set on the caption above.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals(
+			'Menlo-Regular',
+			$json['components'][2]['components'][0]['caption']['textStyle']['fontName']
+		);
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,14 +30,6 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Turn off Gutenberg for tests, at least for now.
 tests_add_filter( 'apple_news_block_editor_is_active', '__return_false' );
 
-// Ensure HTML5 image captions are supported.
-tests_add_filter(
-	'after_setup_theme',
-	function () {
-		add_theme_support( 'html5', ['caption'] );
-	}
-);
-
 require $_tests_dir . '/includes/bootstrap.php';
 
 require_once __DIR__ . '/class-apple-news-testcase.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,14 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Turn off Gutenberg for tests, at least for now.
 tests_add_filter( 'apple_news_block_editor_is_active', '__return_false' );
 
+// Ensure HTML5 image captions are supported.
+tests_add_filter(
+	'after_setup_theme',
+	function () {
+		add_theme_support( 'html5', ['caption'] );
+	}
+);
+
 require $_tests_dir . '/includes/bootstrap.php';
 
 require_once __DIR__ . '/class-apple-news-testcase.php';

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -91,6 +91,9 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		// Ensure HTML5 image captions are supported.
+		add_theme_support( 'html5', ['caption'] );
+
 		// Create some dummy content and save it for future use.
 		$this->content = new Apple_Exporter\Exporter_Content(
 			1,

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -147,12 +147,40 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	/**
 	 * Runs create_upload_object using a test image and returns the image ID.
 	 *
-	 * @param int $parent Optional. The parent post ID. Defaults to no parent.
+	 * @param int    $parent  Optional. The parent post ID. Defaults to no parent.
+	 * @param string $caption Optional. The caption to set on the image.
 	 *
 	 * @return int The post ID of the attachment image that was created.
 	 */
-	protected function get_new_attachment( $parent = 0 ) {
-		return self::factory()->attachment->create_upload_object( __DIR__ . '/data/test-image.jpg', $parent );
+	protected function get_new_attachment( $parent = 0, $caption = '' ) {
+		$image_id = self::factory()->attachment->create_upload_object( __DIR__ . '/data/test-image.jpg', $parent );
+
+		if ( ! empty( $caption ) ) {
+			$image = get_post( $image_id );
+			$image->post_excerpt = $caption;
+			wp_update_post( $image );
+		}
+
+		return $image_id;
+	}
+
+	/**
+	 * Given an image ID, returns the HTML5 markup for an image with a caption.
+	 *
+	 * Extracts the caption from the database entry for the image (stored in post_excerpt).
+	 *
+	 * @param int $image_id The image ID to use when generating the <figure>.
+	 *
+	 * @return string HTML for the image and the caption.
+	 */
+	protected function get_image_with_caption( $image_id ) {
+		return img_caption_shortcode(
+			[
+				'caption' => wp_get_attachment_caption( $image_id ),
+				'width'   => 640,
+			],
+			wp_get_attachment_image( $image_id, 'full' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Ensures that the lightbox caption font matches the font used for captions embedded within articles on both Image and Cover components.