### PR TITLE
APPLE-43 Fix for globals in template parts

### DIFF
--- a/admin/partials/cover-image.php
+++ b/admin/partials/cover-image.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Cover Image template
  *
+ * @global WP_Post $post
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/field-meta-component-order.php
+++ b/admin/partials/field-meta-component-order.php
@@ -2,6 +2,9 @@
 /**
  * Partial for the meta component order field in theme options configuration.
  *
+ * @global array $component_order
+ * @global array $inactive_components
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -2,6 +2,19 @@
 /**
  * Publish to Apple News partials: Publish Metabox template
  *
+ * @global string  $api_id
+ * @global bool    $deleted
+ * @global bool    $is_hidden
+ * @global bool    $is_paid
+ * @global bool    $is_preview
+ * @global bool    $is_sponsored
+ * @global string  $maturity_rating
+ * @global bool    $pending
+ * @global string  $pullquote
+ * @global string  $pullquote_position
+ * @global WP_Post $post
+ * @global string  $publish_action
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -2,6 +2,9 @@
 /**
  * Publish to Apple News partials: Notice template
  *
+ * @global string $message
+ * @global string $type
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-bulk-export.php
+++ b/admin/partials/page-bulk-export.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Bulk Export page template
  *
+ * @global array $articles
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-index.php
+++ b/admin/partials/page-index.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Index page template
  *
+ * @global Admin_Apple_News_List_Table $table
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -2,6 +2,13 @@
 /**
  * Publish to Apple News partials: JSON page template
  *
+ * @global array  $all_themes
+ * @global array  $components
+ * @global string $selected_component
+ * @global string $selected_theme
+ * @global array  $specs
+ * @global string $theme_admin_url
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-options-section-hidden.php
+++ b/admin/partials/page-options-section-hidden.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Options Section Hidden page template
  *
+ * @global Admin_Apple_Settings_Section $apple_section
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-options-section.php
+++ b/admin/partials/page-options-section.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Options Section page template
  *
+ * @global Admin_Apple_Settings_Section $apple_section
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Options page template
  *
+ * @global array $sections
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -2,6 +2,13 @@
 /**
  * Publish to Apple News partials: Sections page template
  *
+ * @global array       $sections
+ * @global WP_Taxonomy $taxonomy
+ * @global array       $taxonomy_mappings
+ * @global string      $theme_admin_url
+ * @global array       $theme_mappings
+ * @global array       $themes
+ *
  * @package Apple_News
  */
 
@@ -71,7 +78,7 @@
 					<td>
 						<?php
 							$apple_theme_id       = 'apple-news-theme-mapping-' . ( ++ $apple_count );
-							$apple_selected_theme = ( isset( $apple_theme_mappings[ $apple_section_id ] ) ) ? $apple_theme_mappings[ $apple_section_id ] : '';
+							$apple_selected_theme = ( isset( $theme_mappings[ $apple_section_id ] ) ) ? $theme_mappings[ $apple_section_id ] : '';
 						?>
 						<select name="theme-mapping-<?php echo esc_attr( $apple_section_id ); ?>" id="<?php echo esc_attr( $apple_theme_id ); ?>">
 							<option value=""></option>

--- a/admin/partials/page-single-push.php
+++ b/admin/partials/page-single-push.php
@@ -2,6 +2,11 @@
 /**
  * Publish to Apple News partials: Single Push page template
  *
+ * @global string  $message
+ * @global WP_Post $post
+ * @global array   $post_meta
+ * @global array   $sections
+ *
  * @package Apple_News
  */
 

--- a/admin/partials/page-theme-edit.php
+++ b/admin/partials/page-theme-edit.php
@@ -2,6 +2,11 @@
 /**
  * Publish to Apple News partials: Theme Edit page template
  *
+ * @global Apple_Exporter\Theme $theme
+ * @global array                $theme_options
+ * @global string               $theme_admin_url
+ * @global string               $theme_name
+ *
  * @package Apple_News
  */
 


### PR DESCRIPTION
* Fixes an issue on section / category / theme mapping where the theme option didn't save due to a mistake in namespacing variables as part of an earlier phpcs fix.
* Adds `@global` directives to template parts that inherit variables from the calling context to eliminate warnings about undefined variables in IDEs and allow for code completion.