### PR TITLE
Update to vipwpcs 2.2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ branches:
 cache:
   directories:
     - $HOME/.config/composer/cache
-    - ./npm
-    - ./vendor
+    - $HOME/.npm
 
 # Git clone depth.
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,13 @@ branches:
 cache:
   directories:
     - $HOME/.config/composer/cache
+    - ./npm
     - ./vendor
-    - node_modules
 
 # Git clone depth.
 git:
   depth: 1
+  quiet: true
 
 matrix:
   fast_finish: true
@@ -75,8 +76,7 @@ before_script:
   # Set up phpcs.
   - |
     if [[ "$WP_PHPCS" == "1" ]] ; then
-      composer global require automattic/vipwpcs
-      phpcs --config-set installed_paths $HOME/.config/composer/vendor/wp-coding-standards/wpcs,$HOME/.config/composer/vendor/automattic/vipwpcs
+      composer g require --dev automattic/vipwpcs dealerdirect/phpcodesniffer-composer-installer
     fi
 
   # Set up jest.
@@ -84,7 +84,7 @@ before_script:
     if [[ "$WP_JS" == "1" ]] ; then
       nvm install 12
       npm i -g npm@6
-      npm install
+      npm ci
     fi
 
 # Run test script commands.

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -97,7 +97,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 
 		switch ( $action ) {
 			case self::namespace_action( 'push' ):
-				/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+				/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
 
 				$section = new Apple_Actions\Index\Section( $this->settings );
 				try {

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -165,7 +165,7 @@ class Admin_Apple_JSON extends Apple_News {
 			wp_die( esc_html__( 'You do not have permissions to access this page.', 'apple-news' ) );
 		}
 
-		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+		/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
 
 		// Get components for the dropdown.
 		$components = $this->list_components();

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -272,7 +272,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 	 */
 	public function publish_meta_box( $post ) {
 
-		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+		/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
 
 		// Only show the publish feature if the user is authorized and auto sync is not enabled.
 		// Also check if the post has been previously published and/or deleted.

--- a/admin/class-admin-apple-preview.php
+++ b/admin/class-admin-apple-preview.php
@@ -48,7 +48,7 @@ class Admin_Apple_Preview extends Apple_News {
 		?>
 		<div class="apple-news-preview">
 			<?php
-			/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+			/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
 
 			// Build sample content.
 			$title = sprintf(

--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -370,11 +370,13 @@ class Admin_Apple_Sections extends Apple_News {
 			}
 		}
 
-		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+		/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
+
 		$theme_mappings  = get_option( self::THEME_MAPPING_KEY );
 		$theme_obj       = new Admin_Apple_Themes();
 		$theme_admin_url = add_query_arg( 'page', $theme_obj->theme_page_name, admin_url( 'admin.php' ) );
 		$themes          = \Apple_Exporter\Theme::get_registry();
+
 		/* phpcs:enable */
 
 		// Load the partial with the form.

--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -149,7 +149,12 @@ class Admin_Apple_Settings extends Apple_News {
 			wp_die( esc_html__( 'You do not have permissions to access this page.', 'apple-news' ) );
 		}
 
-		$sections = $this->sections; // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
+
+		$sections = $this->sections;
+
+		/* phpcs:enable */
+
 		include plugin_dir_path( __FILE__ ) . 'partials/page-options.php';
 	}
 

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -270,7 +270,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 */
 	public function page_theme_edit_render() {
 
-		/* phpcs:disable WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable */
+		/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
 
 		// Ensure the user has permission to load this screen.
 		if ( ! current_user_can( apply_filters( 'apple_news_settings_capability', 'manage_options' ) ) ) {

--- a/admin/partials/cover-image.php
+++ b/admin/partials/cover-image.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Cover Image template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global WP_Post $post
  *
  * @package Apple_News

--- a/admin/partials/field-meta-component-order.php
+++ b/admin/partials/field-meta-component-order.php
@@ -2,6 +2,8 @@
 /**
  * Partial for the meta component order field in theme options configuration.
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global array $component_order
  * @global array $inactive_components
  *

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -2,6 +2,9 @@
 /**
  * Publish to Apple News partials: Publish Metabox template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.SelfOutsideClass
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global string  $api_id
  * @global bool    $deleted
  * @global bool    $is_hidden

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Notice template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global string $message
  * @global string $type
  *

--- a/admin/partials/page-bulk-export.php
+++ b/admin/partials/page-bulk-export.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Bulk Export page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global array $articles
  *
  * @package Apple_News

--- a/admin/partials/page-index.php
+++ b/admin/partials/page-index.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Index page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global Admin_Apple_News_List_Table $table
  *
  * @package Apple_News

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: JSON page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global array  $all_themes
  * @global array  $components
  * @global string $selected_component

--- a/admin/partials/page-options-section-hidden.php
+++ b/admin/partials/page-options-section-hidden.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Options Section Hidden page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global Admin_Apple_Settings_Section $apple_section
  *
  * @package Apple_News

--- a/admin/partials/page-options-section.php
+++ b/admin/partials/page-options-section.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Options Section page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global Admin_Apple_Settings_Section $apple_section
  *
  * @package Apple_News

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Options page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global array $sections
  *
  * @package Apple_News

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Sections page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global array       $sections
  * @global WP_Taxonomy $taxonomy
  * @global array       $taxonomy_mappings

--- a/admin/partials/page-single-push.php
+++ b/admin/partials/page-single-push.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Single Push page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global string  $message
  * @global WP_Post $post
  * @global array   $post_meta

--- a/admin/partials/page-theme-edit.php
+++ b/admin/partials/page-theme-edit.php
@@ -2,6 +2,8 @@
 /**
  * Publish to Apple News partials: Theme Edit page template
  *
+ * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ *
  * @global Apple_Exporter\Theme $theme
  * @global array                $theme_options
  * @global string               $theme_admin_url

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -13,7 +13,7 @@ namespace Apple_News\REST;
  * @param array $data data from query args.
  * @return array updated response.
  */
-function get_settings_response( $data ) {
+function get_settings_response( $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	if ( empty( get_current_user_id() ) ) {
 		return [];
 	}

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -482,6 +482,8 @@ class Theme {
 	 */
 	public static function render_meta_component_order( $theme ) {
 
+		/* phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable */
+
 		// Get the current order.
 		$component_order = $theme->get_value( 'meta_component_order' );
 		if ( empty( $component_order ) || ! is_array( $component_order ) ) {
@@ -489,10 +491,12 @@ class Theme {
 		}
 
 		// Get inactive components.
-		$inactive_components = array_diff( // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		$inactive_components = array_diff(
 			[ 'cover', 'title', 'byline', 'intro' ],
 			$component_order
 		);
+
+		/* phpcs:enable */
 
 		// Load the template.
 		include dirname( dirname( plugin_dir_path( __FILE__ ) ) )

--- a/includes/apple-exporter/components/class-advertisement.php
+++ b/includes/apple-exporter/components/class-advertisement.php
@@ -49,7 +49,7 @@ class Advertisement extends Component {
 	 * @param string $html The HTML to parse into text for processing.
 	 * @access protected
 	 */
-	protected function build( $html ) {
+	protected function build( $html ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$this->register_json(
 			'json',
 			array()

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -270,7 +270,7 @@ abstract class Component {
 	 * @access public
 	 * @return \DOMElement|null The node on success, or null on no match.
 	 */
-	public static function node_matches( $node ) {
+	public static function node_matches( $node ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return null;
 	}
 

--- a/includes/apple-exporter/components/class-divider.php
+++ b/includes/apple-exporter/components/class-divider.php
@@ -67,7 +67,7 @@ class Divider extends Component {
 	 * @param string $html The HTML to parse into text for processing.
 	 * @access protected
 	 */
-	protected function build( $html ) {
+	protected function build( $html ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$this->register_json(
 			'json',
 			array()

--- a/includes/apple-exporter/components/class-end-of-article.php
+++ b/includes/apple-exporter/components/class-end-of-article.php
@@ -42,7 +42,7 @@ class End_Of_Article extends Component {
 	 * @param string $html The HTML to parse into text for processing.
 	 * @access protected
 	 */
-	protected function build( $html ) {
+	protected function build( $html ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$this->register_json(
 			'json',
 			array()

--- a/includes/apple-push-api/class-mime-builder.php
+++ b/includes/apple-push-api/class-mime-builder.php
@@ -175,7 +175,7 @@ class MIME_Builder {
 			$name,
 			$filename,
 			$contents,
-			$this->get_mime_type_for( $filepath ),
+			'application/octet-stream',
 			$size
 		);
 	}
@@ -244,19 +244,6 @@ class MIME_Builder {
 		}
 
 		return $attachment;
-	}
-
-	/**
-	 * Get the MIME type for a file.
-	 *
-	 * @todo replace with the proper WordPress function.
-	 * @param string $filepath The filepath to get the MIME type for.
-	 * @access private
-	 * @return string The MIME type for the filepath.
-	 */
-	private function get_mime_type_for( $filepath ) {
-		// TODO: rethink this for better integration with WordPress.
-		return 'application/octet-stream';
 	}
 
 	/**


### PR DESCRIPTION
* Convert `WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable` to `VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable`
* Ignore or fix instances of unused function parameters
* Convert to using the VIP recommended method of installing vipwpcs and registering sniffs
* Convert to using `npm ci` and caching the `.npm` directory