### PR TITLE
APPLE-115 Bugfix for apple_news_is_exporting flag

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -76,10 +76,10 @@ class Export extends Action {
 	 * @access public
 	 */
 	public function perform() {
-		self::$exporting = true;
-		$exporter        = $this->fetch_exporter();
-		$json            = $exporter->export();
-		self::$exporting = false;
+		$this->set_exporting( true );
+		$exporter = $this->fetch_exporter();
+		$json     = $exporter->export();
+		$this->set_exporting( false );
 
 		return $json;
 	}
@@ -453,6 +453,15 @@ class Export extends Action {
 		}
 
 		return $date;
+	}
+
+	/**
+	 * Sets the exporting flag.
+	 *
+	 * @param bool $exporting The new value of the exporting flag.
+	 */
+	public function set_exporting( $exporting ) {
+		self::$exporting = (bool) $exporting;
 	}
 
 	/**

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -70,16 +70,25 @@ class Export extends Action {
 	}
 
 	/**
+	 * Sets the exporting flag.
+	 *
+	 * @param bool $exporting The new value of the exporting flag.
+	 */
+	public static function set_exporting( $exporting ) {
+		self::$exporting = (bool) $exporting;
+	}
+
+	/**
 	 * Perform the export and return the results.
 	 *
 	 * @return string The JSON data
 	 * @access public
 	 */
 	public function perform() {
-		$this->set_exporting( true );
+		self::set_exporting( true );
 		$exporter = $this->fetch_exporter();
 		$json     = $exporter->export();
-		$this->set_exporting( false );
+		self::set_exporting( false );
 
 		return $json;
 	}
@@ -453,15 +462,6 @@ class Export extends Action {
 		}
 
 		return $date;
-	}
-
-	/**
-	 * Sets the exporting flag.
-	 *
-	 * @param bool $exporting The new value of the exporting flag.
-	 */
-	public function set_exporting( $exporting ) {
-		self::$exporting = (bool) $exporting;
 	}
 
 	/**

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -555,10 +555,10 @@ class Push extends API_Action {
 	private function generate_article() {
 
 		$export_action = new Export( $this->settings, $this->id, $this->sections );
-		$export_action->set_exporting( true );
+		Export::set_exporting( true );
 		$this->exporter = $export_action->fetch_exporter();
 		$this->exporter->generate();
-		$export_action->set_exporting( false );
+		Export::set_exporting( false );
 
 		return array( $this->exporter->get_json(), $this->exporter->get_bundles(), $this->exporter->get_errors() );
 	}

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -554,9 +554,11 @@ class Push extends API_Action {
 	 */
 	private function generate_article() {
 
-		$export_action  = new Export( $this->settings, $this->id, $this->sections );
+		$export_action = new Export( $this->settings, $this->id, $this->sections );
+		$export_action->set_exporting( true );
 		$this->exporter = $export_action->fetch_exporter();
 		$this->exporter->generate();
+		$export_action->set_exporting( false );
 
 		return array( $this->exporter->get_json(), $this->exporter->get_bundles(), $this->exporter->get_errors() );
 	}

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -29,6 +29,18 @@ class Admin_Action_Index_Push_Test extends Apple_News_Testcase {
 	}
 
 	/**
+	 * A filter on the_content that tests the behavior of the
+	 * apple_news_is_exporting function.
+	 *
+	 * @param string $content The content to be filtered.
+	 *
+	 * @return string The filtered content.
+	 */
+	public function filter_the_content( $content ) {
+		return apple_news_is_exporting() ? '<p>EXPORTING</p>' : $content;
+	}
+
+	/**
 	 * Tests the behavior of the component errors setting (none, warn, fail).
 	 */
 	public function test_component_errors() {
@@ -137,6 +149,18 @@ class Admin_Action_Index_Push_Test extends Apple_News_Testcase {
 		$this->assertEquals( 3, $metadata['data']['isNumber'] );
 		$this->assertEquals( 'Test String Value', $metadata['data']['isString'] );
 		$this->assertEquals( ['a', 'b', 'c'], $metadata['data']['isArray'] );
+	}
+
+	/**
+	 * Ensures that the apple_news_is_exporting function works properly during a
+	 * push request.
+	 */
+	public function test_exporting_flag() {
+		$post_id = self::factory()->post->create();
+		add_filter( 'the_content', [ $this, 'filter_the_content' ] );
+		$request = $this->get_request_for_post( $post_id );
+		remove_filter( 'the_content', [ $this, 'filter_the_content'] );
+		$this->assertTrue( false !== strpos( $request['body'], '<p>EXPORTING<\/p>' ) );
 	}
 
 	/**


### PR DESCRIPTION
Ensures that the exporting flag is properly set both when downloading JSON from the article list and when pushing to Apple via the API.

Fixes #611