### PR TITLE
Fix theme overrides for default-pullquote

### DIFF
--- a/assets/themes/classic.json
+++ b/assets/themes/classic.json
@@ -94,7 +94,7 @@
                         "text": "#text#",
                         "format": "#format#",
                         "layout": "pullquote-layout",
-                        "textStyle": "default-pullquote"
+                        "textStyle": "#default_pullquote#"
                     }
                 ],
                 "anchor": {

--- a/assets/themes/dark.json
+++ b/assets/themes/dark.json
@@ -151,7 +151,7 @@
                         "text": "#text#",
                         "format": "#format#",
                         "layout": "pullquote-layout",
-                        "textStyle": "default-pullquote"
+                        "textStyle": "#default_pullquote#"
                     },
                     {
                         "role": "divider",

--- a/assets/themes/modern.json
+++ b/assets/themes/modern.json
@@ -90,7 +90,7 @@
                         "text": "#text#",
                         "format": "#format#",
                         "layout": "pullquote-layout",
-                        "textStyle": "default-pullquote"
+                        "textStyle": "#default_pullquote#"
                     }
                 ],
                 "layout": "pullquote-layout"
@@ -100,7 +100,7 @@
                 "text": "#text#",
                 "format": "#format#",
                 "layout": "pullquote-layout",
-                "textStyle": "default-pullquote"
+                "textStyle": "#default_pullquote#"
             }
         },
         "title": {


### PR DESCRIPTION
classic, dark and modern themes have no styles defined for
default-pullquote in their overrides for pullquotes. This results in
errors in the API: Document has missing references. Couldn't find
ComponentTextStyle on document for id: default-pullquote and, no inline
value set!

Fixes #815