### PR TITLE
APPLE-67 Add support for additional href protocols

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -129,6 +129,12 @@ class Export extends Action {
 				$cover_caption = wp_get_attachment_caption( $thumb_id );
 			}
 			if ( ! empty( $post_thumb_url ) ) {
+				// If the post thumb URL is root-relative, convert it to fully-qualified.
+				if ( 0 === strpos( $post_thumb_url, '/' ) ) {
+					$post_thumb_url = site_url( $post_thumb_url );
+				}
+
+				// Compile the post_thumb object using the URL and caption from the featured image.
 				$post_thumb = [
 					'caption' => ! empty( $cover_caption ) ? $cover_caption : '',
 					'url'     => $post_thumb_url,

--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.2.2
+ * Version:     2.3.0
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/includes/apple-exporter/class-parser.php
+++ b/includes/apple-exporter/class-parser.php
@@ -196,8 +196,8 @@ class Parser {
 				continue;
 			}
 
-			// Ensure that the resulting URL is fully-formed.
-			if ( ! preg_match( '/^https?:\/\/[^.]+\.[^.]+/', $href ) ) {
+			// Ensure that the resulting URL uses a supported protocol. Leave it up to the content creator to ensure the URL is otherwise valid.
+			if ( ! preg_match( '/^(https?:\/\/|mailto:|musics?:\/\/|stocks:\/\/|webcal:\/\/)/', $href ) ) {
 				$html = str_replace( $a_tag, $content, $html );
 				continue;
 			}

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -39,7 +39,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.2.2';
+	public static $version = '2.3.0';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -47,7 +47,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 == Changelog ==
 
 = 2.3.0 =
-* Enhancement: Added support for mailto: links.
+* Enhancement: Added support for mailto:, music://, musics://, stocks:// and webcal:// links.
 
 = 2.2.2 =
 * Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 == Changelog ==
 
 = 2.3.0 =
+* Bugfix: Fixes an issue where a custom filter is used to make all image URLs root-relative when using featured images to populate the Cover component, which was leading to an INVALID_DOCUMENT error from the News API due to the root-relative URL (e.g., /path/to/my/image.jpg instead of https://example.org/path/to/my/image.jpg).
 * Enhancement: Added support for mailto:, music://, musics://, stocks:// and webcal:// links.
 
 = 2.2.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 2.2.2
+Stable tag: 2.3.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.3.0 =
+* Enhancement: Added support for mailto: links.
 
 = 2.2.2 =
 * Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -202,6 +202,12 @@ HTML
 			// Standard link, https.
 			[ 'https://example.com', true ],
 
+			// Root-relative URL. Should be permitted, but auto-converted to a fully qualified URL.
+			[ '/test', true ],
+
+			// Hash-based URL. Should be permitted, but auto-converted to a hash link against the test post's permalink.
+			[ '#test', true ],
+
 			// Apple News article URL.
 			[ 'https://apple.news/A5vHgPPmQSvuIxPjeXLTdGQ', true ],
 
@@ -355,6 +361,13 @@ HTML;
 HTML;
 		$post_id  = self::factory()->post->create( [ 'post_content' => $content ] );
 		$json     = $this->get_json_for_post( $post_id );
+
+		// Negotiate expected value and test.
+		if ( 0 === strpos( $link, '/' ) ) {
+			$link = 'http://example.org' . $link;
+		} elseif ( 0 === strpos( $link, '#' ) ) {
+			$link = get_permalink( $post_id ) . $link;
+		}
 		$expected = $should_work
 			? sprintf( '<p>Lorem ipsum <a href="%s">dolor sit amet</a>.</p>', $link )
 			: '<p>Lorem ipsum dolor sit amet.</p>';

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -188,6 +188,47 @@ HTML
 	}
 
 	/**
+	 * A data provider for the test_link_types function.
+	 *
+	 * @see https://developer.apple.com/documentation/apple_news/supportedurls
+	 *
+	 * @return array An array of arrays representing function arguments.
+	 */
+	public function data_link_types() {
+		return [
+			// Standard link, non-https.
+			[ 'http://example.com', true ],
+
+			// Standard link, https.
+			[ 'https://example.com', true ],
+
+			// Apple News article URL.
+			[ 'https://apple.news/A5vHgPPmQSvuIxPjeXLTdGQ', true ],
+
+			// Apple News article URL with a hash reference.
+			[ 'https://apple.news/A5vHgPPmQSvuIxPjeXLTdGQ#TextComponent-1', true ],
+
+			// A Stocks app URL.
+			[ 'stocks://?symbol=AAPL', true ],
+
+			// An Apple Music URL, non-https.
+			[ 'music://abc123', true ],
+
+			// An Apple Music URL, https.
+			[ 'musics://abc123', true ],
+
+			// A mailto link.
+			[ 'mailto:example@example.com', true ],
+
+			// A hosted calendar.
+			[ 'webcal://abc123', true ],
+
+			// An unsupported protocol.
+			[ 'badprotocol://abc123', false ],
+		];
+	}
+
+	/**
 	 * A filter function to modify the text style in the generated JSON.
 	 *
 	 * @param array $json The JSON array to modify.
@@ -293,6 +334,31 @@ HTML;
 		$this->assertEquals( 'markdown', $json['components'][2]['format'] );
 		$this->assertEquals( 'Test content.', $json['components'][2]['text'] );
 		remove_filter( 'apple_news_body_html_enabled', [ $this, 'filter_apple_news_body_html_enabled' ] );
+	}
+
+	/**
+	 * Given an expected result and an actual link, verifies that the link URL is
+	 * correctly processed. Used to ensure that valid link types (not just http/s,
+	 * but also mailto, webcal, stocks, etc) are supported, and that unsupported
+	 * types are stripped out.
+	 *
+	 * @dataProvider data_link_types
+	 *
+	 * @param string $link        The link, which will be added as the href parameter in an anchor tag in the test post that the test creates.
+	 * @param bool   $should_work Whether the link is expected to work in Apple News Format or not.
+	 */
+	public function test_link_types( $link, $should_work ) {
+		$content  = <<<HTML
+<!-- wp:paragraph -->
+<p>Lorem ipsum <a href="{$link}">dolor sit amet</a>.</p>
+<!-- /wp:paragraph -->
+HTML;
+		$post_id  = self::factory()->post->create( [ 'post_content' => $content ] );
+		$json     = $this->get_json_for_post( $post_id );
+		$expected = $should_work
+			? sprintf( '<p>Lorem ipsum <a href="%s">dolor sit amet</a>.</p>', $link )
+			: '<p>Lorem ipsum dolor sit amet.</p>';
+		$this->assertEquals( $expected, $json['components'][2]['text'] );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,21 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Disable CAP by default - make it opt-in in tests.
 tests_add_filter( 'apple_news_use_coauthors', '__return_false' );
 
+// Filter the list of allowed protocols to allow Apple News-specific ones.
+tests_add_filter(
+	'kses_allowed_protocols',
+	function ( $protocols ) {
+		return array_merge(
+			(array) $protocols,
+			[
+				'music',
+				'musics',
+				'stocks',
+			]
+		);
+	}
+);
+
 require $_tests_dir . '/includes/bootstrap.php';
 
 require_once __DIR__ . '/class-apple-news-testcase.php';


### PR DESCRIPTION
* Adds support for the `stocks`, `music`, `musics`, `mailto`, and `webcal` protocols in `href` attributes of anchor tags.
* Adds a unit test to verify proper functioning of the filter, including conversion of root-relative and hash-based href links.
* Adds a test fixture to allow the custom Apple News protocols in a unit test context so they don't get stripped out on save.
* Bumps the plugin version to 2.3.0 and adds changelog text for the above.
* Fixes a bug in URL processing for featured images, whereby a custom setup that filters featured image URLs to make them root-relative is not properly handled when deriving the URL of the featured image in the Cover component, although this is handled properly elsewhere.

Fixes #852 