### PR TITLE
APPLE-72 Fix cover image deduping when using Photon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.phpunit.result.cache
 *.zip
 tags
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   "require-dev": {
     "phpspec/prophecy": "~1.0",
     "alleyinteractive/alley-coding-standards": "^0.3.0",
-    "phpunit/phpunit": "6.5.*"
+    "phpunit/phpunit": "6.5.*",
+    "yoast/phpunit-polyfills": "^1.0"
   },
   "scripts": {
     "phpcbf" : "phpcbf .",

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -545,6 +545,13 @@ class Components extends Builder {
 		 */
 		$normalized_path = preg_replace( '/-(?:\d+x\d+|scaled|rotated)(\.[^.]+)$/', '$1', $url_parts['path'] );
 
+		// Remove the Jetpack CDN domain.
+		if ( preg_match( '/^i[0-9]\.wp\.com$/', $url_parts['host'] ) ) {
+			$path_parts        = explode( '/', $normalized_path );
+			$url_parts['host'] = array_shift( $path_parts );
+			$normalized_path   = implode( '/', $path_parts );
+		}
+
 		// Put Humpty Dumpty back together again.
 		return sprintf(
 			'%s://%s%s',

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,7 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 = 2.3.0 =
 * Bugfix: Fixes an issue with some of the example themes where pullquotes would create invalid JSON due to the default-pullquote textStyle not being set. Props to @soulseekah for the fix.
 * Bugfix: Fixes an issue where a custom filter is used to make all image URLs root-relative when using featured images to populate the Cover component, which was leading to an INVALID_DOCUMENT error from the News API due to the root-relative URL (e.g., /path/to/my/image.jpg instead of https://example.org/path/to/my/image.jpg).
+* Bugfix: Fixes an issue with images not deduping when Jetpack Site Accelerator (Photon) is enabled.
 * Enhancement: Added support for mailto:, music://, musics://, stocks:// and webcal:// links.
 * Enhancement: Added an option and a filter for skipping auto-push of posts with certain taxonomy terms.
 

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -24,32 +24,32 @@ class Component_Tests extends Apple_News_Testcase {
 		return [
 			// An image without crops should return itself.
 			[
-				'http://example.org/wp-content/uploads/2020/07/image.jpg',
-				'http://example.org/wp-content/uploads/2020/07/image.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image.jpg',
 			],
 
 			// An image with a crop should return the original image without the crop.
 			[
-				'http://example.org/wp-content/uploads/2020/07/image-150x150.jpg',
-				'http://example.org/wp-content/uploads/2020/07/image.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image-150x150.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image.jpg',
 			],
 
 			// Scaled images should return the un-scaled version.
 			[
-				'http://example.org/wp-content/uploads/2020/07/image-scaled.jpg',
-				'http://example.org/wp-content/uploads/2020/07/image.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image-scaled.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image.jpg',
 			],
 
 			// Rotated images should return the un-rotated version.
 			[
-				'http://example.org/wp-content/uploads/2020/07/image-rotated.jpg',
-				'http://example.org/wp-content/uploads/2020/07/image.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image-rotated.jpg',
+				'https://example.org/wp-content/uploads/2020/07/image.jpg',
 			],
 
 			// Photon images should return the original.
 			[
-				'http://example.org/wp-content/uploads/2020/07/image.jpg?w=234&crop=0%2C5px%2C100%2C134px&ssl=1',
-				'http://example.org/wp-content/uploads/2020/07/image.jpg',
+				'https://i1.wp.com/example.org/wp-content/uploads/2020/07/image.jpg?w=234&crop=0%2C5px%2C100%2C134px&ssl=1',
+				'https://example.org/wp-content/uploads/2020/07/image.jpg',
 			],
 		];
 	}

--- a/tests/apple-exporter/builders/test-class-components.php
+++ b/tests/apple-exporter/builders/test-class-components.php
@@ -230,6 +230,25 @@ class Component_Tests extends Apple_News_Testcase {
 		$this->assertEquals( 'photo', $json_6['components'][1]['components'][2]['role'] );
 		$this->assertEquals( wp_get_attachment_image_url( $image_2, 'full' ), $json_6['components'][1]['components'][2]['URL'] );
 		$this->assertEquals( 3, count( $json_6['components'][1]['components'] ) );
+
+		/*
+		 * Scenario 7:
+		 * - No featured image is set.
+		 * - Images in the content.
+		 * - Cover image set via postmeta.
+		 * Expected: The cover image is used from postmeta and the first image from the content is removed.
+		 */
+		$post_7 = self::factory()->post->create( [ 'post_content' => wp_get_attachment_image( $image_1, 'full' ) . wp_get_attachment_image( $image_2, 'full' ) ] );
+		add_post_meta( $post_7, 'apple_news_coverimage', $image_1 );
+		$json_7 = $this->get_json_for_post( $post_7 );
+		$this->assertEquals( 'header', $json_7['components'][0]['role'] );
+		$this->assertEquals( 'headerPhotoLayout', $json_7['components'][0]['layout'] );
+		$this->assertEquals( 'photo', $json_7['components'][0]['components'][0]['role'] );
+		$this->assertEquals( 'headerPhotoLayout', $json_7['components'][0]['components'][0]['layout'] );
+		$this->assertEquals( wp_get_attachment_image_url( $image_1, 'full' ), $json_7['components'][0]['components'][0]['URL'] );
+		$this->assertEquals( 'photo', $json_7['components'][1]['components'][2]['role'] );
+		$this->assertEquals( wp_get_attachment_image_url( $image_2, 'full' ), $json_7['components'][1]['components'][2]['URL'] );
+		$this->assertEquals( 3, count( $json_7['components'][1]['components'] ) );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Publish to Apple News Tests: Bootstrap File
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+const WP_TESTS_PHPUNIT_POLYFILLS_PATH = __DIR__ . '/../vendor/yoast/phpunit-polyfills';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
* Fixes an issue where cover images would not dedupe because Jetpack Site Accelerator was being used, and one of the two image URLs used for deduping would use the Photon URL and the other would not, causing the plugin to erroneously think that the two images were different.
* Prepares for the release of WordPress 5.9 by installing and configuring the PHPUnit Polyfills package.