### PR TITLE
Hotfix: .papi file parsing

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.2.0
+ * Version:     2.2.1
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -4,9 +4,9 @@
 
     // storing RegExp strings for decoding the uploaded config file
     var RegExpStrings = {
-      channel_id: /channel_id: ([0-9a-zA-Z_-]+)/g,
-      key: /key: ([0-9a-zA-Z_-]+)/g,
-      secret: /secret: ([0-9a-zA-Z_-]+)/g
+      channel_id: /channel_id: ([^\s]+)/g,
+      key: /key: ([^\s]+)/g,
+      secret: /secret: ([^\s]+)/g
     }
 
     function updateCreds(input) {

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.2.0';
+	public static $version = '2.2.1';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-to-apple-news",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "hasInstallScript": true,
       "license": "GPLv3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.2.1 =
+* Bugfix: Fixed a bug with .papi file upload that occurred when any of the three fields (channel_id, key, secret) contained a character that was not alphanumeric or a hyphen (e.g., /), which would cause the field to get cut short, thereby causing API requests to fail.
 
 = 2.2.0 =
 * Enhancement: Added support for HLS video (.m3u8) in thumbnails.


### PR DESCRIPTION
* Fixes a bug with `.papi` file parsing where special characters present in any field (channel_id, key, secret) such as a `/` would cause parsing to end prematurely, resulting in a cut off value being saved to the database, which would cause subsequent API requests to fail.
* Bumps version to 2.2.1 and adds changelog.

Fixes #875 