### PR TITLE
APPLE-50 Add .deployignore

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,14 @@
+.DS_Store
+*.zip
+tags
+composer.lock
+vendor
+node_modules
+npm-debug.log
+
+# IDEs
+.idea
+.vscode
+
+# Directories and files that we do not want to be included with the built
+# version and deployed to WordPress.org.

--- a/.deployignore
+++ b/.deployignore
@@ -12,3 +12,21 @@ npm-debug.log
 
 # Directories and files that we do not want to be included with the built
 # version and deployed to WordPress.org.
+.babelrc
+.editorconfig
+.eslintignore
+.eslintrc.json
+.github
+.travis.yml
+assets/images
+assets/js/pluginsidebar
+assets/js/util
+bin
+composer.json
+package.json
+package-lock.json
+phpcs.xml.dist
+phpunit.xml.dist
+README.md
+tests
+webpack.config.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Provided by Actions
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: A version that contains pre-built JavaScript assets for Gutenberg. This version matches what is deployed to WordPress.org, minus some development and wiki image files, and is suitable for inclusion via submodule.
           draft: false
           prerelease: true


### PR DESCRIPTION
Add a .deployignore file to specify what folders and files should be included in what is built, which will control what is deployed to WordPress.org. Notably, we are including the build folder for JS assets, and we are excluding a number of files and folders that should not be sent to WordPress.org (certain uncompiled source files, tests, etc).