### PR TITLE
APPLE-71/byline textstyle and hyperlink

### DIFF
--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -154,6 +154,7 @@
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_size', 'font-size', 'px', null );
 
 		// Toggle byline link.
+		// phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.html
 		$( '.apple-news-byline' ).html(function(index, html) {
 			return 'yes' === $( '#byline_links' ).val()
 				? html.replace('John Doe', '<a href="#">John Doe</a>')

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -152,6 +152,14 @@
 		// Byline
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_font', 'font-family', null, null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_size', 'font-size', 'px', null );
+
+		// Toggle byline link.
+		$( '.apple-news-byline' ).html(function(index, html) {
+			return 'yes' === $( '#byline_links' ).val()
+				? html.replace('John Doe', '<a href="#">John Doe</a>')
+				: html.replace(/<a[^>]*>([^<]+)<\/a>/, 'John Doe');
+		})
+
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_line_height', 'line-height', 'px', null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_tracking', 'letter-spacing', 'px', $( '#byline_size' ).val() / 100 );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_color', 'color', null, null );

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -163,6 +163,7 @@
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_line_height', 'line-height', 'px', null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_tracking', 'letter-spacing', 'px', $( '#byline_size' ).val() / 100 );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline', 'byline_color', 'color', null, null );
+		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline a', 'byline_link_color', 'color', null, null );
 
 		// Slug
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-slug', 'slug_font', 'font-family', null, null );

--- a/includes/apple-exporter/builders/class-text-styles.php
+++ b/includes/apple-exporter/builders/class-text-styles.php
@@ -153,27 +153,5 @@ class Text_Styles extends Builder {
 				$conditional
 			)
 		);
-
-		// Add style for <byline> custom tag if supported.
-		if ( 'yes' === $theme->get_value( 'byline_links' ) ) {
-			$this->register_style(
-				'default-byline',
-				(
-					array(
-						'fontName'   => $theme->get_value( 'byline_font' ),
-						'fontSize'   => intval( $theme->get_value( 'byline_size' ) ),
-						'lineHeight' => intval( $theme->get_value( 'byline_line_height' ) ),
-						'tracking'   => intval( $theme->get_value( 'byline_tracking' ) ) / 100,
-						'textColor'  => $theme->get_value( 'byline_color' ),
-					) + (
-						! empty( $theme->get_value( 'byline_color_dark' ) )
-							? array(
-								'textColor' => $theme->get_value( 'byline_color_dark' )
-							)
-							: array()
-					)
-				),
-			);
-		}
 	}
 }

--- a/includes/apple-exporter/builders/class-text-styles.php
+++ b/includes/apple-exporter/builders/class-text-styles.php
@@ -153,5 +153,27 @@ class Text_Styles extends Builder {
 				$conditional
 			)
 		);
+
+		// Add style for <byline> custom tag if supported.
+		if ( 'yes' === $theme->get_value( 'byline_links' ) ) {
+			$this->register_style(
+				'default-byline',
+				(
+					array(
+						'fontName'   => $theme->get_value( 'byline_font' ),
+						'fontSize'   => intval( $theme->get_value( 'byline_size' ) ),
+						'lineHeight' => intval( $theme->get_value( 'byline_line_height' ) ),
+						'tracking'   => intval( $theme->get_value( 'byline_tracking' ) ) / 100,
+						'textColor'  => $theme->get_value( 'byline_color' ),
+					) + (
+						! empty( $theme->get_value( 'byline_color_dark' ) )
+							? array(
+								'textColor' => $theme->get_value( 'byline_color_dark' )
+							)
+							: array()
+					)
+				),
+			);
+		}
 	}
 }

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -716,6 +716,12 @@ class Theme {
 				'label'       => __( 'Byline format', 'apple-news' ),
 				'type'        => 'text',
 			),
