### PR TITLE
APPLE-63: New file upload for config files

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -90,7 +90,8 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 	 */
 	public function get_section_info() {
 		return sprintf(
-			__( 'Please upload your Apple News channel configuration file below. Please see %sthe Apple News API documentation%s and %sthe News Publisher documentation%s for detailed information. For further assistance, please contact your Apple News representative.', 'apple-news' ),
+			// translators: tokens fill in <a> tags.
+			__( 'Please upload your Apple News channel configuration file below. Please see %1$sthe Apple News API documentation%2$s and %3$sthe News Publisher documentation%4$s for detailed information. For further assistance, please contact your Apple News representative.', 'apple-news' ),
 			'<a target="_blank" href="https://developer.apple.com/documentation/apple_news/apple_news_api/getting_ready_to_publish_and_manage_your_articles">',
 			'</a>',
 			'<a target="_blank" href="https://support.apple.com/guide/news-publisher/use-your-cms-with-news-publisher-apd88c8447e6/icloud">',

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -33,7 +33,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		// Add the settings.
 		$this->settings = array(
 			'api_config_file'     => array(
-        'description' => __( 'Having trouble? <a href="#apple-news-credentials-input">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
+        'description' => __( 'Having trouble? <a href="#api_config_file">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
 				'type'  => 'file',
         'size'  => '100',
 			),

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -90,12 +90,11 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 	 */
 	public function get_section_info() {
 		return sprintf(
-			'%s <a target="_blank" href="https://developer.apple.com/documentation/apple_news/apple_news_api/getting_ready_to_publish_and_manage_your_articles">%s</a> %s <a target="_blank" href="https://support.apple.com/guide/news-publisher/use-your-cms-with-news-publisher-apd88c8447e6/icloud">%s</a> %s.',
-			__( 'Please upload your Apple News channel configuration file below. Please see', 'apple-news' ),
-			__( 'the Apple News API documentation', 'apple-news' ),
-			__( 'and', 'apple-news' ),
-			__( 'the News Publisher documentation', 'apple-news' ),
-			__( 'for detailed information. For further assistance, please contact your Apple News representative.', 'apple-news' )
+			__( 'Please upload your Apple News channel configuration file below. Please see %sthe Apple News API documentation%s and %sthe News Publisher documentation%s for detailed information. For further assistance, please contact your Apple News representative.', 'apple-news' ),
+			'<a target="_blank" href="https://developer.apple.com/documentation/apple_news/apple_news_api/getting_ready_to_publish_and_manage_your_articles">',
+			'</a>',
+			'<a target="_blank" href="https://support.apple.com/guide/news-publisher/use-your-cms-with-news-publisher-apd88c8447e6/icloud">',
+			'</a>',
 		);
 	}
 

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -33,7 +33,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		// Add the settings.
 		$this->settings = array(
 			'api_config_file'     => array(
-				'label' => __( 'PAPI File Upload', 'apple-news' ),
+				'label' => __( 'Upload channel configuration file:', 'apple-news' ),
 				'type'  => 'file',
 			),
       'api_config_file_input'     => array(

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -32,20 +32,22 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 
 		// Add the settings.
 		$this->settings = array(
+			'api_config_file'     => array(
+				'label' => __( 'PAPI File Upload', 'apple-news' ),
+				'type'  => 'file',
+			),
+      'api_config_file_input'     => array(
+				'label' => __( 'PAPI File Input', 'apple-news' ),
+				'type'  => 'textarea',
+			),
 			'api_channel'         => array(
-				'label' => __( 'Channel ID', 'apple-news' ),
-				'type'  => 'string',
-				'size'  => 40,
+				'type'  => 'hidden',
 			),
 			'api_key'             => array(
-				'label' => __( 'API Key ID', 'apple-news' ),
-				'type'  => 'string',
-				'size'  => 40,
+				'type'  => 'hidden',
 			),
 			'api_secret'          => array(
-				'label' => __( 'API Key Secret', 'apple-news' ),
-				'type'  => 'password',
-				'size'  => 40,
+				'type'  => 'hidden',
 			),
 			'api_autosync'        => array(
 				'label' => __( 'Automatically publish to Apple News when published in WordPress', 'apple-news' ),
@@ -70,7 +72,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		$this->groups = array(
 			'apple_news' => array(
 				'label'    => __( 'Apple News API', 'apple-news' ),
-				'settings' => array( 'api_channel', 'api_key', 'api_secret', 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async' ),
+				'settings' => array( 'api_config_file', 'api_config_file_input', 'api_channel', 'api_key', 'api_secret', 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async' ),
 			),
 		);
 

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -33,10 +33,11 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		// Add the settings.
 		$this->settings = array(
 			'api_config_file'     => array(
+        'description' => __( 'Having trouble? <a href="#apple-news-credentials-input">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
 				'type'  => 'file',
+        'size'  => '100',
 			),
       'api_config_file_input'     => array(
-				'label' => __( 'Advanced users <a href="#">click here</a>.', 'apple-news' ),
 				'type'  => 'textarea',
 			),
 			'api_channel'         => array(

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -90,10 +90,12 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 	 */
 	public function get_section_info() {
 		return sprintf(
-			'%s <a target="_blank" href="https://developer.apple.com/news-publisher/">%s</a> %s.',
-			__( 'Enter your Apple News credentials below. See', 'apple-news' ),
-			__( 'the Apple News documentation', 'apple-news' ),
-			__( 'for detailed information', 'apple-news' )
+			'%s <a target="_blank" href="https://developer.apple.com/documentation/apple_news/apple_news_api/getting_ready_to_publish_and_manage_your_articles">%s</a> %s <a target="_blank" href="https://support.apple.com/guide/news-publisher/use-your-cms-with-news-publisher-apd88c8447e6/icloud">%s</a> %s.',
+			__( 'Please upload your Apple News channel configuration file below. Please see', 'apple-news' ),
+			__( 'the Apple News API documentation', 'apple-news' ),
+			__( 'and', 'apple-news' ),
+			__( 'the News Publisher documentation', 'apple-news' ),
+			__( 'for detailed information. For further assistance, please contact your Apple News representative.', 'apple-news' )
 		);
 	}
 

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -35,7 +35,6 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 			'api_config_file'     => array(
         'description' => __( 'Having trouble? <a href="#api_config_file">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
 				'type'  => 'file',
-        'size'  => '100',
 			),
       'api_config_file_input'     => array(
 				'type'  => 'textarea',

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -33,11 +33,10 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		// Add the settings.
 		$this->settings = array(
 			'api_config_file'     => array(
-				'label' => __( 'Upload channel configuration file:', 'apple-news' ),
 				'type'  => 'file',
 			),
       'api_config_file_input'     => array(
-				'label' => __( 'PAPI File Input', 'apple-news' ),
+				'label' => __( 'Advanced users <a href="#">click here</a>.', 'apple-news' ),
 				'type'  => 'textarea',
 			),
 			'api_channel'         => array(
@@ -70,9 +69,13 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 
 		// Add the groups.
 		$this->groups = array(
-			'apple_news' => array(
-				'label'    => __( 'Apple News API', 'apple-news' ),
-				'settings' => array( 'api_config_file', 'api_config_file_input', 'api_channel', 'api_key', 'api_secret', 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async' ),
+			'apple_news_config_upload' => array(
+				'label'    => __( 'Upload Channel Configuration File:', 'apple-news' ),
+				'settings' => array( 'api_config_file', 'api_config_file_input', 'api_channel', 'api_key', 'api_secret'),
+			),
+      'apple_news_options' => array(
+				'label'    => __( 'Apple News API Options', 'apple-news' ),
+				'settings' => array( 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async' ),
 			),
 		);
 

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -95,7 +95,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 			'<a target="_blank" href="https://developer.apple.com/documentation/apple_news/apple_news_api/getting_ready_to_publish_and_manage_your_articles">',
 			'</a>',
 			'<a target="_blank" href="https://support.apple.com/guide/news-publisher/use-your-cms-with-news-publisher-apd88c8447e6/icloud">',
-			'</a>',
+			'</a>'
 		);
 	}
 

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -32,35 +32,35 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 
 		// Add the settings.
 		$this->settings = array(
-			'api_config_file'     => array(
+			'api_config_file'       => array(
 				'description' => __( 'Having trouble? <a href="#api_config_file">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
-				'type'  => 'file',
+				'type'        => 'file',
 			),
-			'api_config_file_input'     => array(
-				'type'  => 'textarea',
+			'api_config_file_input' => array(
+				'type' => 'textarea',
 			),
-			'api_channel'         => array(
-				'type'  => 'hidden',
+			'api_channel'           => array(
+				'type' => 'hidden',
 			),
-			'api_key'             => array(
-				'type'  => 'hidden',
+			'api_key'               => array(
+				'type' => 'hidden',
 			),
-			'api_secret'          => array(
-				'type'  => 'hidden',
+			'api_secret'            => array(
+				'type' => 'hidden',
 			),
-			'api_autosync'        => array(
+			'api_autosync'          => array(
 				'label' => __( 'Automatically publish to Apple News when published in WordPress', 'apple-news' ),
 				'type'  => array( 'yes', 'no' ),
 			),
-			'api_autosync_update' => array(
+			'api_autosync_update'   => array(
 				'label' => __( 'Automatically update in Apple News when updated in WordPress', 'apple-news' ),
 				'type'  => array( 'yes', 'no' ),
 			),
-			'api_autosync_delete' => array(
+			'api_autosync_delete'   => array(
 				'label' => __( 'Automatically delete from Apple News when deleted in WordPress', 'apple-news' ),
 				'type'  => array( 'yes', 'no' ),
 			),
-			'api_async'           => array(
+			'api_async'             => array(
 				'label'       => __( 'Asynchronously publish to Apple News', 'apple-news' ),
 				'type'        => array( 'yes', 'no' ),
 				'description' => $this->get_async_description(),
@@ -73,7 +73,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 				'label'    => __( 'Upload Channel Configuration File:', 'apple-news' ),
 				'settings' => array( 'api_config_file', 'api_config_file_input', 'api_channel', 'api_key', 'api_secret' ),
 			),
-			'apple_news_options' => array(
+			'apple_news_options'       => array(
 				'label'    => __( 'Apple News API Options', 'apple-news' ),
 				'settings' => array( 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async' ),
 			),

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -33,10 +33,10 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		// Add the settings.
 		$this->settings = array(
 			'api_config_file'     => array(
-        'description' => __( 'Having trouble? <a href="#api_config_file">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
+				'description' => __( 'Having trouble? <a href="#api_config_file">Enter the contents of your .papi file manually</a>.', 'apple-news' ),
 				'type'  => 'file',
 			),
-      'api_config_file_input'     => array(
+			'api_config_file_input'     => array(
 				'type'  => 'textarea',
 			),
 			'api_channel'         => array(
@@ -71,9 +71,9 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 		$this->groups = array(
 			'apple_news_config_upload' => array(
 				'label'    => __( 'Upload Channel Configuration File:', 'apple-news' ),
-				'settings' => array( 'api_config_file', 'api_config_file_input', 'api_channel', 'api_key', 'api_secret'),
+				'settings' => array( 'api_config_file', 'api_config_file_input', 'api_channel', 'api_key', 'api_secret' ),
 			),
-      'apple_news_options' => array(
+			'apple_news_options' => array(
 				'label'    => __( 'Apple News API Options', 'apple-news' ),
 				'settings' => array( 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async' ),
 			),

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -314,8 +314,8 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field .= '</select>';
 		} elseif ( 'password' === $type ) {
 			$field = '<input type="password" id="%s" name="%s" value="%s" size="%s" %s>';
-		} elseif ( 'hidden' === $type ) {
-			$field = '<input type="hidden" id="%s" name="%s" value="%s">';
+		} elseif ( 'hidden' === $type ) { // change this back
+			$field = '<input type="text" id="%s" name="%s" value="%s">';
 		} elseif ( 'file' === $type ) {
 			$field = '<input type="file" id="%s" name="%s">';
 		} elseif ( 'textarea' === $type ) {

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -108,6 +108,11 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'id'       => array(),
 			'size'     => array(),
 		),
+    'textarea' => array(
+			'class'    => array(),
+			'name'     => array(),
+			'id'       => array(),
+		),
 		'option' => array(
 			'value'    => array(),
 			'selected' => array(),
@@ -311,6 +316,10 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field = '<input type="password" id="%s" name="%s" value="%s" size="%s" %s>';
 		} elseif ( 'hidden' === $type ) {
 			$field = '<input type="hidden" id="%s" name="%s" value="%s">';
+		} elseif ( 'file' === $type ) {
+			$field = '<input type="file" id="%s" name="%s">';
+		} elseif ( 'textarea' === $type ) {
+			$field = '<textarea id="%s" name="%s">%s</textarea>';
 		} else {
 			// If nothing else matches, it's a string.
 			$field = '<input type="text" id="%s" name="%s" value="%s" size="%s" %s>';
@@ -337,6 +346,19 @@ class Admin_Apple_Settings_Section extends Apple_News {
 				intval( $size )
 			);
 		} elseif ( 'hidden' === $type ) {
+			return sprintf(
+				$field,
+				esc_attr( $name ),
+				esc_attr( $name ),
+				esc_attr( $value )
+			);
+		} elseif ( 'file' === $type ) {
+			return sprintf(
+				$field,
+				esc_attr( $name ),
+				esc_attr( $name )
+			);
+		} elseif ( 'textarea' === $type ) {
 			return sprintf(
 				$field,
 				esc_attr( $name ),

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -315,7 +315,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		} elseif ( 'password' === $type ) {
 			$field = '<input type="password" id="%s" name="%s" value="%s" size="%s" %s>';
 		} elseif ( 'hidden' === $type ) {
-			$field = '<input type="hidden" id="%s" name="%s" value="%s">';
+			$field = '<input type="text" id="%s" name="%s" value="%s">';
 		} elseif ( 'file' === $type ) {
 			$field = '<input type="file" id="%s" name="%s">';
 		} elseif ( 'textarea' === $type ) {

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -101,7 +101,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 * @access public
 	 */
 	public static $allowed_html = array(
-		'select' => array(
+		'select'   => array(
 			'class'    => array(),
 			'name'     => array(),
 			'multiple' => array(),
@@ -109,15 +109,15 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'size'     => array(),
 		),
 		'textarea' => array(
-			'class'    => array(),
-			'name'     => array(),
-			'id'       => array(),
+			'class' => array(),
+			'name'  => array(),
+			'id'    => array(),
 		),
-		'option' => array(
+		'option'   => array(
 			'value'    => array(),
 			'selected' => array(),
 		),
-		'input'  => array(
+		'input'    => array(
 			'class'       => array(),
 			'name'        => array(),
 			'value'       => array(),
@@ -128,34 +128,34 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'size'        => array(),
 			'id'          => array(),
 		),
-		'br'     => array(),
-		'b'      => array(),
-		'strong' => array(),
-		'i'      => array(),
-		'em'     => array(),
-		'a'      => array(
+		'br'       => array(),
+		'b'        => array(),
+		'strong'   => array(),
+		'i'        => array(),
+		'em'       => array(),
+		'a'        => array(
 			'href'   => array(),
 			'target' => array(),
 		),
-		'div'    => array(
+		'div'      => array(
 			'class' => array(),
 		),
-		'h1'     => array(
+		'h1'       => array(
 			'class' => array(),
 		),
-		'h2'     => array(
+		'h2'       => array(
 			'class' => array(),
 		),
-		'h3'     => array(
+		'h3'       => array(
 			'class' => array(),
 		),
-		'h4'     => array(
+		'h4'       => array(
 			'class' => array(),
 		),
-		'h5'     => array(
+		'h5'       => array(
 			'class' => array(),
 		),
-		'h6'     => array(
+		'h6'       => array(
 			'class' => array(),
 		),
 	);

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -314,8 +314,8 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field .= '</select>';
 		} elseif ( 'password' === $type ) {
 			$field = '<input type="password" id="%s" name="%s" value="%s" size="%s" %s>';
-		} elseif ( 'hidden' === $type ) { // change this back
-			$field = '<input type="text" id="%s" name="%s" value="%s">';
+		} elseif ( 'hidden' === $type ) {
+			$field = '<input type="hidden" id="%s" name="%s" value="%s">';
 		} elseif ( 'file' === $type ) {
 			$field = '<input type="file" id="%s" name="%s">';
 		} elseif ( 'textarea' === $type ) {

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -108,7 +108,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'id'       => array(),
 			'size'     => array(),
 		),
-    'textarea' => array(
+		'textarea' => array(
 			'class'    => array(),
 			'name'     => array(),
 			'id'       => array(),

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -315,7 +315,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		} elseif ( 'password' === $type ) {
 			$field = '<input type="password" id="%s" name="%s" value="%s" size="%s" %s>';
 		} elseif ( 'hidden' === $type ) {
-			$field = '<input type="text" id="%s" name="%s" value="%s">';
+			$field = '<input type="hidden" id="%s" name="%s" value="%s">';
 		} elseif ( 'file' === $type ) {
 			$field = '<input type="file" id="%s" name="%s">';
 		} elseif ( 'textarea' === $type ) {

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -54,6 +54,7 @@
         reader.onload = function(f) {
           // When a file is uploaded, the read contents populate the hidden textarea.
           var contents = f.target.result;
+          updateCreds(contents);
           $( '#api_config_file_input' ).val(contents);
         };
         reader.readAsText(file);

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -2,6 +2,25 @@
 	function ( $, window, undefined ) {
 		'use strict';
 
+    // storing RegExp strings for decoding the uploaded config file
+    var RegExpStrings = {
+      channel_id: /channel_id: [0-9a-zA-Z_-]*/g,
+      key: /key: [0-9a-zA-Z_-]*/g,
+      secret: /secret: [0-9a-zA-Z_-]*/g
+    }
+
+    function updateCreds(input) {
+      $( '#api_channel' ).val(
+        input.match(RegExpStrings.channel_id).toString().split(" ")[1]
+      );
+      $( '#api_key' ).val(
+        input.match(RegExpStrings.key).toString().split(" ")[1]
+      );
+      $( '#api_secret' ).val(
+        input.match(RegExpStrings.secret).toString().split(" ")[1]
+      );
+    }
+
 		// Listen for changes to the debugging settings.
 		$( '#apple_news_enable_debugging' ).on( 'change', function () {
 			var $email = $( '#apple_news_admin_email' );
@@ -21,7 +40,9 @@
         const reader = new FileReader();
         reader.onload = function(f) {
           // When a file is uploaded, the read contents populate the hidden textarea.
-          $( '#api_config_file_input' ).val(f.target.result);
+          var contents = f.target.result;
+          updateCreds(contents);
+          $( '#api_config_file_input' ).val(contents);
         };
         reader.readAsText(file);
       }
@@ -30,22 +51,7 @@
     // Reading in the needed values from the hidden textarea field.
     $( '#api_config_file_input' ).on( 'change', function () {
       var input = $( '#api_config_file_input' ).val();
-
-      var RegExpStrings = {
-        channel_id: /channel_id: [0-9a-zA-Z_-]*/g,
-        key: /key: [0-9a-zA-Z_-]*/g,
-        secret: /secret: [0-9a-zA-Z_-]*/g
-      }
-
-      $( '#api_channel' ).val(
-        input.match(RegExpStrings.channel_id).toString().split(" ")[1]
-      );
-      $( '#api_key' ).val(
-        input.match(RegExpStrings.key).toString().split(" ")[1]
-      );
-      $( '#api_secret' ).val(
-        input.match(RegExpStrings.secret).toString().split(" ")[1]
-      );
+      updateCreds(input);
     });
 	}
 )( jQuery, window );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -21,6 +21,20 @@
       );
     }
 
+    // Hide manual-input textarea for creds on load.
+    $( '#api_config_file_input' ).css({
+        'display': 'none',
+        'width': '300px',
+        'height': '250px'
+    });
+
+    $( 'a[href$="#api_config_file"]' ).click(function () {
+      $( '#api_config_file_input' ).css({
+              'display': 'block'
+      });
+    });
+
+
 		// Listen for changes to the debugging settings.
 		$( '#apple_news_enable_debugging' ).on( 'change', function () {
 			var $email = $( '#apple_news_admin_email' );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -4,9 +4,9 @@
 
     // storing RegExp strings for decoding the uploaded config file
     var RegExpStrings = {
-      channel_id: /channel_id: ([0-9a-zA-Z_-]+)/,
-      key: /key: ([0-9a-zA-Z_-]+)/,
-      secret: /secret: ([0-9a-zA-Z_-]+)/
+      channel_id: /channel_id: ([0-9a-zA-Z_-]+)/g,
+      key: /key: ([0-9a-zA-Z_-]+)/g,
+      secret: /secret: ([0-9a-zA-Z_-]+)/g
     }
 
     function updateCreds(input) {
@@ -54,7 +54,6 @@
         reader.onload = function(f) {
           // When a file is uploaded, the read contents populate the hidden textarea.
           var contents = f.target.result;
-          updateCreds(contents);
           $( '#api_config_file_input' ).val(contents);
         };
         reader.readAsText(file);

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -11,5 +11,19 @@
 				$email.removeAttr( 'required' );
 			}
 		} ).change();
+
+    // Code for reading uploaded papi file.
+		$( '#api_config_file' ).on( 'change', function (e) {
+			if (!e.target.files || !e.target.files[0]) {
+        return;
+      } else {
+        const file = e.target.files[0];
+        const reader = new FileReader();
+        reader.onload = function(f) {
+          console.log(f.target.result);
+        };
+        reader.readAsText(file);
+      }
+		} );
 	}
 )( jQuery, window );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -20,7 +20,7 @@
         const file = e.target.files[0];
         const reader = new FileReader();
         reader.onload = function(f) {
-          console.log(f.target.result);
+          $( '#api_config_file_input' ).text(f.target.result);
         };
         reader.readAsText(file);
       }

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -4,21 +4,20 @@
 
     // storing RegExp strings for decoding the uploaded config file
     var RegExpStrings = {
-      channel_id: /channel_id: [0-9a-zA-Z_-]*/g,
-      key: /key: [0-9a-zA-Z_-]*/g,
-      secret: /secret: [0-9a-zA-Z_-]*/g
+      channel_id: /channel_id: ([0-9a-zA-Z_-]+)/,
+      key: /key: ([0-9a-zA-Z_-]+)/,
+      secret: /secret: ([0-9a-zA-Z_-]+)/
     }
 
     function updateCreds(input) {
-      $( '#api_channel' ).val(
-        input.match(RegExpStrings.channel_id).toString().split(" ")[1]
-      );
-      $( '#api_key' ).val(
-        input.match(RegExpStrings.key).toString().split(" ")[1]
-      );
-      $( '#api_secret' ).val(
-        input.match(RegExpStrings.secret).toString().split(" ")[1]
-      );
+      var channelIdMatch = input.match(RegExpStrings.channel_id).toString().split(" ");
+      $( '#api_channel' ).val(channelIdMatch ? channelIdMatch[1] : '');
+
+      var keyMatch = input.match(RegExpStrings.key).toString().split(" ");
+      $( '#api_key' ).val(keyMatch ? keyMatch[1] : '');
+
+      var secretMatch = input.match(RegExpStrings.secret).toString().split(" ");
+      $( '#api_secret' ).val(secretMatch ? secretMatch[1] : '');
     }
 
     // Hide manual-input textarea for creds on load.

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -20,10 +20,32 @@
         const file = e.target.files[0];
         const reader = new FileReader();
         reader.onload = function(f) {
-          $( '#api_config_file_input' ).text(f.target.result);
+          // When a file is uploaded, the read contents populate the hidden textarea.
+          $( '#api_config_file_input' ).val(f.target.result);
         };
         reader.readAsText(file);
       }
 		} );
+
+    // Reading in the needed values from the hidden textarea field.
+    $( '#api_config_file_input' ).on( 'change', function () {
+      var input = $( '#api_config_file_input' ).val();
+
+      var RegExpStrings = {
+        channel_id: /channel_id: [0-9a-zA-Z_-]*/g,
+        key: /key: [0-9a-zA-Z_-]*/g,
+        secret: /secret: [0-9a-zA-Z_-]*/g
+      }
+
+      $( '#api_channel' ).val(
+        input.match(RegExpStrings.channel_id).toString().split(" ")[1]
+      );
+      $( '#api_key' ).val(
+        input.match(RegExpStrings.key).toString().split(" ")[1]
+      );
+      $( '#api_secret' ).val(
+        input.match(RegExpStrings.secret).toString().split(" ")[1]
+      );
+    });
 	}
 )( jQuery, window );


### PR DESCRIPTION
This eliminates the individual inputs for API config credentials, and replaces them with a file upload (or text area) for a single .papi file that includes all of those creds. We're extracting the actual creds using RegExp and JS.