### PR TITLE
APPLE-104 Add api_autosync_update setting to list of settings keys in the Settings class

### DIFF
--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -33,6 +33,7 @@ class Settings {
 		'api_async'                   => 'no',
 		'api_autosync'                => 'yes',
 		'api_autosync_delete'         => 'yes',
+		'api_autosync_skip'           => '[]',
 		'api_autosync_update'         => 'yes',
 		'api_channel'                 => '',
 		'api_key'                     => '',


### PR DESCRIPTION
* Fixes a bug with skipping posts by checking taxonomy because the settings object isn't loading because the key isn't set.