### PR TITLE
APPLE-48 Add stillURL property to Brightcove videos using the API

### DIFF
--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -57,6 +57,7 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 		$json    = $this->get_json_for_post( $post_id );
 		$this->assertEquals( 'video', $json['components'][2]['role'] );
 		$this->assertEquals( 'https://edge.api.brightcove.com/playback/v1/accounts/1234567890/videos/1234567890123', $json['components'][2]['URL'] );
+		$this->assertEquals( 'https://cf-images.us-east-1.prod.boltdns.net/v1/jit/1234567890/abcd1234-ef56-ab78-cd90-efabcd123456/main/1280x720/1s234ms/match/image.jpg', $json['components'][2]['stillURL'] );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,3 +35,8 @@ require $_tests_dir . '/includes/bootstrap.php';
 require_once __DIR__ . '/class-apple-news-testcase.php';
 
 require_once __DIR__ . '/apple-exporter/components/class-component-testcase.php';
+
+// Load mocks for integration tests.
+require_once __DIR__ . '/mocks/class-bc-accounts.php';
+require_once __DIR__ . '/mocks/class-bc-cms-api.php';
+$bc_accounts = new BC_Accounts();

--- a/tests/mocks/class-bc-accounts.php
+++ b/tests/mocks/class-bc-accounts.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Apple News Tests Mocks: BC_Accounts class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+/**
+ * A mock for the BC_Accounts class from the Brightcove Video Connect plugin.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+class BC_Accounts {
+
+	/**
+	 * Mocks the functionality of BC_Accounts::get_account_id.
+	 *
+	 * Returns the currently "set" account ID, which will always be 12345678980.
+	 *
+	 * @return string The account ID.
+	 */
+	public function get_account_id() {
+		return '1234567890';
+	}
+
+	/**
+	 * Mocks the functionality of BC_Accounts::set_current_account_by_id.
+	 *
+	 * @param string $account_id The account ID to set.
+	 *
+	 * @return array An array containing the "new" account object.
+	 */
+	public function set_current_account_by_id( $account_id ) {
+		return [
+			'account_id'    => $account_id,
+			'account_name'  => 'Test Account Name',
+			'client_id'     => 'abcd1234-ef56-ab78-cd90-efabcd123456',
+			'client_secret' => 'AbCdEfGhIjKlMnOpQrStUvWxYz12345678-AbCdEfGhIjKlMnOpQrStUvWxYz0_AbCdE-AbCdEfG_AbCdE_AbC',
+			'hash'          => 'abcdef0123456789',
+			'set_default'   => 'default',
+		];
+	}
+}

--- a/tests/mocks/class-bc-cms-api.php
+++ b/tests/mocks/class-bc-cms-api.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Apple News Tests Mocks: BC_CMS_API class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+/**
+ * A mock for the BC_CMS_API class from the Brightcove Video Connect plugin.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+class BC_CMS_API {
+	/**
+	 * Mocks the response from the Brightcove API for a single video's images.
+	 *
+	 * @param string $video_id Not used. The ID of the requested video. This is used in the actual function.
+	 *
+	 * @return array Array of the video's images retrieved.
+	 */
+	public function video_get_images( $video_id ) {
+		return [
+			'poster' => [
+				'src' => 'https://cf-images.us-east-1.prod.boltdns.net/v1/jit/1234567890/abcd1234-ef56-ab78-cd90-efabcd123456/main/1280x720/1s234ms/match/image.jpg',
+        'sources' => [
+          [
+						'src' => 'https://cf-images.us-east-1.prod.boltdns.net/v1/jit/1234567890/abcd1234-ef56-ab78-cd90-efabcd123456/main/1280x720/1s234ms/match/image.jpg',
+            'height' => 720,
+            'width' => 1280,
+          ],
+	      ],
+			],
+			'thumbnail' => [
+				'src' => 'https://cf-images.us-east-1.prod.boltdns.net/v1/jit/1234567890/abcd1234-ef56-ab78-cd90-efabcd123456/main/1690x90/1s234ms/match/image.jpg',
+				'sources' => [
+					[
+						'src' => 'https://cf-images.us-east-1.prod.boltdns.net/v1/jit/1234567890/abcd1234-ef56-ab78-cd90-efabcd123456/main/160x90/1s234ms/match/image.jpg',
+						'height' => 90,
+						'width' => 160,
+					],
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
Note to reviewer: since we're using the Brightcove Video Connect plugin to get the API connection, we needed to mock some of the classes and functions from that plugin in order to get the tests to work properly.