### PR TITLE
APPLE-43 Improvements to the EOA editing experience

### DIFF
--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -98,7 +98,7 @@
 				foreach ( $specs as $apple_spec ) :
 					$apple_field_name   = 'apple_news_json_' . $apple_spec->key_from_name( $apple_spec->name );
 					$apple_json_display = $apple_spec->format_json( $apple_spec->get_spec( $selected_theme ) );
-					$apple_rows         = substr_count( $apple_json_display, "\n" ) + 1;
+					$apple_rows         = max( substr_count( $apple_json_display, "\n" ) + 1, 5 );
 					$apple_editor_name  = 'editor_' . str_replace( '-', '_', $apple_field_name );
 					$apple_editor_style = sprintf(
 						'width: %spx; height: %spx',

--- a/includes/apple-exporter/class-component-spec.php
+++ b/includes/apple-exporter/class-component-spec.php
@@ -221,7 +221,7 @@ class Component_Spec {
 	/**
 	 * Save the provided spec override.
 	 *
-	 * @param array  $spec       The spec definition to save.
+	 * @param string $spec       The spec definition to save.
 	 * @param string $theme_name Optional. Theme name to save to if other than default.
 	 *
 	 * @access public
@@ -232,13 +232,15 @@ class Component_Spec {
 		// Validate the JSON.
 		$json = json_decode( $spec, true );
 		if ( empty( $json ) ) {
-			\Admin_Apple_Notice::info(
-				sprintf(
+			if ( null === $json ) {
+				\Admin_Apple_Notice::info(
+					sprintf(
 					// translators: token is a spec label.
-					__( 'The spec for %s was empty or invalid. Reverting to the default spec.', 'apple-news' ),
-					$this->label
-				)
-			);
+						__( 'The spec for %s was empty or invalid. Reverting to the default spec.', 'apple-news' ),
+						$this->label
+					)
+				);
+			}
 
 			$json = $this->spec;
 		}
@@ -407,7 +409,9 @@ class Component_Spec {
 	 * @return string The JSON for the spec.
 	 */
 	public function format_json( $spec ) {
-		return wp_json_encode( $spec, JSON_PRETTY_PRINT );
+		return ! empty( $spec )
+			? wp_json_encode( $spec, JSON_PRETTY_PRINT )
+			: '{}';
 	}
 
 	/**


### PR DESCRIPTION
* If a spec is empty, default it to an empty object rather than an empty array. The distinction isn't important in PHP, but it is in JSON.
* Default the editing window to a minimum of 5 lines. The editing window doesn't automatically resize when you add content, and the logic that was in place would size it to the current content, making editing an EOA module, which renders at only 1 line, extremely frustrating.
* Don't display the warning about invalid JSON and resetting to the default state if the EOA spec is empty and is supposed to be empty. Only warn if the spec is literally empty (`''`) which will cause the `json_decode` to return a `null` value.