### PR TITLE
Fix greedy regex for pullquotes

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -7,7 +7,6 @@
  * @package Apple_News
  */
 
-global $post;
 // Include dependencies.
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-settings.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-post-sync.php';
@@ -20,6 +19,7 @@ require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-sections.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-themes.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-preview.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-json.php';
+
 // REST Includes.
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-delete.php';
 require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-published-state.php';

--- a/includes/apple-exporter/class-html.php
+++ b/includes/apple-exporter/class-html.php
@@ -33,6 +33,7 @@ class HTML {
 		'blockquote' => array(),
 		'br'         => array(),
 		'caption'    => array(),
+		'cite'       => array(),
 		'code'       => array(),
 		'del'        => array(),
 		'em'         => array(),

--- a/includes/apple-exporter/components/class-quote.php
+++ b/includes/apple-exporter/components/class-quote.php
@@ -313,15 +313,26 @@ class Quote extends Component {
 
 		// Extract text from blockquote HTML.
 		preg_match( $string_match, $html, $matches );
-		// Default to center.  Set to matches[1] if set.
+
+		// Negotiate alignment.
 		$this->text_alignment = 'left';
-		if ( 3 === count( $matches ) && $matches[1] ) {
-			$this->text_alignment = $matches[1];
+		if ( 3 === count( $matches ) && ! empty( $matches[1] ) ) {
+			// The regex is a little greedy, so trim off anything else it found.
+			$parts = explode( ' ', $matches[1] );
+			switch ( $parts[0] ) {
+				case 'center':
+				case 'full':
+				case 'wide':
+					$this->text_alignment = 'center';
+					break;
+				case 'right':
+					$this->text_alignment = 'right';
+					break;
+			}
 		}
-		$this->text_alignment =
-			'wide' === $this->text_alignment || 'full' === $this->text_alignment
-				? 'center' : $this->text_alignment;
-		$text                 = isset( $matches[2] ) ? $matches[2] : $matches[1];
+
+		// Negotiate the text.
+		$text = isset( $matches[2] ) ? $matches[2] : $matches[1];
 
 		// If there is no text for this element, bail.
 		$check = trim( $text );

--- a/tests/apple-exporter/components/test-class-quote.php
+++ b/tests/apple-exporter/components/test-class-quote.php
@@ -550,4 +550,57 @@ class Quote_Test extends Component_TestCase {
 		$this->assertEquals( 'default-pullquote-left', $result['textStyle'] );
 		$this->assertEquals( 'pullquote-layout', $result['layout'] );
 	}
+
+	/**
+	 * Tests a full transformation of a post containing a pullquote.
+	 */
+	public function testFullTransform() {
+		// Create a Gutenberg pullquote.
+		$post_content = <<<HTML
+<!-- wp:pullquote {"mainColor":"accent","textColor":"primary","align":"right","className":"has-background has-accent-background-color is-style-solid-color another-class"} -->
+<figure class="wp-block-pullquote alignright has-background has-accent-background-color is-style-solid-color another-class" id="testing-anchor"><blockquote class="has-text-color has-primary-color"><p>Testing pullquote.</p><cite>Testing citation.</cite></blockquote></figure>
+<!-- /wp:pullquote -->
+HTML;
+
+		// Create a post with the pullquote and get the JSON for it.
+		$post_id = self::factory()->post->create( [ 'post_content' => $post_content ] );
+		$json = $this->get_json_for_post( $post_id );
+
+		// Test the component itself.
+		$this->assertEquals(
+			[
+				'format'    => 'html',
+				'layout'    => 'pullquote-layout',
+				'role'      => 'quote',
+				'text'      => '<p>Testing pullquote.</p><cite>Testing citation.</cite>',
+				'textStyle' => 'default-pullquote-right',
+			],
+			$json['components'][2]['components'][0]
+		);
+
+		// Test the component text style.
+		$this->assertEquals(
+			[
+				'fontName'      => 'AvenirNext-Bold',
+				'fontSize'      => 48,
+				'lineHeight'    => 48,
+				'textAlignment' => 'right',
+				'textColor'     => '#53585f',
+				'textTransform' => 'uppercase',
+				'tracking'      => 0,
+			],
+			$json['componentTextStyles']['default-pullquote-right']
+		);
+
+		// Test the component layout.
+		$this->assertEquals(
+			[
+				'margin' => [
+					'bottom' => 12,
+					'top'    => 12,
+				],
+			],
+			$json['componentLayouts']['pullquote-layout']
+		);
+	}
 }


### PR DESCRIPTION
Fixes a bug where the regex for pullquote alignment grabs everything from `align*` to the end of the `<figure>` tag, when we really only care about `left`/`center`/`right`/`full`/`wide`. Adds a test to expose the bug and fixes the bug via splitting what is returned by the regex match to isolate the first "word."

See #815 