### PR TITLE
APPLE-65 Add support for HLS video (.m3u8) in video thumbnails

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.1.3
+ * Version:     2.1.4
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -92,7 +92,7 @@ class Metadata extends Builder {
 			for ( $i = 0; $i < $total; $i ++ ) {
 
 				// Try to match an MP4 source URL.
-				if ( preg_match( '/src="([^\?"]+\.mp4[^"]*)"/', $matches[0][ $i ], $src ) ) {
+				if ( preg_match( '/src="([^\?"]+\.(mp4|m3u8)[^"]*)"/', $matches[0][ $i ], $src ) ) {
 
 					// Include the thumbnail and video URL if the video URL is valid.
 					$url = Exporter_Content::format_src_url( $src[1] );

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.1.3';
+	public static $version = '2.1.4';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.7.2
 Requires PHP: 5.6
-Stable tag: 2.1.3
+Stable tag: 2.1.4
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.1.4 =
+* Enhancement: Added support for HLS video (.m3u8) in thumbnails.
 
 = 2.1.3 =
 * Enhancement: Added article authors to the `metadata.authors` property so they display in the article listing view on Apple News.

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -15,6 +15,24 @@
 class Metadata_Test extends Apple_News_Testcase {
 
 	/**
+	 * A data provider for the test_video function.
+	 *
+	 * @return array An array of arrays representing function arguments.
+	 */
+	public function data_video() {
+		return [
+			[
+				'https://example.com/wp-content/uploads/2017/02/example-poster.jpg',
+				'https://example.com/wp-content/uploads/2017/02/example-video.mp4',
+			],
+			[
+				'https://example.com/wp-content/uploads/2017/02/example-poster.jpg',
+				'https://example.com/wp-content/uploads/2017/02/example-video.m3u8',
+			],
+		];
+	}
+
+	/**
 	 * Ensures authors are properly added using Co-Authors Plus.
 	 *
 	 * @access public
@@ -90,26 +108,23 @@ class Metadata_Test extends Apple_News_Testcase {
 	/**
 	 * Ensures video metadata is properly added.
 	 *
-	 * @access public
+	 * @param string $poster The URL to the poster image for the video.
+	 * @param string $video  The URL to the video.
+	 *
+	 * @dataProvider data_video
 	 */
-	public function test_video() {
+	public function test_video( $poster, $video ) {
 		// Setup.
 		$post_id  = self::factory()->post->create(
 			[
-				'post_content' => '<figure class="wp-block-video"><video controls="" poster="https://example.com/wp-content/uploads/2017/02/example-poster.jpg" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4"></video></figure>',
+				'post_content' => '<figure class="wp-block-video"><video controls="" poster="' . $poster . '" src="' . $video . '"></video></figure>',
 			]
 		);
 		$result   = $this->get_json_for_post( $post_id );
 		$metadata = $result['metadata'];
 
 		// Assertions.
-		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/example-poster.jpg',
-			$metadata['thumbnailURL']
-		);
-		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/example-video.mp4',
-			$metadata['videoURL']
-		);
+		$this->assertEquals( $poster, $metadata['thumbnailURL'] );
+		$this->assertEquals( $video, $metadata['videoURL'] );
 	}
 }


### PR DESCRIPTION
* Adds support for .m3u8 video files in video thumbnails in addition to .mp4 files.
* Adds a unit test to confirm the functionality.
* Bumps the version to 2.1.4 and adds a note about this change to the changelog.