### PR TITLE
APPLE-64 Add authors field to article metadata

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -17,7 +17,8 @@ use Apple_Exporter\Exporter as Exporter;
 use Apple_Exporter\Exporter_Content as Exporter_Content;
 use Apple_Exporter\Exporter_Content_Settings as Exporter_Content_Settings;
 use Apple_Exporter\Third_Party\Jetpack_Tiled_Gallery as Jetpack_Tiled_Gallery;
-use \Admin_Apple_Sections;
+use Admin_Apple_Sections;
+use Apple_News;
 
 /**
  * A class to handle an export request from the admin.
@@ -273,13 +274,7 @@ class Export extends Action {
 
 		// Get the author.
 		if ( empty( $author ) ) {
-
-			// Try to get the author information from Co-Authors Plus.
-			if ( function_exists( 'coauthors' ) ) {
-				$author = coauthors( null, null, null, null, false );
-			} else {
-				$author = ucfirst( get_the_author_meta( 'display_name', $post->post_author ) );
-			}
+			$author = Apple_News::get_authors();
 		}
 
 		// Get the date.

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -45,10 +45,19 @@ class Metadata extends Builder {
 		}
 
 		// Add authors.
-		// TODO: CAP.
 		$post = get_post( $this->content_id() );
 		if ( function_exists( 'coauthors' ) ) {
-			// $author = coauthors( null, null, null, null, false );
+			$coauthors = array_values(
+				array_filter(
+					explode(
+						'APPLE_NEWS_DELIMITER',
+						coauthors( 'APPLE_NEWS_DELIMITER', 'APPLE_NEWS_DELIMITER', null, null, false )
+					)
+				)
+			);
+			if ( ! empty( $coauthors ) ) {
+				$meta['authors'] = $coauthors;
+			}
 		} else {
 			$author = ucfirst( get_the_author_meta( 'display_name', $post->post_author ) );
 			if ( ! empty( $author ) ) {

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -71,14 +71,14 @@ class Metadata extends Builder {
 		$meta['generatorVersion']    = $plugin_data['Version'];
 
 		// Extract all video elements that include a poster element.
-		if ( preg_match_all( '/<video[^>]+poster="([^"]+)".*?>(.+?)<\/video>/s', $this->content_text(), $matches ) ) {
+		if ( preg_match_all( '/<video[^>]+poster="([^"]+)".*?>.*?<\/video>/s', $this->content_text(), $matches ) ) {
 
 			// Loop through matched video elements looking for MP4 files.
-			$total = count( $matches[2] );
+			$total = count( $matches[0] );
 			for ( $i = 0; $i < $total; $i ++ ) {
 
 				// Try to match an MP4 source URL.
-				if ( preg_match( '/src="([^\?"]+\.mp4[^"]*)"/', $matches[2][ $i ], $src ) ) {
+				if ( preg_match( '/src="([^\?"]+\.mp4[^"]*)"/', $matches[0][ $i ], $src ) ) {
 
 					// Include the thumbnail and video URL if the video URL is valid.
 					$url = Exporter_Content::format_src_url( $src[1] );

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -10,8 +10,9 @@ namespace Apple_Exporter\Builders;
 
 require_once plugin_dir_path( __FILE__ ) . '../../../admin/class-admin-apple-news.php';
 
-use \Admin_Apple_News;
-use \Apple_Exporter\Exporter_Content;
+use Admin_Apple_News;
+use Apple_Exporter\Exporter_Content;
+use Apple_News;
 
 /**
  * A class to handle building metadata.
@@ -45,24 +46,16 @@ class Metadata extends Builder {
 		}
 
 		// Add authors.
-		$post = get_post( $this->content_id() );
-		if ( function_exists( 'coauthors' ) ) {
-			$coauthors = array_values(
-				array_filter(
-					explode(
-						'APPLE_NEWS_DELIMITER',
-						coauthors( 'APPLE_NEWS_DELIMITER', 'APPLE_NEWS_DELIMITER', null, null, false )
-					)
+		$authors = array_values(
+			array_filter(
+				explode(
+					'APPLE_NEWS_DELIMITER',
+					Apple_News::get_authors( 'APPLE_NEWS_DELIMITER', 'APPLE_NEWS_DELIMITER' )
 				)
-			);
-			if ( ! empty( $coauthors ) ) {
-				$meta['authors'] = $coauthors;
-			}
-		} else {
-			$author = ucfirst( get_the_author_meta( 'display_name', $post->post_author ) );
-			if ( ! empty( $author ) ) {
-				$meta['authors'] = [ $author ];
-			}
+			)
+		);
+		if ( ! empty( $authors ) ) {
+			$meta['authors'] = $authors;
 		}
 
 		/**
@@ -70,6 +63,7 @@ class Metadata extends Builder {
 		 * We need to get the WordPress post for this
 		 * since the date functions are inconsistent.
 		 */
