### PR TITLE
APPLE-115 v2.3.0 release prep

### DIFF
--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -339,10 +339,7 @@ class Admin_Apple_JSON extends Apple_News {
 			// Ensure the value exists.
 			$key = 'apple_news_json_' . $spec->key_from_name( $spec->name );
 			if ( isset( $_POST[ $key ] ) ) {
-				// Allow for HTML characters, strip extra slashes and unslash string.
-				$custom_spec = wp_kses_data( wp_unslash( $_POST[ $key ] ) );
-				$result      = $spec->save( $custom_spec, $theme );
-				if ( true === $result ) {
+				if ( true === $spec->save( wp_unslash( $_POST[ $key ] ), $theme ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					$updates[] = $spec->label;
 				}
 			}

--- a/admin/partials/field-meta-component-order.php
+++ b/admin/partials/field-meta-component-order.php
@@ -10,6 +10,8 @@
  * @package Apple_News
  */
 
+use Apple_Exporter\Theme;
+
 ?>
 <div class="apple-news-sortable-list">
 	<h4><?php esc_html_e( 'Active', 'apple-news' ); ?></h4>
@@ -19,7 +21,7 @@
 			echo sprintf(
 				'<li id="%s" class="ui-sortable-handle">%s</li>',
 				esc_attr( $apple_component_name ),
-				esc_html( ucwords( $apple_component_name ) )
+				esc_html( Theme::get_meta_component_name( $apple_component_name ) )
 			);
 			?>
 		<?php endforeach; ?>
@@ -33,10 +35,10 @@
 			echo sprintf(
 				'<li id="%s" class="ui-sortable-handle">%s</li>',
 				esc_attr( $apple_component_name ),
-				esc_html( ucwords( $apple_component_name ) )
+				esc_html( Theme::get_meta_component_name( $apple_component_name ) )
 			);
 			?>
 		<?php endforeach; ?>
 	</ul>
 </div>
-<p class="description"><?php esc_html_e( 'Drag to set the order of the meta components at the top of the article. These include the title, the cover (i.e. featured image) and byline which also includes the date. Drag elements into the "Inactive" column to prevent them from being included in your articles.', 'apple-news' ); ?></p>
+<p class="description"><?php esc_html_e( 'Drag to set the order of the meta components at the top of the article. Drag elements into the "Inactive" column to prevent them from being included in your articles.', 'apple-news' ); ?></p>

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -127,7 +127,7 @@
 					<p>
 						<label for="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_html( $apple_spec->label ); ?></label>
 						<div id="<?php echo esc_attr( $apple_editor_name ); ?>" style="<?php echo esc_attr( $apple_editor_style ); ?>"></div>
-						<textarea id="<?php echo esc_attr( $apple_field_name ); ?>" name="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_textarea( stripslashes( $apple_json_display ) ); ?></textarea>
+						<textarea id="<?php echo esc_attr( $apple_field_name ); ?>" name="<?php echo esc_attr( $apple_field_name ); ?>"><?php echo esc_textarea( $apple_json_display ); ?></textarea>
 						<script type="text/javascript">
 							var <?php echo esc_js( $apple_editor_name ); ?> = ace.edit( '<?php echo esc_js( $apple_editor_name ); ?>' );
 							jQuery( function() {

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -180,14 +180,14 @@
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-author', 'author_tracking', 'letter-spacing', 'px', $( '#author_size' ).val() / 100 );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-author', 'author_color', 'color', null, null );
 
-		// Publication date.
+		// Date.
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-date', 'date_font', 'font-family', null, null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-date', 'date_size', 'font-size', 'px', null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-date', 'date_line_height', 'line-height', 'px', null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-date', 'date_tracking', 'letter-spacing', 'px', $( '#date_size' ).val() / 100 );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-date', 'date_color', 'color', null, null );
 
-		// Author Links.
+		// Author URL.
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-byline a', 'author_link_color', 'color', null, null );
 		appleNewsSetCSS( '.apple-news-preview div.apple-news-author a', 'author_link_color', 'color', null, null );
 

--- a/includes/apple-exporter/class-component-spec.php
+++ b/includes/apple-exporter/class-component-spec.php
@@ -12,7 +12,6 @@
 namespace Apple_Exporter;
 
 use Admin_Apple_Notice;
-use Apple_Exporter\Theme;
 
 /**
  * A class that defines a JSON spec for a component.
@@ -232,26 +231,6 @@ class Component_Spec {
 	 */
 	public function save( $spec, $theme_name = '' ) {
 
-		// Negotiate the theme name.
-		if ( empty( $theme_name ) ) {
-			$theme_name = Theme::get_active_theme_name();
-		}
-
-		// Attempt to load the theme to be saved.
-		$theme = new Theme();
-		$theme->set_name( $theme_name );
-		if ( ! $theme->load() ) {
-			Admin_Apple_Notice::error(
-				sprintf(
-					// translators: token is a theme name.
-					__( 'Unable to load theme %s to save spec', 'apple-news' ),
-					$theme_name
-				)
-			);
-
-			return false;
-		}
-
 		// Check for empty JSON.
 		$json = $this->spec;
 		if ( empty( $spec ) ) {
@@ -298,6 +277,26 @@ class Component_Spec {
 						'apple-news'
 					),
 					$this->label
+				)
+			);
+
+			return false;
+		}
+
+		// Negotiate the theme name.
+		if ( empty( $theme_name ) ) {
+			$theme_name = Theme::get_active_theme_name();
+		}
+
+		// Attempt to load the theme to be saved.
+		$theme = new Theme();
+		$theme->set_name( $theme_name );
+		if ( ! $theme->load() ) {
+			Admin_Apple_Notice::error(
+				sprintf(
+				// translators: token is a theme name.
+					__( 'Unable to load theme %s to save spec', 'apple-news' ),
+					$theme_name
 				)
 			);
 

--- a/includes/apple-exporter/class-component-spec.php
+++ b/includes/apple-exporter/class-component-spec.php
@@ -421,7 +421,7 @@ class Component_Spec {
 	 */
 	public function format_json( $spec ) {
 		return ! empty( $spec )
-			? wp_json_encode( $spec, JSON_PRETTY_PRINT )
+			? wp_json_encode( $spec, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
 			: '{}';
 	}
 

--- a/includes/apple-exporter/class-exporter-content.php
+++ b/includes/apple-exporter/class-exporter-content.php
@@ -147,7 +147,7 @@ class Exporter_Content {
 	 * @param \Apple_Exporter\Settings $settings Optional. Settings for the exporter.
 	 * @param string                   $slug     Optional. The slug of the post to be exported.
 	 * @param string                   $author   Optional. The author(s) of the post to be exported.
-	 * @param string                   $date     Optional. They published date of the post to be exported.
+	 * @param string                   $date     Optional. The date of the post to be exported.
 	 * @access public
 	 */
 	public function __construct( $id, $title, $content, $intro = null, $cover = null, $byline = null, $settings = null, $slug = null, $author = null, $date = null ) {

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -378,6 +378,34 @@ class Theme {
 	}
 
 	/**
+	 * Given a meta component slug, returns its human-readable name.
+	 *
+	 * @param string $slug The meta component slug to look up.
+	 *
+	 * @return string The human-readable component name.
+	 */
+	public static function get_meta_component_name( $slug ) {
+		switch ( $slug ) {
+			case 'author':
+				return __( 'Author', 'apple-news' );
+			case 'byline':
+				return __( 'Combined Date and Author', 'apple-news' );
+			case 'cover':
+				return __( 'Cover', 'apple-news' );
+			case 'date':
+				return __( 'Date', 'apple-news' );
+			case 'intro':
+				return __( 'Intro', 'apple-news' );
+			case 'slug':
+				return __( 'Slug', 'apple-news' );
+			case 'title':
+				return __( 'Title', 'apple-news' );
+			default:
+				return ucwords( $slug );
+		}
+	}
+
+	/**
 	 * Returns an array of configurable options for themes.
 	 *
 	 * @access public
@@ -530,55 +558,55 @@ class Theme {
 			),
 			'author_color'                       => array(
 				'default' => '#7c7c7c',
-				'label'   => __( 'Byline font color', 'apple-news' ),
+				'label'   => __( 'Author font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'author_color_dark'                  => array(
 				'default' => '',
-				'label'   => __( 'Byline font color', 'apple-news' ),
+				'label'   => __( 'Author font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'author_font'                        => array(
 				'default' => 'AvenirNext-Medium',
-				'label'   => __( 'Byline font face', 'apple-news' ),
+				'label'   => __( 'Author font face', 'apple-news' ),
 				'type'    => 'font',
 			),
 			'author_format'                      => array(
 				'default'     => 'by #author#',
 				'description' => __( 'Set the byline format. #author# denotes the location of the author name. The default format is "by #author#. Note that byline format updates only preview on save.', 'apple-news' ),
-				'label'       => __( 'Byline format', 'apple-news' ),
+				'label'       => __( 'Author format', 'apple-news' ),
 				'type'        => 'text',
 			),
 			'author_line_height'                 => array(
 				'default' => 24.0,
-				'label'   => __( 'Byline line height', 'apple-news' ),
+				'label'   => __( 'Author line height', 'apple-news' ),
 				'type'    => 'float',
 			),
 			'author_link_color'                  => array(
 				'default' => '#7c7c7c',
-				'label'   => __( 'Byline link font color', 'apple-news' ),
+				'label'   => __( 'Author URL font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'author_link_color_dark'             => array(
 				'default' => '',
-				'label'   => __( 'Byline link font color ', 'apple-news' ),
+				'label'   => __( 'Author URL font color ', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'author_links'                       => array(
 				'default' => 'no',
-				'label'   => __( 'Byline author links', 'apple-news' ),
+				'label'   => __( 'Hyperlink author names?', 'apple-news' ),
 				'options' => array( 'yes', 'no' ),
 				'type'    => 'select',
 			),
 			'author_size'                        => array(
 				'default' => 13,
-				'label'   => __( 'Byline font size', 'apple-news' ),
+				'label'   => __( 'Author font size', 'apple-news' ),
 				'type'    => 'integer',
 			),
 			'author_tracking'                    => array(
 				'default'     => 0,
 				'description' => __( '(Percentage of font size)', 'apple-news' ),
-				'label'       => __( 'Byline tracking', 'apple-news' ),
+				'label'       => __( 'Author tracking', 'apple-news' ),
 				'type'        => 'integer',
 			),
 			'blockquote_background_color'        => array(
@@ -703,39 +731,39 @@ class Theme {
 			),
 			'byline_color'                       => array(
 				'default' => '#7c7c7c',
-				'label'   => __( 'Unified Byline font color', 'apple-news' ),
+				'label'   => __( 'Combined Date and Author font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'byline_color_dark'                  => array(
 				'default' => '',
-				'label'   => __( 'Unified Byline font color', 'apple-news' ),
+				'label'   => __( 'Combined Date and Author font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'byline_font'                        => array(
 				'default' => 'AvenirNext-Medium',
-				'label'   => __( 'Unified Byline font face', 'apple-news' ),
+				'label'   => __( 'Combined Date and Author font face', 'apple-news' ),
 				'type'    => 'font',
 			),
 			'byline_format'                      => array(
 				'default'     => 'by #author# | #M j, Y | g:i A#',
 				'description' => __( 'Set the byline format. Two tokens can be present, #author# to denote the location of the author name and a <a href="http://php.net/manual/en/function.date.php" target="blank">PHP date format</a> string also encapsulated by #. The default format is "by #author# | #M j, Y | g:i A#". Note that byline format updates only preview on save.', 'apple-news' ),
-				'label'       => __( 'Unified Byline format', 'apple-news' ),
+				'label'       => __( 'Combined Date and Author format', 'apple-news' ),
 				'type'        => 'text',
 			),
 			'byline_line_height'                 => array(
 				'default' => 24.0,
-				'label'   => __( 'Unified Byline line height', 'apple-news' ),
+				'label'   => __( 'Combined Date and Author line height', 'apple-news' ),
 				'type'    => 'float',
 			),
 			'byline_size'                        => array(
 				'default' => 13,
-				'label'   => __( 'Unified Byline font size', 'apple-news' ),
+				'label'   => __( 'Combined Date and Author font size', 'apple-news' ),
 				'type'    => 'integer',
 			),
 			'byline_tracking'                    => array(
 				'default'     => 0,
 				'description' => __( '(Percentage of font size)', 'apple-news' ),
-				'label'       => __( 'Unified Byline tracking', 'apple-news' ),
+				'label'       => __( 'Combined Date and Author tracking', 'apple-news' ),
 				'type'        => 'integer',
 			),
 			'caption_color'                      => array(
@@ -1088,39 +1116,39 @@ class Theme {
 			),
 			'date_color'                         => array(
 				'default' => '#7c7c7c',
-				'label'   => __( 'Publication date font color', 'apple-news' ),
+				'label'   => __( 'Date font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'date_color_dark'                    => array(
 				'default' => '',
-				'label'   => __( 'Publication date font color', 'apple-news' ),
+				'label'   => __( 'Date font color', 'apple-news' ),
 				'type'    => 'color',
 			),
 			'date_font'                          => array(
 				'default' => 'AvenirNext-Medium',
-				'label'   => __( 'Publication date font face', 'apple-news' ),
+				'label'   => __( 'Date font face', 'apple-news' ),
 				'type'    => 'font',
 			),
 			'date_format'                        => array(
 				'default'     => '#M j, Y | g:i A#',
-				'description' => __( 'Set the publication date format. <a href="http://php.net/manual/en/function.date.php" target="blank">PHP date format</a> string is encapsulated by #. The default format is "#M j, Y | g:i A#". Note that publication date format updates only preview on save.', 'apple-news' ),
-				'label'       => __( 'Publication date format', 'apple-news' ),
+				'description' => __( 'Set the date format. <a href="http://php.net/manual/en/function.date.php" target="blank">PHP date format</a> string is encapsulated by #. The default format is "#M j, Y | g:i A#". Note that date format updates only preview on save.', 'apple-news' ),
+				'label'       => __( 'Date format', 'apple-news' ),
 				'type'        => 'text',
 			),
 			'date_line_height'                   => array(
 				'default' => 24.0,
-				'label'   => __( 'Publication date line height', 'apple-news' ),
+				'label'   => __( 'Date line height', 'apple-news' ),
 				'type'    => 'float',
 			),
 			'date_size'                          => array(
 				'default' => 13,
-				'label'   => __( 'Publication date font size', 'apple-news' ),
+				'label'   => __( 'Date font size', 'apple-news' ),
 				'type'    => 'integer',
 			),
 			'date_tracking'                      => array(
 				'default'     => 0,
 				'description' => __( '(Percentage of font size)', 'apple-news' ),
-				'label'       => __( 'Publication date tracking', 'apple-news' ),
+				'label'       => __( 'Date tracking', 'apple-news' ),
 				'type'        => 'integer',
 			),
 			'pullquote_border_color'             => array(
@@ -2090,6 +2118,20 @@ class Theme {
 					'dropcap_color_dark',
 				),
 			),
+			'date'            => array(
+				'label'       => __( 'Date', 'apple-news' ),
+				'description' => __( "Displays the article's date", 'apple-news' ),
+				'settings'    => array(
+					'date_font',
+					'date_size',
+					'date_line_height',
+					'date_tracking',
+					'date_color',
+					'date_format',
+					'dark_mode_colors_heading',
+					'date_color_dark',
+				),
+			),
 			'author'          => array(
 				'label'       => __( 'Author', 'apple-news' ),
 				'description' => __( "Displays the article's author byline", 'apple-news' ),
@@ -2105,8 +2147,8 @@ class Theme {
 				),
 			),
 			'byline'          => array(
-				'label'       => __( 'Unified Byline', 'apple-news' ),
-				'description' => __( "The byline displays the article's author and publish date", 'apple-news' ),
+				'label'       => __( 'Combined Date and Author', 'apple-news' ),
+				'description' => __( "The Combined Date and Author displays both the article's author and date", 'apple-news' ),
 				'settings'    => array(
 					'byline_font',
 					'byline_size',
@@ -2119,27 +2161,13 @@ class Theme {
 				),
 			),
 			'author_links'    => array(
-				'label'       => __( 'Author Links', 'apple-news' ),
+				'label'       => __( 'Author URL', 'apple-news' ),
 				'description' => __( 'Displays links to authors archive.', 'apple-news' ),
 				'settings'    => array(
 					'author_links',
 					'author_link_color',
 					'dark_mode_colors_heading',
 					'author_link_color_dark',
-				),
-			),
-			'date'            => array(
-				'label'       => __( 'Publicaton date', 'apple-news' ),
-				'description' => __( "Displays the article's published date", 'apple-news' ),
-				'settings'    => array(
-					'date_font',
-					'date_size',
-					'date_line_height',
-					'date_tracking',
-					'date_color',
-					'date_format',
-					'dark_mode_colors_heading',
-					'date_color_dark',
 				),
 			),
 			'heading1'        => array(

--- a/readme.txt
+++ b/readme.txt
@@ -50,11 +50,18 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 * Bugfix: Fixes an issue with some of the example themes where pullquotes would create invalid JSON due to the default-pullquote textStyle not being set. Props to @soulseekah for the fix.
 * Bugfix: Fixes an issue where a custom filter is used to make all image URLs root-relative when using featured images to populate the Cover component, which was leading to an INVALID_DOCUMENT error from the News API due to the root-relative URL (e.g., /path/to/my/image.jpg instead of https://example.org/path/to/my/image.jpg).
 * Bugfix: Fixes an issue with images not deduping when Jetpack Site Accelerator (Photon) is enabled.
+* Bugfix: Synchronizes the list of available fonts to what is actually available.
+* Bugfix: Fixes display of date pickers in the article list.
+* Bugfix: Fixes apple_news_is_exporting function to make it fire for both downloading JSON in the article list and pushing articles to Apple via the API.
+* Bugfix: Fixes an editor crash when using Gutenberg and a custom post type that does not support postmeta (custom-fields).
+* Bugfix: Fixes an issue with embedding YouTube and Vimeo videos when using Gutenberg blocks.
+* Bugfix: Fixes an issue where making a mistake in customizing JSON results in the custom JSON being reset to the default value rather than the previously saved value.
 * Enhancement: Added support for mailto:, music://, musics://, stocks:// and webcal:// links.
 * Enhancement: Added an option and a filter for skipping auto-push of posts with certain taxonomy terms.
-* Enhancement: Added support for html tags when customizing theme JSON.
+* Enhancement: Added support for HTML tags when customizing theme JSON.
 * Enhancement: Added an author component for author without date.
 * Enhancement: Added a date component for date without author byline.
+* Enhancement: Added support for determining the aspect ratio of an embedded video based on the value configured on the embed block.
 
 = 2.2.2 =
 * Bugfix: Moved custom metadata fields to the request level rather than the article level to align them with existing metadata properties like isPaid and isHidden.


### PR DESCRIPTION
Prepares for releasing v2.3.0:

* Bugfix for new feature allowing HTML in custom JSON to allow HTML with attributes
* Enhancement for custom HTML that doesn't reset the JSON to the default value if you make a mistake in an edit—it now reverts it to what was previously saved rather than the spec default value
* Renames several meta components to be more clear about their purpose
* Finalizes changelog for v2.3.0