### PR TITLE
APPLE-73/inline html end of article

### DIFF
--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -339,7 +339,8 @@ class Admin_Apple_JSON extends Apple_News {
 			// Ensure the value exists.
 			$key = 'apple_news_json_' . $spec->key_from_name( $spec->name );
 			if ( isset( $_POST[ $key ] ) ) {
-				$custom_spec = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+				// Allow for HTML characters, strip extra slashes and unslash string.
+				$custom_spec = wp_kses_data( wp_unslash( $_POST[ $key ] ) );
 				$result      = $spec->save( $custom_spec, $theme );
 				if ( true === $result ) {
 					$updates[] = $spec->label;

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -127,7 +127,7 @@
 					<p>
 						<label for="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_html( $apple_spec->label ); ?></label>
 						<div id="<?php echo esc_attr( $apple_editor_name ); ?>" style="<?php echo esc_attr( $apple_editor_style ); ?>"></div>
-						<textarea id="<?php echo esc_attr( $apple_field_name ); ?>" name="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_textarea( $apple_json_display ); ?></textarea>
+						<textarea id="<?php echo esc_attr( $apple_field_name ); ?>" name="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_textarea( stripslashes( $apple_json_display ) ); ?></textarea>
 						<script type="text/javascript">
 							var <?php echo esc_js( $apple_editor_name ); ?> = ace.edit( '<?php echo esc_js( $apple_editor_name ); ?>' );
 							jQuery( function() {

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Bugfix: Fixes an issue where a custom filter is used to make all image URLs root-relative when using featured images to populate the Cover component, which was leading to an INVALID_DOCUMENT error from the News API due to the root-relative URL (e.g., /path/to/my/image.jpg instead of https://example.org/path/to/my/image.jpg).
 * Enhancement: Added support for mailto:, music://, musics://, stocks:// and webcal:// links.
 * Enhancement: Added an option and a filter for skipping auto-push of posts with certain taxonomy terms.
+* Enhancement: Aded support for html tags when customizing theme JSON.
 
 = 2.2.2 =
 * Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Bugfix: Fixes an issue where a custom filter is used to make all image URLs root-relative when using featured images to populate the Cover component, which was leading to an INVALID_DOCUMENT error from the News API due to the root-relative URL (e.g., /path/to/my/image.jpg instead of https://example.org/path/to/my/image.jpg).
 * Enhancement: Added support for mailto:, music://, musics://, stocks:// and webcal:// links.
 * Enhancement: Added an option and a filter for skipping auto-push of posts with certain taxonomy terms.
-* Enhancement: Aded support for html tags when customizing theme JSON.
+* Enhancement: Added support for html tags when customizing theme JSON.
 
 = 2.2.2 =
 * Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.

--- a/tests/apple-exporter/components/test-class-end-of-article.php
+++ b/tests/apple-exporter/components/test-class-end-of-article.php
@@ -35,6 +35,10 @@ class Test_End_Of_Article extends Component_TestCase {
 					'end_of_article' => [
 						'json'   => [
 							'role' => 'heading',
+							'text' => '<strong>Heading <em>1<\/em><\/strong> Test',
+							'format' => 'html',
+							'textStyle' => 'default-heading-1',
+							'layout' => 'heading-layout'
 						],
 						'layout' => [],
 					],
@@ -46,5 +50,6 @@ class Test_End_Of_Article extends Component_TestCase {
 		$json    = $this->get_json_for_post( $post_id );
 		$this->assertEquals( 4, count( $json['components'] ) );
 		$this->assertEquals( 'heading', $json['components'][3]['role'] );
+		$this->assertEquals( '<strong>Heading <em>1</em></strong> Test', $json['components'][3]['text'] );
 	}
 }


### PR DESCRIPTION
Closes: https://alleyinteractive.atlassian.net/browse/APPLE-73

- Adds HTML tag support when Customizing JSON. Specifically meant for End of Article use.
- Updates readme/changelog.
- Adds additional check in the End of Article class test.