### PR TITLE
Hotfix: Sections Save Error (Gutenberg)

### DIFF
--- a/assets/js/pluginsidebar/components/sidebar/index.js
+++ b/assets/js/pluginsidebar/components/sidebar/index.js
@@ -85,7 +85,7 @@ class Sidebar extends React.PureComponent {
     modified: 0,
     publishState: '',
     sections: [],
-    selectedSectionsPrev: null,
+    selectedSectionsPrev: '',
     settings: {},
     userCanPublish: false,
   };
@@ -310,14 +310,14 @@ class Sidebar extends React.PureComponent {
     const selectedSectionsArray = safeJsonParseArray(selectedSections);
 
     const selectedArrayDefault = Array.isArray(selectedSectionsArray)
-      ? JSON.stringify([...selectedSectionsArray, name]) : null;
+      ? JSON.stringify([...selectedSectionsArray, name]) : '';
 
     const arrayFilter = selectedSectionsArray.filter(
       (section) => section !== name
     );
 
     const selectedArrayFilter = 0 < arrayFilter.length
-      ? JSON.stringify(arrayFilter) : null;
+      ? JSON.stringify(arrayFilter) : '';
 
     onUpdate(
       'apple_news_sections',
@@ -402,11 +402,11 @@ class Sidebar extends React.PureComponent {
                     });
                     if (checked) {
                       this.setState({
-                        selectedSectionsPrev: selectedSections || null,
+                        selectedSectionsPrev: selectedSections || [],
                       });
                       onUpdate(
                         'apple_news_sections',
-                        null
+                        ''
                       );
                     } else {
                       onUpdate(
@@ -414,7 +414,7 @@ class Sidebar extends React.PureComponent {
                         selectedSectionsPrev
                       );
                       this.setState({
-                        selectedSectionsPrev: null,
+                        selectedSectionsPrev: [],
                       });
                     }
                   }

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 == Changelog ==
 
+= 2.1.1 =
+* Bugfix: Updates `pluginSidebar` sections default values to prevent save errors in some cases.
+
 = 2.1.0 =
 * Enhancement: Adds support for Dark Mode, including the ability to customize Dark Mode colors in a theme.
 * Enhancement: The cover component now supports captions. If a featured image is used for the cover, the caption will come from the attachment itself in the database. If the first image from the content is used, the caption will be read from the HTML. There is also a new filter, apple_news_exporter_cover_caption, which allows for filtering of the caption text.


### PR DESCRIPTION
Closes: #812 

- Ensures that expected section values are consistent preventing save/JSON error.
- Adds changelog notes.

## Info
Prevents generic JSON error on save. Prior to updates, error in debug was:

> Updating failed. The apple_news_sections property has an invalid stored value, and cannot be updated to null.

Ensuring that the value saved or read (prior to JSON.parse) is a string that prevents errors.

## Testing
- Create a new post and save/publish.
- Uncheck "Assign sections by category" checkbox, and leave sections unchecked. Save. Confirm no errors.
- Check any available sections. Save. Confirm no errors.
- Re-check the "Assign sections by category" checkbox. Save. Confirm no errors.

NOTE: An error may persist if the post is being published:

> Skipped push of article POST_ID because it is already in sync.

As far as I can tell this is normal and expected, but the post should still save. Should confirm the post saves as expected regardless.