### PR TITLE
APPLE-46 Hide cover caption by default

### DIFF
--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -73,6 +73,13 @@ class Admin_Apple_Themes extends Apple_News {
 		$field = '';
 		$value = $theme->get_value( $option_name );
 		switch ( $option['type'] ) {
+			case 'boolean':
+				$field = '<select id="%s" name="%s">'
+					. '<option value="0" ' . selected( $value, false, false ) . '>No</option>'
+					. '<option value="1" ' . selected( $value, true, false ) . '>Yes</option>'
+					. '</select>';
+
+				break;
 			case 'color':
 				$field = '<input type="text" id="%s" name="%s" value="%s" class="apple-news-color-picker">';
 

--- a/includes/apple-exporter/class-exporter.php
+++ b/includes/apple-exporter/class-exporter.php
@@ -286,7 +286,7 @@ class Exporter {
 	private function build_article_style() {
 
 		// Get information about the currently used theme.
-		$theme             = \Apple_Exporter\Theme::get_used();
+		$theme       = \Apple_Exporter\Theme::get_used();
 		$conditional = array();
 		if ( ! empty( $theme->get_value( 'body_background_color_dark' ) ) ) {
 			$conditional = array(
@@ -295,7 +295,7 @@ class Exporter {
 					'conditions'      => array(
 						'preferredColorScheme' => 'dark',
 					),
-				)
+				),
 			);
 		}
 

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -714,6 +714,11 @@ class Theme {
 				'label'       => __( 'Caption tracking', 'apple-news' ),
 				'type'        => 'integer',
 			),
+			'cover_caption'                     => array(
+				'default' => false,
+				'label'   => __( 'Enable caption on the Cover component', 'apple-news' ),
+				'type'    => 'boolean',
+			),
 			'dropcap_background_color'          => array(
 				'default' => '',
 				'label'   => __( 'Drop cap background color', 'apple-news' ),
@@ -1931,6 +1936,7 @@ class Theme {
 			'caption'         => array(
 				'label'    => __( 'Image caption', 'apple-news' ),
 				'settings' => array(
+					'cover_caption',
 					'caption_font',
 					'caption_size',
 					'caption_line_height',

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1366,6 +1366,9 @@ class Theme {
 
 			// Convert the format of the value based on type.
 			switch ( $options[ $key ]['type'] ) {
+				case 'boolean':
+					$this->values[ $key ] = (bool) $value;
+					break;
 				case 'float':
 					$this->values[ $key ] = (float) $value;
 					break;
@@ -1438,13 +1441,18 @@ class Theme {
 
 					break;
 
+				case 'boolean':
+					$this->values[ $option_key ] = (bool) $_POST[ $option_key ];
+
+					break;
+
 				case 'float':
-					$this->values[ $option_key ] = floatval( $_POST[ $option_key ] );
+					$this->values[ $option_key ] = (float) $_POST[ $option_key ];
 
 					break;
 
 				case 'integer':
-					$this->values[ $option_key ] = intval( $_POST[ $option_key ] );
+					$this->values[ $option_key ] = (int) $_POST[ $option_key ];
 
 					break;
 
@@ -1675,6 +1683,11 @@ class Theme {
 
 					break;
 
+				case 'boolean':
+					$value = (bool) $value;
+
+					break;
+
 				case 'color':
 					// Sanitize.
 					$value = sanitize_text_field( $value );
@@ -1699,7 +1712,7 @@ class Theme {
 					break;
 
 				case 'float':
-					$value = floatval( $value );
+					$value = (float) $value;
 
 					break;
 
@@ -1727,7 +1740,7 @@ class Theme {
 					break;
 
 				case 'integer':
-					$value = intval( $value );
+					$value = (int) $value;
 
 					break;
 

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -754,7 +754,7 @@ class Theme {
 				'label'       => __( 'Caption tracking', 'apple-news' ),
 				'type'        => 'integer',
 			),
-			'cover_caption'                     => array(
+			'cover_caption'                      => array(
 				'default' => false,
 				'label'   => __( 'Enable caption on the Cover component', 'apple-news' ),
 				'type'    => 'boolean',
@@ -764,7 +764,7 @@ class Theme {
 				'description' => __( 'Colors specific to Apple News Dark Mode', 'apple-news' ),
 				'type'        => 'group_heading',
 			),
-			'dropcap_background_color'          => array(
+			'dropcap_background_color'           => array(
 				'default' => '',
 				'label'   => __( 'Drop cap background color', 'apple-news' ),
 				'type'    => 'color',
@@ -1034,7 +1034,7 @@ class Theme {
 				'hidden'  => true,
 				'type'    => 'integer',
 			),
-			'meta_component_order'              => array(
+			'meta_component_order'               => array(
 				'default'  => array( 'cover', 'title', 'byline' ),
 				'callback' => array( get_called_class(), 'render_meta_component_order' ),
 				'type'     => 'array',

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -8,6 +8,8 @@
 
 namespace Apple_Exporter\Components;
 
+use Apple_Exporter\Theme;
+
 /**
  * A cover is optional and displayed at the very top of the article. It's
  * loaded from the Exporter_Content's cover attribute, if present.
@@ -137,6 +139,8 @@ class Cover extends Component {
 	 */
 	protected function build( $options ) {
 
+		$theme = Theme::get_used();
+
 		// Handle case where options is a URL.
 		if ( ! is_array( $options ) ) {
 			$options = [
@@ -152,7 +156,9 @@ class Cover extends Component {
 		}
 
 		// Fork for caption vs. not.
-		if ( ! empty( $options['caption'] ) ) {
+		if ( ! empty( $options['caption'] )
+			&& true === $theme->get_value( 'cover_caption' )
+		) {
 			$this->register_json(
 				'jsonWithCaption',
 				array(

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -107,8 +107,8 @@ class Heading extends Component {
 						'textColor'     => '#header' . $level . '_color#',
 						'textAlignment' => '#text_alignment#',
 						'tracking'      => '#header' . $level . '_tracking#',
-					)
-					,$conditional
+					),
+					$conditional
 				)
 			);
 		}

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -451,9 +451,9 @@ class Quote extends Component {
 
 		// Set JSON for this element.
 		$values = array(
-			'#text#'   => $text,
-			'#format#' => $this->parser->format,
-			'#default_pullquote#'               => 'default-pullquote-' . $this->text_alignment,
+			'#text#'              => $text,
+			'#format#'            => $this->parser->format,
+			'#default_pullquote#' => 'default-pullquote-' . $this->text_alignment,
 		);
 
 		// Determine if there is a border specified.

--- a/includes/apple-exporter/components/class-table.php
+++ b/includes/apple-exporter/components/class-table.php
@@ -101,14 +101,14 @@ class Table extends Component {
 		// Register the JSON for the table style.
 		$table_cell_base_conditional    = array();
 		$table_row_col_base_conditional = array();
-		// Get Dark Table Colors
+		// Get Dark Table Colors.
 		$table_border_color_dark            = $theme->get_value( 'table_border_color_dark' );
 		$table_body_background_color_dark   = $theme->get_value( 'table_body_background_color_dark' );
 		$table_body_color_dark              = $theme->get_value( 'table_body_color_dark' );
 		$table_header_background_color_dark = $theme->get_value( 'table_header_background_color_dark' );
 		$table_header_color_dark            = $theme->get_value( 'table_header_color_dark' );
 
-		// If all are empty, do not add conditional styles
+		// If all are empty, do not add conditional styles.
 		$dark_table_colors_exist =
 			! empty( $table_border_color_dark ) ||
 			! empty( $table_body_background_color_dark ) ||
@@ -142,7 +142,7 @@ class Table extends Component {
 
 		// The following block sets:
 		// Dark Background Color of Cells
-		// Dark Text Color of Cells
+		// Dark Text Color of Cells.
 		$dark_bg_text_conditional = array();
 		if (
 			! empty( $table_body_background_color_dark ) ||
@@ -156,7 +156,7 @@ class Table extends Component {
 		if ( ! empty( $table_body_background_color_dark ) ) {
 			$dark_bg_text_conditional['conditional'][0]['backgroundColor'] = '#table_body_background_color_dark#';
 		}
-		
+
 		if ( ! empty( $table_body_color_dark ) ) {
 			$dark_bg_text_conditional['conditional'][0]['textStyle'] = array(
 				'textColor' => '#table_body_color_dark#',
@@ -165,7 +165,7 @@ class Table extends Component {
 
 		// The following block sets:
 		// Dark Header Background Color of Cells
-		// Dark Header Text Color of Cells
+		// Dark Header Text Color of Cells.
 		$dark_header_bg_text_conditional = array();
 		if (
 			! empty( $table_body_background_color_dark ) ||
@@ -179,14 +179,14 @@ class Table extends Component {
 		if ( ! empty( $table_header_background_color_dark ) ) {
 			$dark_header_bg_text_conditional['conditional'][0]['backgroundColor'] = '#table_header_background_color_dark#';
 		}
-		
+
 		if ( ! empty( $table_header_color_dark ) ) {
 			$dark_header_bg_text_conditional['conditional'][0]['textStyle'] = array(
 				'textColor' => '#table_header_color_dark#',
 			);
 		}
 
-		// Set Dark Border for Columns
+		// Set Dark Border for Columns.
 		$dark_inner_border_conditional = array();
 		if ( ! empty( $table_border_color_dark ) ) {
 			$dark_inner_border_conditional = array(
@@ -202,7 +202,7 @@ class Table extends Component {
 			);
 		}
 
-		// Set Dark Outer Border for Table
+		// Set Dark Outer Border for Table.
 		$dark_outer_border_conditional = array();
 		if ( ! empty( $table_border_color_dark ) ) {
 			$dark_outer_border_conditional = array(

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -63,19 +63,14 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 	 * Tests the ability to include a caption with a cover image.
 	 */
 	public function testCoverWithCaption() {
+		$this->set_theme_settings( [ 'cover_caption' => true ] );
 
 		// Create dummy post and attachment.
-		$file    = dirname( dirname( dirname( __DIR__ ) ) ) . '/data/test-image.jpg';
 		$post_id = self::factory()->post->create();
-		$image   = self::factory()->attachment->create_upload_object( $file, $post_id );
-
-		// Add a caption to the image.
-		$image_post = get_post( $image );
-		$image_post->post_excerpt = 'Test Caption';
-		wp_update_post( $image_post );
+		$image   = $this->get_new_attachment( $post_id, 'Test Caption' );
 
 		// Set the image as the featured image for the post.
-		update_post_meta( $post_id, '_thumbnail_id', $image );
+		set_post_thumbnail( $post_id, $image );
 
 		// Run the export and check the result.
 		$json = $this->get_json_for_post( $post_id );
@@ -86,7 +81,7 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 		$this->assertEquals( 'Test Caption', $json['components'][0]['components'][1]['text'] );
 
 		// Set cover image and caption via postmeta and ensure it takes priority.
-		$image2 = self::factory()->attachment->create_upload_object( $file );
+		$image2 = $this->get_new_attachment();
 		update_post_meta( $post_id, 'apple_news_coverimage', $image2 );
 		update_post_meta( $post_id, 'apple_news_coverimage_caption', 'Test Caption 2' );
 		$json = $this->get_json_for_post( $post_id );

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -19,7 +19,7 @@ use \Apple_Exporter\Builders\Component_Text_Styles;
 /**
  * A class which is used to test the \Apple_Exporter\Builders\Components class.
  */
-class Component_Tests extends WP_UnitTestCase {
+class Component_Tests extends Apple_News_Testcase {
 
 	/**
 	 * A data provider for the full size image URL test.
@@ -104,6 +104,7 @@ class Component_Tests extends WP_UnitTestCase {
 	 * @access public
 	 */
 	public function setup() {
+		parent::setUp();
 
 		// Setup.
 		$themes = new Admin_Apple_Themes;
@@ -147,6 +148,7 @@ class Component_Tests extends WP_UnitTestCase {
 	 * a URL, which lets us build cover images with captions.
 	 */
 	public function testCoverImageArrayConfig() {
+		$this->set_theme_settings( [ 'cover_caption' => true ] );
 		$cover_url = wp_get_attachment_url( $this->cover );
 		$content   = new Exporter_Content(
 			1,
@@ -198,6 +200,8 @@ class Component_Tests extends WP_UnitTestCase {
 	 * cover image.
 	 */
 	public function testFeaturedImageDeduping() {
+		$this->set_theme_settings( [ 'cover_caption' => true ] );
+
 		// Get image URLs for the two attachment images created during setUp.
 		$image1           = wp_get_attachment_url( $this->cover );
 		$image2           = wp_get_attachment_url( $this->image2 );

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -133,6 +133,7 @@ class Cover_Test extends Component_TestCase {
 	 */
 	public function testGeneratedJSONFromHTMLWithCaption() {
 		$this->settings->set( 'use_remote_images', 'yes' );
+		$this->set_theme_settings( [ 'cover_caption' => true ] );
 
 		// Create dummy post and attachment.
 		$post_id = self::factory()->post->create();
@@ -238,7 +239,12 @@ class Cover_Test extends Component_TestCase {
 	 * Ensures that the lightbox font is set to the same font face as the image caption.
 	 */
 	public function testLightboxFont() {
-		$this->set_theme_settings( [ 'caption_font' => 'Menlo-Regular' ] );
+		$this->set_theme_settings(
+			[
+				'caption_font'  => 'Menlo-Regular',
+				'cover_caption' => true,
+			]
+		);
 
 		// Create an image and give it a caption.
 		$image_id = $this->get_new_attachment( 0, 'Test Caption!' );

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -256,4 +256,33 @@ class Cover_Test extends Component_TestCase {
 			$json['components'][0]['components'][0]['caption']['textStyle']['fontName']
 		);
 	}
+
+	/**
+	 * Ensures that the cover caption is not enabled by default, but can be
+	 * enabled via a setting.
+	 */
+	public function testCaptionSetting() {
+		// Create an image and give it a caption.
+		$image_id = $this->get_new_attachment( 0, 'Test Caption!' );
+
+		// Create a test post.
+		$post_id = self::factory()->post->create();
+
+		// Set the featured image for the post.
+		set_post_thumbnail( $post_id, $image_id );
+
+		// Ensure that the caption is not set on the Cover component by default.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 1, count( $json['components'][0]['components'] ) );
+		$this->assertEquals( 'headerPhotoLayout', $json['components'][0]['components'][0]['layout'] );
+
+		// Enable support for the cover caption.
+		$this->set_theme_settings( [ 'cover_caption' => true ] );
+
+		// Ensure that the caption is set on the Cover component.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 2, count( $json['components'][0]['components'] ) );
+		$this->assertEquals( 'headerPhotoLayoutWithCaption', $json['components'][0]['components'][0]['layout'] );
+		$this->assertEquals( 'caption', $json['components'][0]['components'][1]['role'] );
+	}
 }


### PR DESCRIPTION
* By default, the cover caption will not appear in output, even if a caption is set on the image.
* Add a new option to the theme settings to determine whether the cover caption should be displayed.
* Add support for boolean options in theme settings.
* Fix some phpcs errors along the way.