### PR TITLE
APPLE-51 Allow for save of empty specs

### DIFF
--- a/includes/apple-exporter/class-component-spec.php
+++ b/includes/apple-exporter/class-component-spec.php
@@ -232,15 +232,15 @@ class Component_Spec {
 		// Validate the JSON.
 		$json = json_decode( $spec, true );
 		if ( empty( $json ) ) {
-			\Admin_Apple_Notice::error(
+			\Admin_Apple_Notice::info(
 				sprintf(
 					// translators: token is a spec label.
-					__( 'The spec for %s was invalid and cannot be saved', 'apple-news' ),
+					__( 'The spec for %s was empty or invalid. Reverting to the default spec.', 'apple-news' ),
 					$this->label
 				)
 			);
 
-			return false;
+			$json = $this->spec;
 		}
 
 		// Compare this JSON to the built-in JSON.


### PR DESCRIPTION
With the introduction of the End of Article component, which defaults to having specs that are empty, we need a way to be able to reset a spec to its default state. Previously, saving an empty spec would result in an error. We are here downgrading the error to a notice and resetting the spec to its default value if the JSON passed was empty or invalid. In the case of the End of Article module, the default state is empty.