### PR TITLE
APPLE-53 Add section priority level setting

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -459,13 +459,33 @@ class Export extends Action {
 	 */
 	private function set_theme( $sections ) {
 
-		// This can only work if there is explicitly one section.
-		if ( ! is_array( $sections ) || 1 !== count( $sections ) ) {
+		// If there are no sections, bail.
+		if ( empty( $sections ) || ! is_array( $sections ) ) {
 			return;
 		}
 
+		// Negotiate the section to use based on priority.
+		$priorities = get_option(
+			Admin_Apple_Sections::PRIORITY_MAPPING_KEY,
+			[]
+		);
+		arsort( $priorities );
+		$assigned_section = basename( $sections[0] );
+		$section_keys     = array_map(
+			function ( $section ) {
+				return basename( $section );
+			},
+			$sections
+		);
+		foreach ( array_keys( $priorities ) as $priority ) {
+			if ( in_array( $priority, $section_keys, true ) ) {
+				$assigned_section = $priority;
+				break;
+			}
+		}
+
 		// Check if there is a custom theme mapping.
-		$theme_name = Admin_Apple_Sections::get_theme_for_section( basename( $sections[0] ) );
+		$theme_name = Admin_Apple_Sections::get_theme_for_section( $assigned_section );
 		if ( empty( $theme_name ) ) {
 			return;
 		}

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -499,12 +499,7 @@ class Export extends Action {
 		 * last segment using basename() into a new array that we can use for easy
 		 * comparison.
 		 */
-		$section_keys = array_map(
-			function ( $section ) {
-				return basename( $section );
-			},
-			$sections
-		);
+		$section_keys = array_map( 'basename', $sections );
 
 		/*
 		 * Loop over the priority list and try to find a section that is assigned

--- a/admin/partials/page-sections.php
+++ b/admin/partials/page-sections.php
@@ -4,6 +4,7 @@
  *
  * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  *
+ * @global array       $priority_mappings
  * @global array       $sections
  * @global WP_Taxonomy $taxonomy
  * @global array       $taxonomy_mappings
@@ -34,12 +35,20 @@
 	echo wp_kses_post(
 		sprintf(
 			// translators: first argument is an opening <a> tag, second argument is </a>.
-			__( 'You can also map a theme to automatically be used for posts with a specific Apple News section, if you want to use something other than the %1$sactive theme%2$s. This will only work for posts with precisely one Apple News section to avoid conflicts.', 'apple-news' ),
+			__( 'You can also map a theme to automatically be used for posts with a specific Apple News section, if you want to use something other than the %1$sactive theme%2$s.', 'apple-news' ),
 			'<a href="' . esc_url( $theme_admin_url ) . '">',
 			'</a>'
 		)
 	);
 	?>
+	</p>
+	<p>
+		<?php
+			esc_html_e(
+				'Additionally, you can assign a priority to each section. If a post will be published to more than one section, the priority determines which theme is used for the post. A higher priority will take precedence. The theme assigned to the section with the highest priority that is assigned to the post will be used as the selected theme for the post.',
+				'apple-news'
+			);
+			?>
 	</p>
 	<form method="post" action="" id="apple-news-section-form" enctype="multipart/form-data">
 		<?php wp_nonce_field( 'apple_news_sections' ); ?>
@@ -53,6 +62,7 @@
 			<thead>
 			<tr>
 				<th scope="col" id="apple_news_section_name" class="manage-column column-apple-news-section-name column-primary"><?php esc_html_e( 'Section', 'apple-news' ); ?></th>
+				<th scope="col" id="apple_news_section_priority" class="manage-column column-apple-news-section-priority"><?php esc_html_e( 'Priority', 'apple-news' ); ?></th>
 				<th scope="col" id="apple_news_section_taxonomy_mapping" class="manage-column column-apple-news-section-taxonomy-mapping"><?php echo esc_html( $taxonomy->label ); ?></th>
 				<th scope="col" id="apple_news_section_theme_mapping" class="manage-column column-apple-news-section-theme-mapping column-primary"><?php esc_html_e( 'Theme', 'apple-news' ); ?></th>
 			</tr>
@@ -62,6 +72,15 @@
 			<?php foreach ( $sections as $apple_section_id => $apple_section_name ) : ?>
 				<tr id="apple-news-section-<?php echo esc_attr( $apple_section_id ); ?>">
 					<td><?php echo esc_html( $apple_section_name ); ?></td>
+					<td>
+						<input
+							aria-labelledby="apple_news_section_priority"
+							name="priority-mapping-<?php echo esc_attr( $apple_section_id ); ?>"
+							type="number"
+							step="1"
+							value="<?php echo esc_attr( isset( $priority_mappings[ $apple_section_id ] ) ? (int) $priority_mappings[ $apple_section_id ] : 1 ); ?>"
+						/>
+					</td>
 					<td>
 						<ul class="apple-news-section-taxonomy-mapping-list">
 						<?php if ( ! empty( $taxonomy_mappings[ $apple_section_id ] ) ) : ?>

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -223,29 +223,27 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 		);
 	}
 
+	/**
+	 * Tests mapping taxonomy terms to Apple News sections.
+	 */
 	public function testSectionMapping() {
-		// Create a post
-		$title = 'My Title';
-		$content = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue arcu. Curabitur lacus elit, venenatis a laoreet sit amet, imperdiet ac lorem. Curabitur sed leo sed ligula tempor feugiat. Cras in tellus et elit volutpat.</p>';
 
-		$post_id = $this->factory->post->create( array(
-			'post_title' => $title,
-			'post_content' => $content,
-		) );
+		// Create a post.
+		$post_id = self::factory()->post->create();
 
-		// Create a term and add it to the post
-		$term_id = $this->factory->term->create( array(
+		// Create a term and add it to the post.
+		$term_id = self::factory()->term->create( array(
 			'taxonomy' => 'category',
 			'name' => 'news',
 		) );
 		wp_set_post_terms( $post_id, array( $term_id ), 'category' );
 
-		// Create a taxonomy map
+		// Create a taxonomy map.
 		update_option( \Admin_Apple_Sections::TAXONOMY_MAPPING_KEY, array(
 			'abcdef01-2345-6789-abcd-ef012356789a' => array( $term_id ),
 		) );
 
-		// Cache as a transient to bypass the API call
+		// Cache as a transient to bypass the API call.
 		$self = 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a';
 		set_transient(
 			'apple_news_sections',
@@ -266,46 +264,38 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 			)
 		);
 
-		// Get sections for the post
+		// Get sections for the post.
 		$sections = \Admin_Apple_Sections::get_sections_for_post( $post_id );
 
-		// Check that the correct mapping was returned
+		// Check that the correct mapping was returned.
 		$this->assertEquals(
 			$sections,
 			array( $self )
 		);
 
-		// Remove the transient and the map
+		// Remove the transient and the map.
 		delete_option( \Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
 		delete_transient( 'apple_news_sections' );
 	}
 
+	/**
+	 * Tests the behavior of theme mapping by ensuring that a post with a
+	 * category that is mapped to a particular section also gets the theme
+	 * that is mapped to that section.
+	 */
 	public function testThemeMapping() {
 
-		// Create a default theme.
-		$default_theme = new \Apple_Exporter\Theme;
-		$default_theme->set_name( 'Default' );
-		$this->assertTrue( $default_theme->save() );
+		// Load an additional example theme to facilitate mapping.
+		$this->load_example_theme( 'colorful' );
 
-		// Create a test theme with different settings to differentiate.
-		$test_theme = new \Apple_Exporter\Theme;
-		$test_theme->set_name( 'Test Theme' );
-		$test_settings = $test_theme->all_settings();
-		$test_settings['body_color'] = '#123456';
-		$test_theme->load( $test_settings );
-		$this->assertTrue( $test_theme->save() );
+		// Ensure the default theme is active.
+		$this->load_example_theme( 'default' );
 
 		// Create a post.
-		$title = 'My Title';
-		$content = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue arcu. Curabitur lacus elit, venenatis a laoreet sit amet, imperdiet ac lorem. Curabitur sed leo sed ligula tempor feugiat. Cras in tellus et elit volutpat.</p>';
-
-		$post_id = $this->factory->post->create( array(
-			'post_title' => $title,
-			'post_content' => $content,
-		) );
+		$post_id = self::factory()->post->create();
 
 		// Create a term and add it to the post.
-		$term_id = $this->factory->term->create( array(
+		$term_id = self::factory()->term->create( array(
 			'taxonomy' => 'category',
 			'name' => 'entertainment',
 		) );
@@ -316,7 +306,7 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 			'abcdef01-2345-6789-abcd-ef012356789a' => array( $term_id ),
 		) );
 		update_option( \Admin_Apple_Sections::THEME_MAPPING_KEY, array(
-			'abcdef01-2345-6789-abcd-ef012356789a' => 'Test Theme',
+			'abcdef01-2345-6789-abcd-ef012356789a' => 'Colorful',
 		) );
 
 		// Cache as a transient to bypass the API call.
@@ -342,26 +332,39 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 
 		// Get sections for the post.
 		$json = $this->get_json_for_post( $post_id );
-
 		$this->assertEquals(
 			$json['componentTextStyles']['dropcapBodyStyle']['textColor'],
-			$test_settings['body_color']
+			'#000000'
+		);
+
+		// Change the theme mapping to use the Default theme instead and re-test.
+		update_option( \Admin_Apple_Sections::THEME_MAPPING_KEY, array(
+			'abcdef01-2345-6789-abcd-ef012356789a' => 'Default',
+		) );
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals(
+			$json['componentTextStyles']['dropcapBodyStyle']['textColor'],
+			'#4f4f4f'
 		);
 
 		// Clean up.
-		$default_theme->delete();
-		$test_theme->delete();
 		delete_option( \Admin_Apple_Sections::TAXONOMY_MAPPING_KEY );
 		delete_option( \Admin_Apple_Sections::THEME_MAPPING_KEY );
 		delete_transient( 'apple_news_sections' );
 	}
 
 	/**
-	 * Tests the priority level setting.
+	 * Tests the priority level setting. Ensures that a post that is mapped to
+	 * multiple sections by taxonomy gets the theme that is associated with the
+	 * section that has the highest priority among the sections assigned to the
+	 * post.
 	 */
 	public function testPriority() {
 		// Load an additional example theme to facilitate mapping.
 		$this->load_example_theme( 'colorful' );
+
+		// Ensure the default theme is active.
+		$this->load_example_theme( 'default' );
 
 		// Create a post.
 		$post_id = self::factory()->post->create();
@@ -392,7 +395,6 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 		);
 
 		// Cache as a transient to bypass the API call.
-		$self = 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a';
 		set_transient(
 			'apple_news_sections',
 			array(
@@ -402,7 +404,7 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 					'isDefault' => true,
 					'links' => (object) array(
 						'channel' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
-						'self' => $self,
+						'self' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789a',
 					),
 					'modifiedAt' => '2017-01-01T00:00:00Z',
 					'name' => 'Main',
@@ -415,7 +417,7 @@ class Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 					'isDefault' => false,
 					'links' => (object) array(
 						'channel' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef0123567890',
-						'self' => $self,
+						'self' => 'https://news-api.apple.com/channels/abcdef01-2345-6789-abcd-ef012356789b',
 					),
 					'modifiedAt' => '2017-01-01T00:00:00Z',
 					'name' => 'Secondary',


### PR DESCRIPTION
* Adds a new settings column to the Sections screen that allows users to set a relative priority for sections. This enables a post that is published to multiple sections to use the theme that is associated with the section that has the highest priority out of the sections that are mapped to the post by taxonomy.
* Build in support for juggling theme based on section priority and add a unit test to confirm functionality.
* Simplify and clean up unit tests for theme and section juggling by using functionality recently added to the `Apple_News_Testcase` class.