### PR TITLE
Hotfix/JSON Response Error(s)

### DIFF
--- a/admin/class-admin-apple-sections.php
+++ b/admin/class-admin-apple-sections.php
@@ -97,7 +97,7 @@ class Admin_Apple_Sections extends Apple_News {
 		$sections       = $section_api->get_sections();
 		if ( empty( $sections ) || ! is_array( $sections ) ) {
 			$sections = array();
-			Admin_Apple_News::show_error(
+			Admin_Apple_News::error(
 				__( 'Unable to fetch a list of sections.', 'apple-news' )
 			);
 		}

--- a/includes/REST/apple-news-get-published-state.php
+++ b/includes/REST/apple-news-get-published-state.php
@@ -17,15 +17,7 @@ function get_published_state_response( $data ) {
 	$response = [];
 
 	// Ensure Apple News is first initialized.
-	if ( ! \Apple_News::is_initialized() ) {
-		return new WP_Error(
-			'apple_news_bad_operation',
-			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
-			[
-				'status' => 400,
-			]
-		);
-	}
+	\Apple_News::has_uninitialized_error();
 
 	if ( ! empty( get_current_user_id() ) ) {
 		$response['publishState'] = \Admin_Apple_News::get_post_status( $data['id'] );

--- a/includes/REST/apple-news-get-published-state.php
+++ b/includes/REST/apple-news-get-published-state.php
@@ -16,6 +16,17 @@ namespace Apple_News\REST;
 function get_published_state_response( $data ) {
 	$response = [];
 
+	// Ensure Apple News is first initialized.
+	if ( ! \Apple_News::is_initialized() ) {
+		return new WP_Error(
+			'apple_news_bad_operation',
+			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
+			[
+				'status' => 400,
+			]
+		);
+	}
+
 	if ( ! empty( get_current_user_id() ) ) {
 		$response['publishState'] = \Admin_Apple_News::get_post_status( $data['id'] );
 	}

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -15,15 +15,7 @@ namespace Apple_News\REST;
  */
 function get_settings_response( $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	// Ensure Apple News is first initialized.
-	if ( ! \Apple_News::is_initialized() ) {
-		return new WP_Error(
-			'apple_news_bad_operation',
-			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
-			[
-				'status' => 400,
-			]
-		);
-	}
+	\Apple_News::has_uninitialized_error();
 
 	if ( empty( get_current_user_id() ) ) {
 		return [];

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -14,6 +14,17 @@ namespace Apple_News\REST;
  * @return array updated response.
  */
 function get_settings_response( $data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	// Ensure Apple News is first initialized.
+	if ( ! \Apple_News::is_initialized() ) {
+		return new WP_Error(
+			'apple_news_bad_operation',
+			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
+			[
+				'status' => 400,
+			]
+		);
+	}
+
 	if ( empty( get_current_user_id() ) ) {
 		return [];
 	}

--- a/includes/REST/apple-news-modify-post.php
+++ b/includes/REST/apple-news-modify-post.php
@@ -25,15 +25,7 @@ use WP_Error;
  */
 function modify_post( $post_id, $operation ) {
 	// Ensure Apple News is first initialized.
-	if ( ! \Apple_News::is_initialized() ) {
-		return new WP_Error(
-			'apple_news_bad_operation',
-			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
-			[
-				'status' => 400,
-			]
-		);
-	}
+	\Apple_News::has_uninitialized_error();
 
 	// Ensure there is a post ID provided in the data.
 	if ( empty( $post_id ) ) {

--- a/includes/REST/apple-news-modify-post.php
+++ b/includes/REST/apple-news-modify-post.php
@@ -24,6 +24,16 @@ use WP_Error;
  * @return array|WP_Error Response to the request - either data about a successful operation, or error.
  */
 function modify_post( $post_id, $operation ) {
+	// Ensure Apple News is first initialized.
+	if ( ! \Apple_News::is_initialized() ) {
+		return new WP_Error(
+			'apple_news_bad_operation',
+			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
+			[
+				'status' => 400,
+			]
+		);
+	}
 
 	// Ensure there is a post ID provided in the data.
 	if ( empty( $post_id ) ) {

--- a/includes/REST/apple-news-sections.php
+++ b/includes/REST/apple-news-sections.php
@@ -14,15 +14,7 @@ namespace Apple_News\REST;
  */
 function get_sections_response() {
 	// Ensure Apple News is first initialized.
-	if ( ! \Apple_News::is_initialized() ) {
-		return new WP_Error(
-			'apple_news_bad_operation',
-			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
-			[
-				'status' => 400,
-			]
-		);
-	}
+	\Apple_News::has_uninitialized_error();
 
 	$sections = \Admin_Apple_Sections::get_sections();
 	$response = [];

--- a/includes/REST/apple-news-sections.php
+++ b/includes/REST/apple-news-sections.php
@@ -13,6 +13,17 @@ namespace Apple_News\REST;
  * @return array An array of information about sections.
  */
 function get_sections_response() {
+	// Ensure Apple News is first initialized.
+	if ( ! \Apple_News::is_initialized() ) {
+		return new WP_Error(
+			'apple_news_bad_operation',
+			__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
+			[
+				'status' => 400,
+			]
+		);
+	}
+
 	$sections = \Admin_Apple_Sections::get_sections();
 	$response = [];
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -219,6 +219,24 @@ class Apple_News {
 	}
 
 	/**
+	 * Returns new WP_Error if uninitialized.
+	 *
+	 * @access public
+	 * @return WP_Error error if uninitialized.
+	 */
+	public static function has_uninitialized_error() {
+		if ( ! self::is_initialized() ) {
+			return new WP_Error(
+				'apple_news_bad_operation',
+				__( 'You must enter your API information on the settings page before using Publish to Apple News.', 'apple-news' ),
+				[
+					'status' => 400,
+				]
+			);
+		}
+	}
+
+	/**
 	 * Constructor. Registers action hooks.
 	 *
 	 * @access public

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,10 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 == Changelog ==
 
+= 2.1.1 =
+* Enhancement: Adds checks for plugin initialization before making REST responses.
+* Bugfix: Replaces admin sections error display function.
+
 = 2.1.0 =
 * Enhancement: Adds support for Dark Mode, including the ability to customize Dark Mode colors in a theme.
 * Enhancement: The cover component now supports captions. If a featured image is used for the cover, the caption will come from the attachment itself in the database. If the first image from the content is used, the caption will be read from the HTML. There is also a new filter, apple_news_exporter_cover_caption, which allows for filtering of the caption text.


### PR DESCRIPTION
Closes: #810

- Replaces error function in the admin sections function.
- Adds checks for Apple News initialization before proceeding into REST response functions.
- Adds changelog notes.

In adding init checks with rest responses, actual WP errors are filtering through to the frontend rather than faulting on the post save and returning a generic JSON error. Actual error in #810 once these checks were in the place pointed to an issue in the block editor view, resolved in #812.

NOTE: The only resulting error during save may be:

> Skipped push of article POST_ID because it is already in sync.

As far as I can tell this is normal and expected, but the post should still save. Should confirm the post saves as expected regardless.