### PR TITLE
APPLE-51 Fix default theme check

### DIFF
--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1071,7 +1071,7 @@ class Theme {
 				'type'        => 'integer',
 			),
 			'pullquote_border_color'             => array(
-				'default' => '',
+				'default' => '#53585f',
 				'label'   => __( 'Pull quote border color', 'apple-news' ),
 				'type'    => 'color',
 			),
@@ -1173,17 +1173,17 @@ class Theme {
 				'type'    => 'select',
 			),
 			'table_body_line_height'             => array(
-				'default' => 20.0,
+				'default' => 24.0,
 				'label'   => __( 'Table body line height', 'apple-news' ),
 				'type'    => 'float',
 			),
 			'table_body_padding'                 => array(
-				'default' => 5.0,
+				'default' => 10.0,
 				'label'   => __( 'Table body padding', 'apple-news' ),
 				'type'    => 'float',
 			),
 			'table_body_size'                    => array(
-				'default' => 16,
+				'default' => 17,
 				'label'   => __( 'Table body font size', 'apple-news' ),
 				'type'    => 'integer',
 			),
@@ -1200,7 +1200,7 @@ class Theme {
 				'type'    => 'select',
 			),
 			'table_border_color'                 => array(
-				'default' => '#4f4f4f',
+				'default' => '#333333',
 				'label'   => __( 'Table border color', 'apple-news' ),
 				'type'    => 'color',
 			),
@@ -1221,7 +1221,7 @@ class Theme {
 				'type'    => 'float',
 			),
 			'table_header_background_color'      => array(
-				'default' => '#fafafa',
+				'default' => '#e1e1e1',
 				'label'   => __( 'Table header background color', 'apple-news' ),
 				'type'    => 'color',
 			),
@@ -1246,13 +1246,13 @@ class Theme {
 				'type'    => 'font',
 			),
 			'table_header_horizontal_alignment'  => array(
-				'default' => 'center',
+				'default' => 'left',
 				'label'   => __( 'Table header horizontal alignment', 'apple-news' ),
 				'options' => array( 'left', 'center', 'right' ),
 				'type'    => 'select',
 			),
 			'table_header_line_height'           => array(
-				'default' => 20.0,
+				'default' => 24.0,
 				'label'   => __( 'Table header line height', 'apple-news' ),
 				'type'    => 'float',
 			),
@@ -1262,7 +1262,7 @@ class Theme {
 				'type'    => 'float',
 			),
 			'table_header_size'                  => array(
-				'default' => 16,
+				'default' => 17,
 				'label'   => __( 'Table header font size', 'apple-news' ),
 				'type'    => 'integer',
 			),

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -111,10 +111,8 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 		$this->prophet               = new Prophecy\Prophet();
 		$this->prophecized_workspace = $this->prophet->prophesize( '\Apple_Exporter\Workspace' );
 
-		// Create a new theme and save it for future use.
-		$this->theme = new Apple_Exporter\Theme();
-		$this->theme->save();
-		$this->theme->set_active();
+		// Load the Default theme from config and save it for future use.
+		$this->load_example_theme( 'default' );
 
 		// Create styles for future use.
 		$this->styles = new Apple_Exporter\Builders\Component_Text_Styles(
@@ -201,6 +199,36 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 		);
 
 		return json_decode( $export->perform(), true );
+	}
+
+	/**
+	 * Loads an example theme given a slug.
+	 *
+	 * @param string $slug The slug of the example theme to load.
+	 */
+	protected function load_example_theme( $slug ) {
+		// Load the theme data from the JSON configuration file.
+		$options = json_decode( file_get_contents( dirname( __DIR__ ) . '/assets/themes/' . $slug . '.json' ), true );
+		if ( empty( $options ) ) {
+			return;
+		}
+
+		// Negotiate screenshot URL.
+		$options['screenshot_url'] = plugins_url(
+			'/assets/screenshots/' . $slug . '.png',
+			__DIR__
+		);
+
+		// Create a new instance of the Theme class and set the theme name.
+		$this->theme = new \Apple_Exporter\Theme();
+		$this->theme->set_name( $options['theme_name'] );
+
+		// Save the theme.
+		$this->theme->load( $options );
+		$this->theme->save();
+
+		// Make this theme the active theme.
+		$this->theme->set_active();
 	}
 
 	/**


### PR DESCRIPTION
* Have the `Apple_News_Testcase` class load the default theme from the configuration file rather than relying on the defaults specified in the class. This will allow us to test against the settings that an actual user would be experiencing following an install of the plugin.
* Fix discrepancies between the defaults in the `Theme` class and the defaults in the `Default` theme exposed by making this change.