### PR TITLE
APPLE-98 Prepare v2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Publish to Apple News
 
-The Publish to Apple News plugin enables your WordPress blog content to be published to your Apple News channel.
+The Publish to Apple News plugin enables your WordPress content to be published to your Apple News channel.
 
 * Convert your WordPress content into Apple News format automatically.
 * Create a custom design for your Apple News content with no programming knowledge required.
@@ -10,7 +10,7 @@ The Publish to Apple News plugin enables your WordPress blog content to be publi
 * Handles image galleries and popular embeds like YouTube and Vimeo that are supported by Apple News.
 * Automatically adjust advertisement settings.
 
-To enable content from your WordPress blog to be published to your Apple News channel, you must obtain and enter Apple News API credentials from Apple.
+To enable content from your WordPress site to be published to your Apple News channel, you must obtain and enter Apple News API credentials from Apple.
 
 Please see the [Apple Developer](https://developer.apple.com/) and [Apple News Publisher documentation](https://developer.apple.com/news-publisher/) and terms on Apple's website for complete information.
 

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -431,7 +431,6 @@ class Push extends API_Action {
 	private function process_errors( $errors ) {
 		// Get the current alert settings.
 		$component_alerts = $this->get_setting( 'component_alerts' );
-		$json_alerts      = $this->get_setting( 'json_alerts' );
 
 		// Initialize the alert message.
 		$alert_message = '';
@@ -459,39 +458,13 @@ class Push extends API_Action {
 			}
 		}
 
-		// Check for JSON errors.
-		if ( ! empty( $errors[0]['json_errors'] ) ) {
-			if ( ! empty( $alert_message ) ) {
-				$alert_message .= '|';
-			}
-
-			// Merge all errors into a single message.
-			$json_errors = implode( ', ', $errors[0]['json_errors'] );
-
-			// Add these to the message.
-			if ( 'warn' === $json_alerts ) {
-				$alert_message .= sprintf(
-					// translators: token is a list of errors.
-					__( 'The following JSON errors were detected when publishing to Apple News: %s', 'apple-news' ),
-					$json_errors
-				);
-			} elseif ( 'fail' === $json_alerts ) {
-				$alert_message .= sprintf(
-					// translators: token is a list of errors.
-					__( 'The following JSON errors were detected and prevented publishing to Apple News: %s', 'apple-news' ),
-					$json_errors
-				);
-			}
-		}
-
 		// See if we found any errors.
 		if ( empty( $alert_message ) ) {
 			return;
 		}
 
 		// Proceed based on component alert settings.
-		if ( ( 'fail' === $component_alerts && ! empty( $errors[0]['component_errors'] ) )
-			|| ( 'fail' === $json_alerts && ! empty( $errors[0]['json_errors'] ) ) ) {
+		if ( 'fail' === $component_alerts && ! empty( $errors[0]['component_errors'] ) ) {
 			// Remove the pending designation if it exists.
 			delete_post_meta( $this->id, 'apple_news_api_pending' );
 
@@ -503,8 +476,7 @@ class Push extends API_Action {
 
 			// Throw an exception.
 			throw new \Apple_Actions\Action_Exception( $alert_message );
-		} elseif ( ( 'warn' === $component_alerts && ! empty( $errors[0]['component_errors'] ) )
-			|| ( 'warn' === $json_alerts && ! empty( $errors[0]['json_errors'] ) ) ) {
+		} elseif ( 'warn' === $component_alerts && ! empty( $errors[0]['component_errors'] ) ) {
 				\Admin_Apple_Notice::error( $alert_message, $user_id );
 		}
 	}

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -302,6 +302,31 @@ class Push extends API_Action {
 			$meta['data']['maturityRating'] = $maturity_rating;
 		}
 
+		// Add custom metadata fields.
+		$custom_meta = get_post_meta( $this->id, 'apple_news_metadata', true );
+		if ( ! empty( $custom_meta ) && is_array( $custom_meta ) ) {
+			foreach ( $custom_meta as $metadata ) {
+				// Ensure required fields are set.
+				if ( empty( $metadata['key'] ) || empty( $metadata['type'] ) || ! isset( $metadata['value'] ) ) {
+					continue;
+				}
+
+				// If the value is an array, we have to decode it from JSON.
+				$value = $metadata['value'];
+				if ( 'array' === $metadata['type'] ) {
+					$value = json_decode( $metadata['value'] );
+
+					// If the user entered a bad value for the array, bail out without adding it.
+					if ( empty( $value ) || ! is_array( $value ) ) {
+						continue;
+					}
+				}
+
+				// Add the custom metadata field to the article metadata.
+				$meta['data'][ $metadata['key'] ] = $value;
+			}
+		}
+
 		// Ignore if the post is already in sync.
 		if ( $this->is_post_in_sync( $json, $meta, $bundles ) ) {
 			throw new \Apple_Actions\Action_Exception(

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -12,6 +12,11 @@
 ?>
 <div class="wrap apple-news-settings">
 	<h1><?php esc_html_e( 'Manage Settings', 'apple-news' ); ?></h1>
+	<?php if ( Apple_News::is_initialized() ) : ?>
+		<div class="notice notice-success">
+			<p><?php esc_html_e( 'The Apple News channel config has been successfully added.', 'apple-news' ); ?></p>
+		</div>
+	<?php endif; ?>
 	<form method="post" action="" id="apple-news-settings-form">
 		<?php wp_nonce_field( 'apple_news_options' ); ?>
 		<input type="hidden" name="action" value="apple_news_options" />

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -37,11 +37,6 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'type'        => array( 'none', 'warn', 'fail' ),
 				'description' => __( 'If a post has a component that is unsupported by Apple News, choose "none" to generate no alert, "warn" to provide an admin warning notice, or "fail" to generate a notice and stop publishing.', 'apple-news' ),
 			),
-			'json_alerts'       => array(
-				'label'       => __( 'JSON Alerts', 'apple-news' ),
-				'type'        => array( 'none', 'warn', 'fail' ),
-				'description' => __( 'If a post has invalid JSON that may cause display issues in Apple News, choose "none" to generate no alert, "warn" to provide an admin warning notice, or "fail" to generate a notice and stop publishing.', 'apple-news' ),
-			),
 			'use_remote_images' => array(
 				'label'       => __( 'Use Remote Images?', 'apple-news' ),
 				'type'        => array( 'yes', 'no' ),
@@ -68,7 +63,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 		$this->groups = array(
 			'alerts' => array(
 				'label'    => __( 'Alerts', 'apple-news' ),
-				'settings' => array( 'component_alerts', 'json_alerts' ),
+				'settings' => array( 'component_alerts' ),
 			),
 			'images' => array(
 				'label'    => __( 'Image Settings', 'apple-news' ),

--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.2.1
+ * Version:     2.2.2
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -108,31 +108,6 @@ class Metadata extends Builder {
 			}
 		}
 
-		// Add custom metadata fields.
-		$custom_meta = get_post_meta( $this->content_id(), 'apple_news_metadata', true );
-		if ( ! empty( $custom_meta ) && is_array( $custom_meta ) ) {
-			foreach ( $custom_meta as $metadata ) {
-				// Ensure required fields are set.
-				if ( empty( $metadata['key'] ) || empty( $metadata['type'] ) || ! isset( $metadata['value'] ) ) {
-					continue;
-				}
-
-				// If the value is an array, we have to decode it from JSON.
-				$value = $metadata['value'];
-				if ( 'array' === $metadata['type'] ) {
-					$value = json_decode( $metadata['value'] );
-
-					// If the user entered a bad value for the array, bail out without adding it.
-					if ( empty( $value ) || ! is_array( $value ) ) {
-						continue;
-					}
-				}
-
-				// Add the custom metadata field to the article metadata.
-				$meta[ $metadata['key'] ] = $value;
-			}
-		}
-
 		/**
 		 * Modifies the metadata for a post.
 		 *

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -42,7 +42,6 @@ class Settings {
 		'component_alerts'            => 'none',
 		'full_bleed_images'           => 'no',
 		'html_support'                => 'yes',
-		'json_alerts'                 => 'warn',
 		'post_types'                  => array( 'post' ),
 		'show_metabox'                => 'yes',
 		'use_remote_images'           => 'yes',

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.2.1';
+	public static $version = '2.2.2';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-to-apple-news",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "hasInstallScript": true,
       "license": "GPLv3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 
 = 2.2.2 =
 * Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.
+* Bugfix: Removed JSON alerts setting, as it no longer does anything.
 * Enhancement: Shows a confirmation message to the user when channel credentials are successfully saved, since the channel ID, key, and secret fields are no longer visible following the update to using .papi files to configure credentials.
 
 = 2.2.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -25,7 +25,7 @@ The 'Publish to Apple News' plugin enables WordPress sites with approved Apple N
 * Handles image galleries and popular embeds like YouTube and Vimeo that are supported by Apple News.
 * Automatically adjust advertisement settings.
 
-To enable content from your WordPress blog to be published to your Apple News channel, you must obtain and enter Apple News API credentials from Apple.
+To enable content from your WordPress site to be published to your Apple News channel, you must obtain and enter Apple News API credentials from Apple.
 
 Please see the [Apple Developer](https://developer.apple.com/) and [Apple News Publisher documentation](https://developer.apple.com/news-publisher/) and terms on Apple's website for complete information.
 
@@ -45,6 +45,10 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.2.2 =
+* Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.
+* Enhancement: Shows a confirmation message to the user when channel credentials are successfully saved, since the channel ID, key, and secret fields are no longer visible following the update to using .papi files to configure credentials.
 
 = 2.2.1 =
 * Bugfix: Fixed a bug with .papi file upload that occurred when any of the three fields (channel_id, key, secret) contained a character that was not alphanumeric or a hyphen (e.g., /), which would cause the field to get cut short, thereby causing API requests to fail.

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -10,10 +10,6 @@
 
 use Apple_Actions\Action_Exception;
 
-// TODO: REMOVE THESE
-use Apple_Actions\Index\Push as Push;
-use Prophecy\Argument as Argument;
-
 /**
  * A class used to test the functionality of the Apple_Actions\Index\Push class.
  */
@@ -34,7 +30,7 @@ class Admin_Action_Index_Push_Test extends Apple_News_Testcase {
 	public function test_component_errors() {
 		// Set up a post with an invalid element (div).
 		$this->become_admin();
-		$user_id = wp_get_current_user()->ID;
+		$user_id   = wp_get_current_user()->ID;
 		$post_id_1 = self::factory()->post->create( [ 'post_author' => $user_id, 'post_content' => '<div>Test Content</div>' ] );
 
 		// Test the default behavior, which is no warning or error.

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -75,29 +75,6 @@ class Metadata_Test extends Apple_News_Testcase {
 		);
 		$image   = $this->get_new_attachment( $post_id );
 		set_post_thumbnail( $post_id, $image );
-		$metadata = [
-			[
-				'key'   => 'isBoolean',
-				'type'  => 'boolean',
-				'value' => true,
-			],
-			[
-				'key'   => 'isNumber',
-				'type'  => 'number',
-				'value' => 3,
-			],
-			[
-				'key'   => 'isString',
-				'type'  => 'string',
-				'value' => 'Test String Value',
-			],
-			[
-				'key'   => 'isArray',
-				'type'  => 'array',
-				'value' => '["a", "b", "c"]',
-			],
-		];
-		add_post_meta( $post_id, 'apple_news_metadata', $metadata );
 		$result   = $this->get_json_for_post( $post_id );
 		$metadata = $result['metadata'];
 
@@ -125,22 +102,6 @@ class Metadata_Test extends Apple_News_Testcase {
 		$this->assertEquals(
 			wp_get_attachment_url( $image ),
 			$metadata['thumbnailURL']
-		);
-		$this->assertEquals(
-			true,
-			$metadata['isBoolean']
-		);
-		$this->assertEquals(
-			3,
-			$metadata['isNumber']
-		);
-		$this->assertEquals(
-			'Test String Value',
-			$metadata['isString']
-		);
-		$this->assertEquals(
-			['a', 'b', 'c'],
-			$metadata['isArray']
 		);
 	}
 

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -6,6 +6,8 @@
  * @subpackage Tests
  */
 
+use Apple_Actions\Action_Exception;
+
 /**
  * A base class for Apple News tests.
  *
@@ -399,10 +401,11 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	 * A helper function that performs a sample push operation for a given post ID
 	 * and returns the request data that would be sent to Apple.
 	 *
-	 * @param int   $post_id The post ID for which to perform the push.
-	 * @param array $data    Optional. Overrides for default faked values in the data.
+	 * @param int $post_id The post ID for which to perform the push.
+	 * @param array $data Optional. Overrides for default faked values in the data.
 	 *
 	 * @return array The request data for the post.
+	 * @throws Action_Exception
 	 */
 	protected function get_request_for_post( $post_id, $data = [] ) {
 		// Fake the API response.
@@ -439,10 +442,11 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	 * A helper function that performs a sample update operation for a given post
 	 * ID and returns the request data that would be sent to Apple.
 	 *
-	 * @param int   $post_id The post ID for which to perform the update.
-	 * @param array $data    Optional. Overrides for default faked values in the data.
+	 * @param int $post_id The post ID for which to perform the update.
+	 * @param array $data Optional. Overrides for default faked values in the data.
 	 *
 	 * @return array The request data for the post.
+	 * @throws Action_Exception
 	 */
 	protected function get_request_for_update( $post_id, $data = [] ) {
 		$article_id = isset( $data['id'] ) ? $data['id'] : 'abcd1234-ef56-ab78-cd90-efabcdef123456';

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -198,6 +198,7 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 		$this->prophet->checkPredictions();
 		remove_filter( 'apple_news_post_args', [ $this, 'filter_apple_news_post_args' ] );
 		remove_filter( 'pre_http_request', [ $this, 'filter_pre_http_request' ] );
+		wp_set_current_user( 0 );
 	}
 
 	/**
@@ -217,6 +218,19 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 			'headers'  => new Requests_Utility_CaseInsensitiveDictionary( $headers ),
 			'response' => $response,
 		];
+	}
+
+	/**
+	 * Creates a new admin (or super admin, on multisite) and sets the current
+	 * user ID to the new user. Useful when testing functionality that requires
+	 * an administrator's credentials, such as adding unfiltered HTML to a post.
+	 */
+	protected function become_admin() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		if ( function_exists( 'grant_super_admin' ) ) {
+			grant_super_admin( $user_id );
+		}
+		wp_set_current_user( $user_id );
 	}
 
 	/**

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -245,6 +245,11 @@ class Apple_News_Test extends Apple_News_Testcase {
 		$default_settings = $this->settings->all();
 		$apple_news->migrate_settings();
 
+		// Reset API info.
+		$default_settings['api_channel'] = '';
+		$default_settings['api_key']     = '';
+		$default_settings['api_secret']  = '';
+
 		// Ensure the defaults did not overwrite the migrated legacy data.
 		$migrated_settings = get_option( $apple_news::$option_name );
 		$this->assertNotEquals( $default_settings, $migrated_settings );


### PR DESCRIPTION
Prepares v2.2.2 for release.

* Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like `isPaid` and `isHidden`.
* Bugfix: Removed JSON alerts setting, as it no longer does anything.
* Enhancement: Shows a confirmation message to the user when channel credentials are successfully saved, since the channel ID, key, and secret fields are no longer visible following the update to using `.papi` files to configure credentials.

Additionally, adds a framework for performing a nearly-end-to-end test for pushing articles to Apple News, except stopping short of actually hitting Apple's API. We are faking the response instead. Converts all `Push` component tests to use the new framework.