+			'byline_links'                       => array(
+				'default' => 'no',
+				'label'   => __( 'Byline author links', 'apple-news' ),
+				'options' => array( 'yes', 'no' ),
+				'type'    => 'select',
+			),
 			'byline_line_height'                 => array(
 				'default' => 24.0,
 				'label'   => __( 'Byline line height', 'apple-news' ),
@@ -2053,6 +2059,7 @@ class Theme {
 				'settings'    => array(
 					'byline_font',
 					'byline_size',
+					'byline_links',
 					'byline_line_height',
 					'byline_tracking',
 					'byline_color',

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -716,6 +716,16 @@ class Theme {
 				'label'       => __( 'Byline format', 'apple-news' ),
 				'type'        => 'text',
 			),
+			'byline_link_color'                  => array(
+				'default' => '#7c7c7c',
+				'label'   => __( 'Byline link font color', 'apple-news' ),
+				'type'    => 'color',
+			),
+			'byline_link_color_dark'             => array(
+				'default' => '',
+				'label'   => __( 'Byline link font color ', 'apple-news' ),
+				'type'    => 'color',
+			),
 			'byline_links'                       => array(
 				'default' => 'no',
 				'label'   => __( 'Byline author links', 'apple-news' ),
@@ -2063,9 +2073,11 @@ class Theme {
 					'byline_line_height',
 					'byline_tracking',
 					'byline_color',
+					'byline_link_color',
 					'byline_format',
 					'dark_mode_colors_heading',
 					'byline_color_dark',
+					'byline_link_color_dark',
 				),
 			),
 			'heading1'        => array(

--- a/includes/apple-exporter/components/class-byline.php
+++ b/includes/apple-exporter/components/class-byline.php
@@ -38,10 +38,44 @@ class Byline extends Component {
 			)
 		);
 
+		// Byline style conditional.
+		$byline_conditional = [];
+
+		if ( ! empty( $theme->get_value( 'byline_color_dark' ) ) ) {
+			$byline_conditional['conditional'][] = [
+				'textColor'  => '#byline_color_dark#',
+				'conditions' => array(
+					'minSpecVersion'       => '1.14',
+					'preferredColorScheme' => 'dark',
+				),
+			];
+		}
+
+		// Separate handling for byline link styles.
+		if ( 'yes' === $theme->get_value( 'byline_links' ) ) {
+			if ( ! empty( $theme->get_value( 'byline_link_color' ) ) ) {
+				$byline_conditional['linkStyle'] = [
+					'textColor'  => '#byline_link_color#',
+				];
+			}
+
+			if ( ! empty( $theme->get_value( 'byline_link_color_dark' ) ) ) {
+				$byline_conditional['conditional'][] = [
+					'linkStyle'  => [
+						'textColor'  => '#byline_link_color_dark#',
+					],
+					'conditions' => array(
+						'minSpecVersion'       => '1.14',
+						'preferredColorScheme' => 'dark',
+					),
+				];
+			}
+		}
+
 		$this->register_spec(
 			'default-byline',
 			__( 'Style', 'apple-news' ),
-			(
+			array_merge(
 				array(
 					'textAlignment' => '#text_alignment#',
 					'fontName'      => '#byline_font#',
@@ -49,19 +83,8 @@ class Byline extends Component {
 					'lineHeight'    => '#byline_line_height#',
 					'tracking'      => '#byline_tracking#',
 					'textColor'     => '#byline_color#',
-				) + (
-					! empty( $theme->get_value( 'byline_color_dark' ) )
-						? array(
-							'conditional' => array(
-								'textColor'  => '#byline_color_dark#',
-								'conditions' => array(
-									'minSpecVersion'       => '1.14',
-									'preferredColorScheme' => 'dark',
-								),
-							),
-						)
-						: array()
-				)
+				),
+				$byline_conditional
 			)
 		);
 
@@ -112,22 +135,42 @@ class Byline extends Component {
 		// Get information about the currently loaded theme.
 		$theme = \Apple_Exporter\Theme::get_used();
 
+		$byline_conditional = [];
+
+		if ( ! empty( $theme->get_value( 'byline_color_dark' ) ) ) {
+			$byline_conditional[] = [
+				'#byline_color_dark#' => $theme->get_value( 'byline_color_dark' )
+			];
+		}
+
+		// Separate handling for byline link styles.
+		if ( 'yes' === $theme->get_value( 'byline_links' ) ) {
+			if ( ! empty( $theme->get_value( 'byline_link_color' ) ) ) {
+				$byline_conditional[] = [
+					'#byline_link_color#'      => $theme->get_value( 'byline_link_color' ),
+				];
+			}
+
+			if ( ! empty( $theme->get_value( 'byline_link_color_dark' ) ) ) {
+				$byline_conditional[] = [
+					'#byline_link_color_dark#' => $theme->get_value( 'byline_link_color_dark' ),
+				];
+			}
+		}
+
 		$this->register_style(
 			'default-byline',
 			'default-byline',
-			(
-				array(
+			array_merge(
+				[
 					'#text_alignment#'     => $this->find_text_alignment(),
 					'#byline_font#'        => $theme->get_value( 'byline_font' ),
 					'#byline_size#'        => intval( $theme->get_value( 'byline_size' ) ),
 					'#byline_line_height#' => intval( $theme->get_value( 'byline_line_height' ) ),
 					'#byline_tracking#'    => intval( $theme->get_value( 'byline_tracking' ) ) / 100,
 					'#byline_color#'       => $theme->get_value( 'byline_color' ),
-				) + (
-					! empty( $theme->get_value( 'byline_color_dark' ) )
-						? array( '#byline_color_dark' => $theme->get_value( 'byline_color_dark' ) )
-						: array()
-				)
+				],
+				$byline_conditional
 			),
 			'textStyle'
 		);

--- a/includes/apple-exporter/components/class-byline.php
+++ b/includes/apple-exporter/components/class-byline.php
@@ -27,8 +27,14 @@ class Byline extends Component {
 			'json',
 			__( 'JSON', 'apple-news' ),
 			array(
-				'role' => 'byline',
-				'text' => '#text#',
+				'role'   => 'byline',
+				'text'   => '#text#',
+			) + (
+				'yes' === $theme->get_value( 'byline_links' )
+					? array(
+						'format' => 'html',
+					)
+					: array()
 			)
 		);
 

--- a/includes/apple-exporter/components/class-byline.php
+++ b/includes/apple-exporter/components/class-byline.php
@@ -27,8 +27,8 @@ class Byline extends Component {
 			'json',
 			__( 'JSON', 'apple-news' ),
 			array(
-				'role'   => 'byline',
-				'text'   => '#text#',
+				'role' => 'byline',
+				'text' => '#text#',
 			) + (
 				'yes' === $theme->get_value( 'byline_links' )
 					? array(
@@ -55,14 +55,14 @@ class Byline extends Component {
 		if ( 'yes' === $theme->get_value( 'byline_links' ) ) {
 			if ( ! empty( $theme->get_value( 'byline_link_color' ) ) ) {
 				$byline_conditional['linkStyle'] = [
-					'textColor'  => '#byline_link_color#',
+					'textColor' => '#byline_link_color#',
 				];
 			}
 
 			if ( ! empty( $theme->get_value( 'byline_link_color_dark' ) ) ) {
 				$byline_conditional['conditional'][] = [
 					'linkStyle'  => [
-						'textColor'  => '#byline_link_color_dark#',
+						'textColor' => '#byline_link_color_dark#',
 					],
 					'conditions' => array(
 						'minSpecVersion'       => '1.14',
@@ -139,7 +139,7 @@ class Byline extends Component {
 
 		if ( ! empty( $theme->get_value( 'byline_color_dark' ) ) ) {
 			$byline_conditional[] = [
-				'#byline_color_dark#' => $theme->get_value( 'byline_color_dark' )
+				'#byline_color_dark#' => $theme->get_value( 'byline_color_dark' ),
 			];
 		}
 
@@ -147,7 +147,7 @@ class Byline extends Component {
 		if ( 'yes' === $theme->get_value( 'byline_links' ) ) {
 			if ( ! empty( $theme->get_value( 'byline_link_color' ) ) ) {
 				$byline_conditional[] = [
-					'#byline_link_color#'      => $theme->get_value( 'byline_link_color' ),
+					'#byline_link_color#' => $theme->get_value( 'byline_link_color' ),
 				];
 			}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -139,12 +139,12 @@ class Apple_News {
 		}
 
 		// Get author from post.
-		$post_author  = intval( $post->post_author );
-		$author       = ucfirst( get_the_author_meta( 'display_name', $post_author ) );
+		$post_author_id  = intval( $post->post_author );
+		$author       = ucfirst( get_the_author_meta( 'display_name', $post_author_id ) );
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {
-			$byline_url = apply_filters( 'apple_news_author_byline_link', $post_author, get_author_posts_url( $post_author ) );
+			$byline_url = apply_filters( 'apple_news_author_byline_link', get_author_posts_url( $post_author_id ), $post_author_id );
 			return '<a href="' . esc_url( $byline_url ) . '" rel="author">' . esc_html( $author ) . '</a>';
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -113,6 +113,9 @@ class Apple_News {
 			return '';
 		}
 
+		// Get information about the currently used theme.
+		$theme = \Apple_Exporter\Theme::get_used();
+
 		/**
 		 * Allows for changing the option to use Co-Authors Plus for authorship.
 		 * Defaults to using Co-Authors Plus if the `coauthors` function is defined.
@@ -129,7 +132,16 @@ class Apple_News {
 			return coauthors( $between, $between_last, $before, $after, false );
 		}
 
-		return ucfirst( get_the_author_meta( 'display_name', $post->post_author ) );
+		$byline_links = $theme->get_value( 'byline_links' );
+		$post_author  = intval( $post->post_author );
+		$author       = ucfirst( get_the_author_meta( 'display_name', $post_author ) );
+
+		// If we have byline links enabled.
+		if ( 'yes' === $byline_links ) {
+			return '<a href="' . esc_url( get_author_posts_url( $post_author ) ) . '" rel="author"><byline>' . esc_html( $author ) . '</byline></a>';
+		}
+
+		return $author;
 	}
 
 	/**

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -144,7 +144,21 @@ class Apple_News {
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {
-			$byline_url = apply_filters( 'apple_news_author_byline_link', get_author_posts_url( $post_author_id ), $post_author_id, get_the_author_meta( 'nicename', $post_author_id ) );
+			/**
+			 * Allows for modification of the byline link used by WordPress authors and CoAuthors Plus.
+			 *
+			 * @since 2.3.0
+			 *
+			 * @param string $link            The author link to be filtered.
+			 * @param int    $author_id       Author id for the URL being modified.
+			 * @param string $author_nicename Author nicename for the URL being modified.
+			 */
+			$byline_url = apply_filters(
+				'apple_news_author_byline_link',
+				get_author_posts_url( $post_author_id ),
+				$post_author_id,
+				get_the_author_meta( 'nicename', $post_author_id )
+			);
 			return '<a href="' . esc_url( $byline_url ) . '" rel="author">' . esc_html( $author ) . '</a>';
 		}
 
@@ -511,7 +525,15 @@ class Apple_News {
 	 * @return string updated $author attribute.
 	 */
 	public function filter_author_link( $link, $author_id, $author_nicename ) {
-		// Add filter to hit this directly in Apple News.
+		/**
+		 * Allows for modification of the byline link used by WordPress authors and CoAuthors Plus.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param string $link            The author link to be filtered.
+		 * @param int    $author_id       Author id for the URL being modified.
+		 * @param string $author_nicename Author nicename for the URL being modified.
+		 */
 		return apply_filters( 'apple_news_author_byline_link', $link, $author_id, $author_nicename );
 	}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -144,7 +144,7 @@ class Apple_News {
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {
-			$byline_url = apply_filters( 'apple_news_author_byline_link', get_author_posts_url( $post_author_id ), $post_author_id, get_the_author_meta( 'display_name', $post_author_id ) );
+			$byline_url = apply_filters( 'apple_news_author_byline_link', get_author_posts_url( $post_author_id ), $post_author_id, get_the_author_meta( 'nicename', $post_author_id ) );
 			return '<a href="' . esc_url( $byline_url ) . '" rel="author">' . esc_html( $author ) . '</a>';
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -139,8 +139,8 @@ class Apple_News {
 		}
 
 		// Get author from post.
-		$post_author_id  = intval( $post->post_author );
-		$author       = ucfirst( get_the_author_meta( 'display_name', $post_author_id ) );
+		$post_author_id = intval( $post->post_author );
+		$author         = ucfirst( get_the_author_meta( 'display_name', $post_author_id ) );
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -138,13 +138,14 @@ class Apple_News {
 				: coauthors( $between, $between_last, $before, $after, false );
 		}
 
+		// Get author from post.
 		$post_author  = intval( $post->post_author );
 		$author       = ucfirst( get_the_author_meta( 'display_name', $post_author ) );
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {
-			$byline_url = apply_filters( 'apple_news_byline_link', $post_author, get_author_posts_url( $post_author ) );
-			return '<a href="' . esc_url( $byline_url ) . '" rel="author"><byline>' . esc_html( $author ) . '</byline></a>';
+			$byline_url = apply_filters( 'apple_news_author_byline_link', $post_author, get_author_posts_url( $post_author ) );
+			return '<a href="' . esc_url( $byline_url ) . '" rel="author">' . esc_html( $author ) . '</a>';
 		}
 
 		return $author;
@@ -318,8 +319,16 @@ class Apple_News {
 			5
 		);
 		add_filter(
+			'author_link',
+			[ $this, 'filter_author_link' ],
+			10,
+			3
+		);
+		add_filter(
 			'the_author',
-			[ $this, 'filter_the_author' ]
+			[ $this, 'filter_the_author' ],
+			10,
+			3
 		);
 	}
 
@@ -494,20 +503,25 @@ class Apple_News {
 	}
 
 	/**
+	 * A filter callback for author_link for coauthors URLs.
+	 *
+	 * @param string $link            The URL to the author's page.
+	 * @param int    $author_id       The author's ID.
+	 * @param string $author_nicename The author's nice name.
+	 * @return string updated $author attribute.
+	 */
+	public function filter_author_link( $link, $author_id, $author_nicename ) {
+		// Add filter to hit this directly in Apple News.
+		return apply_filters( 'apple_news_author_byline_link', $link, $author_id, $author_nicename );
+	}
+
+	/**
 	 * A filter callback for the_author to wrap authors in byline tag if supported.
 	 *
 	 * @param string $author author name.
 	 * @return string updated $author attribute.
 	 */
 	public function filter_the_author( $author ) {
-		// Get information about the currently used theme.
-		$theme = \Apple_Exporter\Theme::get_used();
-
-		// Get theme option for byline links. True if set to yes.
-		if ( $theme->get_value( 'byline_links' ) && 'yes' === $theme->get_value( 'byline_links' ) ) {
-			return '<byline>' . ucfirst( $author ). '</byline>';
-		}
-
 		return ucfirst( $author );
 	}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -143,7 +143,7 @@ class Apple_News {
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {
-			$byline_url = apply_filters( 'apple_news_byline_link', get_author_posts_url( $post_author ) );
+			$byline_url = apply_filters( 'apple_news_byline_link', $post_author, get_author_posts_url( $post_author ) );
 			return '<a href="' . esc_url( $byline_url ) . '" rel="author"><byline>' . esc_html( $author ) . '</byline></a>';
 		}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -484,6 +484,24 @@ class Apple_News {
 	}
 
 	/**
+	 * A filter callback for the_author to wrap authors in byline tag if supported.
+	 *
+	 * @param string $author author name.
+	 * @return string updated $author attribute.
+	 */
+	public function filter_the_author( $author ) {
+		// Get information about the currently used theme.
+		$theme = \Apple_Exporter\Theme::get_used();
+
+		// Get theme option for byline links. True if set to yes.
+		if ( $theme->get_value( 'byline_links' ) && 'yes' === $theme->get_value( 'byline_links' ) ) {
+			return '<byline>' . ucfirst( $author ). '</byline>';
+		}
+
+		return ucfirst( $author );
+	}
+
+	/**
 	 * Creates a new Jed instance with specified locale data configuration.
 	 *
 	 * @param string $to_handle The script handle to attach the inline script to.

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -144,7 +144,7 @@ class Apple_News {
 
 		// If we have byline links enabled.
 		if ( $use_byline_links ) {
-			$byline_url = apply_filters( 'apple_news_author_byline_link', get_author_posts_url( $post_author_id ), $post_author_id );
+			$byline_url = apply_filters( 'apple_news_author_byline_link', get_author_posts_url( $post_author_id ), $post_author_id, get_the_author_meta( 'display_name', $post_author_id ) );
 			return '<a href="' . esc_url( $byline_url ) . '" rel="author">' . esc_html( $author ) . '</a>';
 		}
 

--- a/tests/apple-exporter/components/test-class-byline.php
+++ b/tests/apple-exporter/components/test-class-byline.php
@@ -111,4 +111,35 @@ class Byline_Test extends Apple_News_Testcase {
 		$this->assertEquals( '#ccff00', $json['componentTextStyles']['default-byline']['conditional'][1]['linkStyle']['textColor'] );
 		$this->assertEquals( 'by <a href="' . esc_url( get_author_posts_url( $user_id ) ) . '" rel="author">Test Author</a> | Jan 1, 1970 | 12:00 PM', $json['components'][1]['text'] );
 	}
+
+	/**
+	 * Tests byline settings.
+	 */
+	public function test_coauthors_settings() {
+		$this->set_theme_settings(
+			[
+				'byline_color'           => '#abcdef',
+				'byline_color_dark'      => '#123456',
+				'byline_font'            => 'AmericanTypewriter',
+				'byline_line_height'     => 12,
+				'byline_link_color'      => '#ffcc00',
+				'byline_link_color_dark' => '#ccff00',
+				'byline_links'           => 'yes',
+				'byline_size'            => 34,
+				'byline_tracking'        => 56,
+			]
+		);
+
+		// Create a test post and get JSON for it.
+		$this->enable_coauthors_support();
+		global $apple_news_coauthors;
+		$author_1             = self::factory()->user->create( [ 'display_name' => 'Test Author 1' ] );
+		$author_2             = self::factory()->user->create( [ 'display_name' => 'Test Author 2' ] );
+		$apple_news_coauthors = [ $author_1, $author_2 ];
+		$post_id              = self::factory()->post->create( [ 'post_date_gmt' => '1970-01-01 12:00:00' ] );
+		$json                 = $this->get_json_for_post( $post_id );
+
+		// Validate byline settings in generated JSON.
+		$this->assertEquals( 'by <a href="' . esc_url( get_author_posts_url( $author_1 ) ) . '" rel="author">' . get_the_author_meta( 'display_name', $author_1 ) . '</a> and <a href="' . esc_url( get_author_posts_url( $author_2 ) ) . '" rel="author">' . get_the_author_meta( 'display_name', $author_2 ) . '</a> | Jan 1, 1970 | 12:00 PM', $json['components'][1]['text'] );
+	}
 }

--- a/tests/apple-exporter/components/test-class-byline.php
+++ b/tests/apple-exporter/components/test-class-byline.php
@@ -68,6 +68,7 @@ class Byline_Test extends Apple_News_Testcase {
 				'byline_color_dark'  => '#123456',
 				'byline_font'        => 'AmericanTypewriter',
 				'byline_line_height' => 12,
+				'byline_links'       => 'no',
 				'byline_size'        => 34,
 				'byline_tracking'    => 56,
 			]
@@ -80,10 +81,34 @@ class Byline_Test extends Apple_News_Testcase {
 
 		// Validate byline settings in generated JSON.
 		$this->assertEquals( '#abcdef', $json['componentTextStyles']['default-byline']['textColor'] );
-		$this->assertEquals( '#123456', $json['componentTextStyles']['default-byline']['conditional']['textColor'] );
+		$this->assertEquals( '#123456', $json['componentTextStyles']['default-byline']['conditional'][0]['textColor'] );
 		$this->assertEquals( 'AmericanTypewriter', $json['componentTextStyles']['default-byline']['fontName'] );
 		$this->assertEquals( 12, $json['componentTextStyles']['default-byline']['lineHeight'] );
 		$this->assertEquals( 34, $json['componentTextStyles']['default-byline']['fontSize'] );
 		$this->assertEquals( 0.56, $json['componentTextStyles']['default-byline']['tracking'] );
+
+		$this->set_theme_settings(
+			[
+				'byline_color'           => '#abcdef',
+				'byline_color_dark'      => '#123456',
+				'byline_font'            => 'AmericanTypewriter',
+				'byline_line_height'     => 12,
+				'byline_link_color'      => '#ffcc00',
+				'byline_link_color_dark' => '#ccff00',
+				'byline_links'           => 'yes',
+				'byline_size'            => 34,
+				'byline_tracking'        => 56,
+			]
+		);
+
+		// Create a test post and get JSON for it.
+		$user_id = self::factory()->user->create( [ 'display_name' => 'Test Author' ] );
+		$post_id = self::factory()->post->create( [ 'post_author' => $user_id, 'post_date_gmt' => '1970-01-01 12:00:00' ] );
+		$json    = $this->get_json_for_post( $post_id );
+
+		// Validate byline settings in generated JSON.
+		$this->assertEquals( '#ffcc00', $json['componentTextStyles']['default-byline']['linkStyle']['textColor'] );
+		$this->assertEquals( '#ccff00', $json['componentTextStyles']['default-byline']['conditional'][1]['linkStyle']['textColor'] );
+		$this->assertEquals( 'by <a href="' . esc_url( get_author_posts_url( $user_id ) ) . '" rel="author">Test Author</a> | Jan 1, 1970 | 12:00 PM', $json['components'][1]['text'] );
 	}
 }

--- a/tests/mocks/function-coauthors.php
+++ b/tests/mocks/function-coauthors.php
@@ -66,7 +66,7 @@ function coauthors_posts_links( $between = null, $betweenLast = null, $before = 
 		// Get author data.
 		$author = get_user_by( 'id', $author );
 
-		$args        = array(
+		$args = [
 			'before_html' => '',
 			'href'        => get_author_posts_url( $author->ID, $author->user_nicename ),
 			'rel'         => 'author',
@@ -74,7 +74,7 @@ function coauthors_posts_links( $between = null, $betweenLast = null, $before = 
 			'class'       => 'author url fn',
 			'text'        => $author->display_name,
 			'after_html'  => '',
-		);
+		];
 
 		$single_link = sprintf(
 			'<a href="%1$s" rel="%2$s">%3$s</a>',

--- a/tests/mocks/function-coauthors.php
+++ b/tests/mocks/function-coauthors.php
@@ -41,3 +41,100 @@ function coauthors( $between = ', ', $betweenLast = ' and ', $before = '', $afte
 
 	echo $output;
 }
+
+/**
+ * A mock for the coauthors_posts_links function from Co-Authors Plus.
+ *
+ * @param string $between Delimiter that should appear between the co-authors
+ * @param string $betweenLast Delimiter that should appear between the last two co-authors
+ * @param string $before What should appear before the presentation of co-authors
+ * @param string $after What should appear after the presentation of co-authors
+ * @param bool   $echo Whether the co-authors should be echoed or returned. Defaults to true.
+ */
+function coauthors_posts_links( $between = null, $betweenLast = null, $before = null, $after = null, $echo = true ) {
+	// To use this function, put display names in a global array called $apple_news_coauthors.
+	global $apple_news_coauthors;
+
+	// Bail if we don't have coauthors.
+	if ( empty( $apple_news_coauthors ) ) {
+		return '';
+	}
+
+	$output = [];
+
+	foreach ( $apple_news_coauthors as $author ) {
+		// Get author data.
+		$author = get_user_by( 'id', $author );
+
+		$args        = array(
+			'before_html' => '',
+			'href'        => get_author_posts_url( $author->ID, $author->user_nicename ),
+			'rel'         => 'author',
+			'title'       => sprintf( __( 'Posts by %s', 'co-authors-plus' ), $author->display_name ),
+			'class'       => 'author url fn',
+			'text'        => $author->display_name,
+			'after_html'  => '',
+		);
+
+		$single_link = sprintf(
+			'<a href="%1$s" rel="%2$s">%3$s</a>',
+			esc_url( $args['href'] ),
+			esc_attr( $args['rel'] ),
+			esc_html( $args['text'] )
+		);
+
+		$output[] = $args['before_html'] . $single_link . $args['after_html'];
+
+	}
+
+	// Get last element and prepend 'and'.
+	$last_element = array_pop( $output );
+	array_push( $output, 'and ' . $last_element );
+
+	// If we have more than two items comma-separate array items and then conver to string.
+	$output = implode( 2 > count( $output ) ? ', ' : ' ', $output ) ;
+
+	// Fork for echo.
+	if ( ! $echo ) {
+		return $output;
+	}
+
+	echo $output;
+}
+
+/**
+ * A mock for the coauthors_posts_links_single function from Co-Authors Plus.
+ *
+ * @param object $author
+ * @return string
+ */
+function coauthors_posts_links_single( $author ) {
+	// Return if the fields we are trying to use are not sent
+	if ( ! isset( $author->ID, $author->user_nicename, $author->display_name ) ) {
+		_doing_it_wrong(
+			'coauthors_posts_links_single',
+			'Invalid author object used',
+			'3.2'
+		);
+		return;
+	}
+	$args        = array(
+		'before_html' => '',
+		'href'        => get_author_posts_url( $author->ID, $author->user_nicename ),
+		'rel'         => 'author',
+		'title'       => sprintf( __( 'Posts by %s', 'co-authors-plus' ), apply_filters( 'the_author', $author->display_name ) ),
+		'class'       => 'author url fn',
+		'text'        => apply_filters( 'the_author', $author->display_name ),
+		'after_html'  => '',
+	);
+	$args        = apply_filters( 'coauthors_posts_link', $args, $author );
+	$single_link = sprintf(
+		'<a href="%1$s" title="%2$s" class="%3$s" rel="%4$s">%5$s</a>',
+		esc_url( $args['href'] ),
+		esc_attr( $args['title'] ),
+		esc_attr( $args['class'] ),
+		esc_attr( $args['rel'] ),
+		esc_html( $args['text'] )
+	);
+	return $args['before_html'] . $single_link . $args['after_html'];
+}


### PR DESCRIPTION
Closes: https://alleyinteractive.atlassian.net/browse/APPLE-71

- Added new options for byline to support byline links.
  - `byline_links` options, “yes” or “no”. “no” is the default.
  - `byline_link_color` default “#7c7c7c” (same as byline_color default).
  - `byline_link_color_dark` no default provided.
- Adds support for a live preview of that feature.
- Adds output and HTML support for authors, either WP Users or CoAuthors Plus authors, if `byline_links` is set to “yes” and they exist.
  - Added tests to test this, along with a mock of the `coauthors_posts_links` function.
- Adds filters to support intercepting the link URL for authors and coauthors `apple_news_author_byline_link` which expects a return value of the URL (string), but has three parameters, `$link`, `$author_id`, and `$author_nicename`
- Adds new `linkStyle` support to style the links in the byline component if `byline_links` is “yes”.
  - Filterable using `apple_news_component_text_styles`.
- Also fixed issue where default byline color was not being passed to `componentTextStyles` on json export.