### PR TITLE
APPLE-51 Re-add intro component to component order on theme customizer

### DIFF
--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -489,9 +489,8 @@ class Theme {
 		}
 
 		// Get inactive components.
-		$options             = self::get_options();
 		$inactive_components = array_diff( // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
-			$options['meta_component_order']['default'],
+			[ 'cover', 'title', 'byline', 'intro' ],
 			$component_order
 		);
 


### PR DESCRIPTION
Since we removed the Intro component from the default component order, our logic for determining inactive components needed a re-work.