+		$post = get_post( $this->content_id() );
 		if ( ! empty( $post ) ) {
 			$post_date     = gmdate( 'c', strtotime( get_gmt_from_date( $post->post_date ) ) );
 			$post_modified = gmdate( 'c', strtotime( get_gmt_from_date( $post->post_modified ) ) );

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -44,12 +44,23 @@ class Metadata extends Builder {
 			);
 		}
 
+		// Add authors.
+		// TODO: CAP.
+		$post = get_post( $this->content_id() );
+		if ( function_exists( 'coauthors' ) ) {
+			// $author = coauthors( null, null, null, null, false );
+		} else {
+			$author = ucfirst( get_the_author_meta( 'display_name', $post->post_author ) );
+			if ( ! empty( $author ) ) {
+				$meta['authors'] = [ $author ];
+			}
+		}
+
 		/**
 		 * Add date fields.
 		 * We need to get the WordPress post for this
 		 * since the date functions are inconsistent.
 		 */
-		$post = get_post( $this->content_id() );
 		if ( ! empty( $post ) ) {
 			$post_date     = gmdate( 'c', strtotime( get_gmt_from_date( $post->post_date ) ) );
 			$post_modified = gmdate( 'c', strtotime( get_gmt_from_date( $post->post_modified ) ) );

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -94,6 +94,45 @@ class Apple_News {
 	public static $maturity_ratings = array( 'KIDS', 'MATURE', 'GENERAL' );
 
 	/**
+	 * A helper function for getting authors for a post, which supports native
+	 * WordPress authors as well as Co-Authors Plus. Like the coauthors function,
+	 * must be used in the loop.
+	 *
+	 * @param ?string $between      Delimiter that should appear between the co-authors.
+	 * @param ?string $between_last Delimiter that should appear between the last two co-authors.
+	 * @param ?string $before       What should appear before the presentation of co-authors.
+	 * @param ?string $after        What should appear after the presentation of co-authors.
+	 *
+	 * @return string The author list, formatted according to the given options.
+	 */
+	public static function get_authors( $between = null, $between_last = null, $before = null, $after = null ) {
+		global $post;
+
+		// Bail out if we don't have a post.
+		if ( empty( $post ) ) {
+			return '';
+		}
+
+		/**
+		 * Allows for changing the option to use Co-Authors Plus for authorship.
+		 * Defaults to using Co-Authors Plus if the `coauthors` function is defined.
+		 *
+		 * @since 2.1.3
+		 *
+		 * @param bool $use_cap Whether to use Co-Authors Plus for authors.
+		 * @param int  $post_id The post ID being processed.
+		 */
+		$use_cap = apply_filters( 'apple_news_use_coauthors', function_exists( 'coauthors' ), get_the_ID() );
+
+		// Handle CAP authorship.
+		if ( $use_cap ) {
+			return coauthors( $between, $between_last, $before, $after, false );
+		}
+
+		return ucfirst( get_the_author_meta( 'display_name', $post->post_author ) );
+	}
+
+	/**
 	 * Maps a capability to a specific post type, with support for
 	 * custom post types.
 	 *

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -6,9 +6,6 @@
  * @subpackage Tests
  */
 
-use Apple_Exporter\Exporter_Content;
-use Apple_Exporter\Builders\Metadata;
-
 /**
  * A class which is used to test the Apple_Exporter\Builders\Metadata class.
  *
@@ -18,16 +15,36 @@ use Apple_Exporter\Builders\Metadata;
 class Metadata_Test extends Apple_News_Testcase {
 
 	/**
+	 * Ensures authors are properly added using Co-Authors Plus.
+	 *
+	 * @access public
+	 */
+	public function test_cap_authors() {
+		// Setup.
+		global $apple_news_coauthors;
+		$apple_news_coauthors = [ 'Test Author 1', 'Test Author 2' ];
+		$author   = self::factory()->user->create( [ 'display_name' => 'Test Author' ] );
+		$post_id  = self::factory()->post->create( [ 'post_author'  => $author ] );
+		$result   = $this->get_json_for_post( $post_id );
+		$metadata = $result['metadata'];
+
+		// Assertions.
+		$this->assertEquals(
+			[ 'Test Author 1', 'Test Author 2' ],
+			$metadata['authors']
+		);
+
+		// Cleanup.
+		$apple_news_coauthors = [];
+	}
+
+	/**
 	 * Ensures that metadata is properly set.
 	 */
 	public function test_metadata() {
 
 		// Setup.
-		$author  = self::factory()->user->create(
-			[
-				'display_name' => 'Test Author',
-			]
-		);
+		$author  = self::factory()->user->create( [ 'display_name' => 'Test Author' ] );
 		$post_id = self::factory()->post->create(
 			[
 				'post_author'  => $author,
@@ -94,7 +111,4 @@ class Metadata_Test extends Apple_News_Testcase {
 			$metadata['videoURL']
 		);
 	}
-
-	// TODO: Add test for coauthors authorship.
-	// $author = coauthors( null, null, null, null, false );
 }

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -2,247 +2,45 @@
 /**
  * Publish to Apple News Tests: Metadata_Test class
  *
- * Contains a class which is used to test Apple_Exporter\Builders\Metadata.
- *
  * @package Apple_News
  * @subpackage Tests
  */
 
 use Apple_Exporter\Exporter_Content;
-use Apple_Exporter\Settings;
 use Apple_Exporter\Builders\Metadata;
 
 /**
  * A class which is used to test the Apple_Exporter\Builders\Metadata class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
  */
-class Metadata_Test extends WP_UnitTestCase {
+class Metadata_Test extends Apple_News_Testcase {
 
 	/**
-	 * Actions to be run before each test in this class is executed.
-	 *
-	 * @access public
+	 * Ensures that metadata is properly set.
 	 */
-	public function setup() {
-		$this->settings = new Settings();
-	}
-
-	/**
-	 * Ensures that the cover image is properly set in metadata.
-	 *
-	 * @access public
-	 */
-	public function testCover() {
-
+	public function test_metadata() {
 		// Setup.
-		$this->settings->set( 'use_remote_images', 'no' );
-		$content = new Exporter_Content(
-			1,
-			'My Title',
-			'<p>Hello, World!</p>',
-			null,
-			'/etc/somefile.jpg'
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => '<p>Hello, World!</p>',
+				'post_date'    => '2016-04-01 00:00:00',
+				'post_excerpt' => 'Sample excerpt.',
+				'post_title'   => 'My Title',
+			]
 		);
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
+		$image   = $this->get_new_attachment( $post_id );
+		set_post_thumbnail( $post_id, $image );
+		$result   = $this->get_json_for_post( $post_id );
+		$metadata = $result['metadata'];
 
-		// Test.
-		$this->assertEquals(
-			5,
-			count( $result )
-		);
-		$this->assertEquals(
-			'bundle://somefile.jpg',
-			$result['thumbnailURL']
-		);
-	}
-
-	/**
-	 * Ensures that a remote cover image is properly set in metadata.
-	 *
-	 * @access public
-	 */
-	public function testCoverRemoteImages() {
-
-		// Setup.
-		$this->settings->set( 'use_remote_images', 'yes' );
-		$content = new Exporter_Content(
-			1,
-			'My Title',
-			'<p>Hello, World!</p>',
-			null,
-			'http://someurl.com/somefile.jpg'
-		);
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
-
-		// Test.
-		$this->assertEquals(
-			5,
-			count( $result )
-		);
-		$this->assertEquals(
-			'http://someurl.com/somefile.jpg',
-			$result['thumbnailURL']
-		);
-	}
-
-	/**
-	 * Ensure dates are properly set in metadata.
-	 *
-	 * @access public
-	 */
-	public function testDates() {
-
-		// Setup.
-		$title = 'My Title';
-		$content = '<p>Hello, World!</p>';
-		$post_id = $this->factory->post->create( array(
-			'post_title' => $title,
-			'post_content' => $content,
-			'post_date' => '2016-04-01 00:00:00',
-		) );
-		$content = new Exporter_Content(
-			$post_id,
-			$title,
-			$content,
-			null,
-			'/etc/somefile.jpg'
-		);
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
-
-		// Test.
-		$this->assertEquals(
-			8,
-			count( $result )
-		);
-		$this->assertEquals(
-			'2016-04-01T00:00:00+00:00',
-			$result['dateCreated']
-		);
-		$this->assertEquals(
-			'2016-04-01T00:00:00+00:00',
-			$result['dateModified']
-		);
-		$this->assertEquals(
-			'2016-04-01T00:00:00+00:00',
-			$result['datePublished']
-		);
-	}
-
-	/**
-	 * Ensures that the intro text is properly set in metadata.
-	 *
-	 * @access public
-	 */
-	public function testIntro() {
-
-		// Setup.
-		$content = new Exporter_Content(
-			1,
-			'My Title',
-			'<p>Hello, World!</p>',
-			'This is an intro.'
-		);
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
-
-		// Test.
-		$this->assertEquals(
-			5,
-			count( $result )
-		);
-		$this->assertEquals(
-			'This is an intro.',
-			$result['excerpt']
-		);
-	}
-
-	/**
-	 * Ensures that the cover image and intro text are properly set in metadata.
-	 *
-	 * @access public
-	 */
-	public function testIntroAndCover() {
-
-		// Setup.
-		$this->settings->set( 'use_remote_images', 'no' );
-		$content = new Exporter_Content(
-			1,
-			'My Title',
-			'<p>Hello, World!</p>',
-			'This is an intro.',
-			'/etc/somefile.jpg'
-		);
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
-
-		// Test.
-		$this->assertEquals(
-			6,
-			count( $result )
-		);
-		$this->assertEquals(
-			'This is an intro.',
-			$result['excerpt']
-		);
-		$this->assertEquals(
-			'bundle://somefile.jpg',
-			$result['thumbnailURL']
-		);
-	}
-
-	/**
-	 * Ensures that a remote cover image and intro text are properly set in metadata.
-	 *
-	 * @access public
-	 */
-	public function testIntroAndCoverRemoteImages() {
-
-		// Setup.
-		$this->settings->set( 'use_remote_images', 'yes' );
-		$content = new Exporter_Content(
-			1,
-			'My Title',
-			'<p>Hello, World!</p>',
-			'This is an intro.',
-			'http://someurl.com/somefile.jpg'
-		);
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
-
-		// Test.
-		$this->assertEquals(
-			6,
-			count( $result )
-		);
-		$this->assertEquals(
-			'This is an intro.',
-			$result['excerpt']
-		);
-		$this->assertEquals(
-			'http://someurl.com/somefile.jpg',
-			$result['thumbnailURL']
-		);
-	}
-
-	/**
-	 * Ensures metadata is properly generated when no intro and no cover are given.
-	 *
-	 * @access public
-	 */
-	public function testNoIntroNoCover() {
-
-		// Setup.
-		$content = new Exporter_Content( 1, 'My Title', '<p>Hello, World!</p>' );
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
-
-		// Test.
-		$this->assertEquals(
-			4,
-			count( $result )
-		);
+		// Assertions.
+		$this->assertEquals( '2016-04-01T00:00:00+00:00', $metadata['dateCreated'] );
+		$this->assertEquals( '2016-04-01T00:00:00+00:00', $metadata['dateModified'] );
+		$this->assertEquals( '2016-04-01T00:00:00+00:00', $metadata['datePublished'] );
+		$this->assertEquals( 'Sample excerpt.', $metadata['excerpt'] );
+		$this->assertEquals( wp_get_attachment_url( $image ), $metadata['thumbnailURL'] );
 	}
 
 	/**
@@ -250,28 +48,24 @@ class Metadata_Test extends WP_UnitTestCase {
 	 *
 	 * @access public
 	 */
-	public function testVideo() {
-
+	public function test_video() {
 		// Setup.
-		$this->settings->set( 'use_remote_images', 'yes' );
-		$html = <<<HTML
-<video class="wp-video-shortcode" id="video-71-1" width="525" height="295" poster="https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg" preload="metadata" controls="controls">
-	<source type="video/mp4" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1" />
-	<a href="https://example.com/wp-content/uploads/2017/02/example-video.mp4">https://example.com/wp-content/uploads/2017/02/example-video.mp4</a>
-</video>
-HTML;
-		$content = new Exporter_Content( 1, 'My Title', $html );
-		$builder = new Metadata( $content, $this->settings );
-		$result = $builder->to_array();
+		$post_id  = self::factory()->post->create(
+			[
+				'post_content' => '<figure class="wp-block-video"><video controls="" poster="https://example.com/wp-content/uploads/2017/02/example-poster.jpg" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4"></video></figure>',
+			]
+		);
+		$result   = $this->get_json_for_post( $post_id );
+		$metadata = $result['metadata'];
 
-		// Test.
+		// Assertions.
 		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg',
-			$result['thumbnailURL']
+			'https://example.com/wp-content/uploads/2017/02/example-poster.jpg',
+			$metadata['thumbnailURL']
 		);
 		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1',
-			$result['videoURL']
+			'https://example.com/wp-content/uploads/2017/02/example-video.mp4',
+			$metadata['videoURL']
 		);
 	}
 }

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -21,6 +21,7 @@ class Metadata_Test extends Apple_News_Testcase {
 	 */
 	public function test_cap_authors() {
 		// Setup.
+		$this->enable_coauthors_support();
 		global $apple_news_coauthors;
 		$apple_news_coauthors = [ 'Test Author 1', 'Test Author 2' ];
 		$author   = self::factory()->user->create( [ 'display_name' => 'Test Author' ] );
@@ -36,13 +37,13 @@ class Metadata_Test extends Apple_News_Testcase {
 
 		// Cleanup.
 		$apple_news_coauthors = [];
+		$this->disable_coauthors_support();
 	}
 
 	/**
 	 * Ensures that metadata is properly set.
 	 */
 	public function test_metadata() {
-
 		// Setup.
 		$author  = self::factory()->user->create( [ 'display_name' => 'Test Author' ] );
 		$post_id = self::factory()->post->create(

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -21,9 +21,16 @@ class Metadata_Test extends Apple_News_Testcase {
 	 * Ensures that metadata is properly set.
 	 */
 	public function test_metadata() {
+
 		// Setup.
+		$author  = self::factory()->user->create(
+			[
+				'display_name' => 'Test Author',
+			]
+		);
 		$post_id = self::factory()->post->create(
 			[
+				'post_author'  => $author,
 				'post_content' => '<p>Hello, World!</p>',
 				'post_date'    => '2016-04-01 00:00:00',
 				'post_excerpt' => 'Sample excerpt.',
@@ -36,11 +43,30 @@ class Metadata_Test extends Apple_News_Testcase {
 		$metadata = $result['metadata'];
 
 		// Assertions.
-		$this->assertEquals( '2016-04-01T00:00:00+00:00', $metadata['dateCreated'] );
-		$this->assertEquals( '2016-04-01T00:00:00+00:00', $metadata['dateModified'] );
-		$this->assertEquals( '2016-04-01T00:00:00+00:00', $metadata['datePublished'] );
-		$this->assertEquals( 'Sample excerpt.', $metadata['excerpt'] );
-		$this->assertEquals( wp_get_attachment_url( $image ), $metadata['thumbnailURL'] );
+		$this->assertEquals(
+			[ 'Test Author' ],
+			$metadata['authors']
+		);
+		$this->assertEquals(
+			'2016-04-01T00:00:00+00:00',
+			$metadata['dateCreated']
+		);
+		$this->assertEquals(
+			'2016-04-01T00:00:00+00:00',
+			$metadata['dateModified']
+		);
+		$this->assertEquals(
+			'2016-04-01T00:00:00+00:00',
+			$metadata['datePublished']
+		);
+		$this->assertEquals(
+			'Sample excerpt.',
+			$metadata['excerpt']
+		);
+		$this->assertEquals(
+			wp_get_attachment_url( $image ),
+			$metadata['thumbnailURL']
+		);
 	}
 
 	/**
@@ -68,4 +94,7 @@ class Metadata_Test extends Apple_News_Testcase {
 			$metadata['videoURL']
 		);
 	}
+
+	// TODO: Add test for coauthors authorship.
+	// $author = coauthors( null, null, null, null, false );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,16 @@ function _manually_load_plugin() {
 	// Set the permalink structure.
 	update_option( 'permalink_structure', '/%postname%' );
 
+	// Load mocks for integration tests.
+	require_once __DIR__ . '/mocks/class-bc-setup.php';
+	if ( ! function_exists( 'coauthors' ) ) {
+		require_once __DIR__ . '/mocks/function-coauthors.php';
+	}
+
+	// Activate mocked Brightcove functionality.
+	$bc_setup = new BC_Setup();
+	$bc_setup->action_init();
+
 	// Load the plugin.
 	require dirname( dirname( __FILE__ ) ) . '/apple-news.php';
 }
@@ -32,10 +42,3 @@ require $_tests_dir . '/includes/bootstrap.php';
 require_once __DIR__ . '/class-apple-news-testcase.php';
 
 require_once __DIR__ . '/apple-exporter/components/class-component-testcase.php';
-
-// Load mocks for integration tests.
-require_once __DIR__ . '/mocks/class-bc-setup.php';
-
-// Activate mocked Brightcove functionality.
-$bc_setup = new BC_Setup();
-$bc_setup->action_init();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,9 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+// Disable CAP by default - make it opt-in in tests.
+tests_add_filter( 'apple_news_use_coauthors', '__return_false' );
+
 require $_tests_dir . '/includes/bootstrap.php';
 
 require_once __DIR__ . '/class-apple-news-testcase.php';

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -146,6 +146,20 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A helper function for removing Co-Authors Plus support in a test context.
+	 */
+	protected function disable_coauthors_support() {
+		remove_filter( 'apple_news_use_coauthors', '__return_true', 99 );
+	}
+
+	/**
+	 * A helper function for adding Co-Authors Plus support in a test context.
+	 */
+	protected function enable_coauthors_support() {
+		add_filter( 'apple_news_use_coauthors', '__return_true', 99 );
+	}
+
+	/**
 	 * Runs create_upload_object using a test image and returns the image ID.
 	 *
 	 * @param int    $parent  Optional. The parent post ID. Defaults to no parent.

--- a/tests/mocks/function-coauthors.php
+++ b/tests/mocks/function-coauthors.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Apple News Tests Mocks: coauthors function
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+/**
+ * A mock for the coauthors function from Co-Authors Plus.
+ *
+ * @param string $between     Delimiter that should appear between the co-authors
+ * @param string $betweenLast Delimiter that should appear between the last two co-authors
+ * @param string $before      What should appear before the presentation of co-authors
+ * @param string $after       What should appear after the presentation of co-authors
+ * @param bool   $echo        Whether the co-authors should be echoed or returned. Defaults to true.
+ */
+function coauthors( $between = ', ', $betweenLast = ' and ', $before = '', $after = '', $echo = true ) {
+	// To use this function, put display names in a global array called $apple_news_coauthors.
+	global $apple_news_coauthors;
+
+	// Bail if we don't have coauthors.
+	if ( empty( $apple_news_coauthors ) ) {
+		return '';
+	}
+
+	// Get last index.
+	$last_index = count( $apple_news_coauthors ) - 1;
+
+	// Compute output.
+	$output = $before
+		. implode( $between, array_slice( $apple_news_coauthors, 0, $last_index ) )
+		. ( 0 !== $last_index ? $betweenLast : '' )
+		. $apple_news_coauthors[ $last_index ]
+		. $after;
+
+	// Fork for echo.
+	if ( ! $echo ) {
+		return $output;
+	}
+
+	echo $output;
+}


### PR DESCRIPTION
* Adds a new metadata field called `authors` which is an array of strings representing author names.
* Refactors the metadata test class to use the latest conventions for writing unit tests in this project, including extending the base helper class and generating a JSON export of an article from the test database by post ID.
* Centralizes support for Co-Authors Plus and makes the functionality opt-in in a test context, as well as mocking the `coauthors` function to test CAP integration in a unit test context without the need for installing the plugin.
* Introduces a new filter called `apple_news_use_coauthors` to control whether Co-Authors Plus integration should be enabled. Defaults to `true` if the `coauthors` function is defined (the previous behavior).
* Fixes a bug with video metadata when there is a `<video>` element that has a `src` attribute rather than a collection of `<source>` elements representing different formats.

Fixes #850 