### PR TITLE
APPLE-51 Brightcove special handling for REST requests

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -336,9 +336,21 @@ class Export extends Action {
 	private function get_brightcove_stillurl( $account_id, $video_id ) {
 		global $bc_accounts;
 
-		// If the $bc_accounts global doesn't exist, or if the BC_CMS_API class doesn't exist, bail.
-		if ( empty( $bc_accounts ) || ! class_exists( '\BC_CMS_API' ) ) {
+		// If the $bc_accounts global doesn't exist, bail.
+		if ( empty( $bc_accounts ) ) {
 			return '';
+		}
+
+		/*
+		 * BC_Setup only runs if is_admin returns true, which won't be if the
+		 * publish was triggered from a REST request (which it will be if the
+		 * user is using Gutenberg to publish manually, or on publish of the
+		 * post with auto-publish turned on). Therefore, we need to bootstrap
+		 * the functionality ourselves by mimicing the behavior of the init
+		 * hook.
+		 */
+		if ( ! class_exists( '\BC_CMS_API' ) && class_exists( '\BC_Setup' ) ) {
+			\BC_Setup::action_init();
 		}
 
 		// Ensure the account ID and video IDs are strings.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: potatomaster, kevinfodness, jomurgel, danbowles, alleyinteractive,
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 4.0
-Tested up to: 5.4.2
+Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 2.1.0
 License: GPLv3 or later

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,8 @@ require_once __DIR__ . '/class-apple-news-testcase.php';
 require_once __DIR__ . '/apple-exporter/components/class-component-testcase.php';
 
 // Load mocks for integration tests.
-require_once __DIR__ . '/mocks/class-bc-accounts.php';
-require_once __DIR__ . '/mocks/class-bc-cms-api.php';
-$bc_accounts = new BC_Accounts();
+require_once __DIR__ . '/mocks/class-bc-setup.php';
+
+// Activate mocked Brightcove functionality.
+$bc_setup = new BC_Setup();
+$bc_setup->action_init();

--- a/tests/mocks/class-bc-setup.php
+++ b/tests/mocks/class-bc-setup.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Apple News Tests Mocks: BC_Setup class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+/**
+ * A mock for the BC_Setup class from the Brightcove Video Connect plugin.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+class BC_Setup {
+	/**
+	 * Mocks the setup actions that happen on init that are relevant for testing this plugin.
+	 */
+	public function action_init() {
+		global $bc_accounts;
+
+		require_once __DIR__ . '/class-bc-accounts.php';
+		require_once __DIR__ . '/class-bc-cms-api.php';
+
+		$bc_accounts = new BC_Accounts();
+	}
+}


### PR DESCRIPTION
When a request to publish an article to Apple News arrives via a REST request (either a manual publish from Gutenberg or an article publish from Gutenberg with automatic publishing turned on) the Brightcove plugin isn't fully bootstrapped (because `is_admin` returns false) so we have to bootstrap it ourselves to be able to get access to the functionality to let us pull video still frame URLs.