### PR TITLE
Add support for new wp_after_insert_post hook

### DIFF
--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -47,8 +47,12 @@ class Admin_Apple_Post_Sync {
 		if ( 'yes' === $this->settings->get( 'api_autosync' )
 			|| 'yes' === $this->settings->get( 'api_autosync_update' )
 		) {
-			// This needs to happen after meta boxes save.
-			add_action( 'save_post', [ $this, 'do_publish' ], 99, 2 );
+			// Fork for new behavior in WP 5.6 vs. old behavior.
+			if ( function_exists( 'wp_after_insert_post' ) ) {
+				add_action( 'wp_after_insert_post', [ $this, 'do_publish' ], 10, 2 );
+			} else {
+				add_action( 'save_post', [ $this, 'do_publish' ], 99, 2 );
+			}
 		}
 
 		// Register delete hook if needed.


### PR DESCRIPTION
WordPress 5.6 introduced a new hook, called `wp_after_insert_post`, which fires _after_ all of the postmeta and terms are saved during a REST request, which wasn't true for the `save_post` hook. This PR introduces a fork in the logic to use the new hook if it is available, and falls back to the old behavior if not.

Fixes #790 