### PR TITLE
APPLE-121 Fix issue with bundling images with same name

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.3.0
+ * Version:     2.3.1
  * Author:      Alley
  * Author URI:  https://alley.co
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -228,7 +228,7 @@ class Apple_News {
 			);
 			foreach ( self::$bundle_hashes as $bundle_filename ) {
 				if ( preg_match( $pattern, $bundle_filename, $matches ) ) {
-					$file_number = (int) $matches[1] + 1;
+					$file_number = max( $file_number, (int) $matches[1] + 1 );
 				}
 			}
 

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -18,6 +18,13 @@
 class Apple_News {
 
 	/**
+	 * An array of bundle hashes that match an asset URL to a bundle filename.
+	 *
+	 * @var array
+	 */
+	private static $bundle_hashes = [];
+
+	/**
 	 * Link to support for the plugin on github.
 	 *
 	 * @var string
@@ -39,7 +46,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static $version = '2.3.0';
+	public static $version = '2.3.1';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.
@@ -193,6 +200,11 @@ class Apple_News {
 	 */
 	public static function get_filename( $path ) {
 
+		// If we already have a hash for this path, return it.
+		if ( isset( self::$bundle_hashes[ $path ] ) ) {
+			return self::$bundle_hashes[ $path ];
+		}
+
 		// Remove any URL parameters.
 		// This is important for sites using WordPress VIP or Jetpack Photon.
 		$url_parts = wp_parse_url( $path );
@@ -200,7 +212,39 @@ class Apple_News {
 			return '';
 		}
 
-		return str_replace( ' ', '', basename( $url_parts['path'] ) );
+		// Compute base filename.
+		$filename = str_replace( ' ', '', basename( $url_parts['path'] ) );
+
+		// Ensure there are no filename collisions with existing bundles.
+		$bundle_filenames = array_values( self::$bundle_hashes );
+		sort( $bundle_filenames );
+		if ( in_array( $filename, $bundle_filenames, true ) ) {
+			$file_number    = 1;
+			$filename_parts = pathinfo( $filename );
+			$pattern        = sprintf(
+				'/^%s-([0-9]+)\.%s$/',
+				preg_quote( $filename_parts['filename'], '/' ),
+				preg_quote( $filename_parts['extension'], '/' )
+			);
+			foreach ( self::$bundle_hashes as $bundle_filename ) {
+				if ( preg_match( $pattern, $bundle_filename, $matches ) ) {
+					$file_number = (int) $matches[1] + 1;
+				}
+			}
+
+			// Apply the new filename to avoid collisions.
+			$filename = sprintf(
+				'%s-%d.%s',
+				$filename_parts['filename'],
+				$file_number,
+				$filename_parts['extension']
+			);
+		}
+
+		// Store this path/filename pair in the bundle hashes property for future use.
+		self::$bundle_hashes[ $path ] = $filename;
+
+		return $filename;
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-to-apple-news",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "GPLv3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 4.0
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.3.1 =
+* Bugfix: Fixes an issue where images with different URLs but the same filename are bundled with the same name when not using remote images, which can lead to images appearing out of order.
 
 = 2.3.0 =
 * Bugfix: Fixes an issue with some of the example themes where pullquotes would create invalid JSON due to the default-pullquote textStyle not being set. Props to @soulseekah for the fix.

--- a/tests/admin/test-class-admin-apple-themes.php
+++ b/tests/admin/test-class-admin-apple-themes.php
@@ -430,7 +430,7 @@ JSON;
 		$json = <<<JSON
 {
     "role": "audio",
-    "URL": "http://someurl.com",
+    "URL": "https://www.example.org",
     "style": {
         "backgroundColor": "#body_background_color#"
     }

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -22,12 +22,12 @@ class Metadata_Test extends Apple_News_Testcase {
 	public function data_video() {
 		return [
 			[
-				'https://example.com/wp-content/uploads/2017/02/example-poster.jpg',
-				'https://example.com/wp-content/uploads/2017/02/example-video.mp4',
+				'https://www.example.org/wp-content/uploads/2017/02/example-poster.jpg',
+				'https://www.example.org/wp-content/uploads/2017/02/example-video.mp4',
 			],
 			[
-				'https://example.com/wp-content/uploads/2017/02/example-poster.jpg',
-				'https://example.com/wp-content/uploads/2017/02/example-video.m3u8',
+				'https://www.example.org/wp-content/uploads/2017/02/example-poster.jpg',
+				'https://www.example.org/wp-content/uploads/2017/02/example-video.m3u8',
 			],
 		];
 	}

--- a/tests/apple-exporter/components/test-class-audio.php
+++ b/tests/apple-exporter/components/test-class-audio.php
@@ -22,7 +22,7 @@ class Audio_Test extends Component_TestCase {
 	 */
 	public function testGeneratedJSON() {
 		$component = new Audio(
-			'<audio><source src="http://someurl.com/audio-file.mp3?some_query=string"></audio>',
+			'<audio><source src="https://www.example.org/audio-file.mp3?some_query=string"></audio>',
 			$this->workspace,
 			$this->settings,
 			$this->styles,
@@ -31,7 +31,7 @@ class Audio_Test extends Component_TestCase {
 
 		$json = $component->to_array();
 		$this->assertEquals( 'audio', $json['role'] );
-		$this->assertEquals( 'http://someurl.com/audio-file.mp3?some_query=string', $json['URL'] );
+		$this->assertEquals( 'https://www.example.org/audio-file.mp3?some_query=string', $json['URL'] );
 	}
 
 	/**
@@ -39,7 +39,7 @@ class Audio_Test extends Component_TestCase {
 	 */
 	public function testCaption() {
 		$component = new Audio(
-			'<figure class="wp-block-audio"><audio controls="" src="https://www.someurl.com/Song-1.mp3"/><figcaption>caption</figcaption></figure>',
+			'<figure class="wp-block-audio"><audio controls="" src="https://www.example.org/Song-1.mp3"/><figcaption>caption</figcaption></figure>',
 			$this->workspace,
 			$this->settings,
 			$this->styles,
@@ -53,7 +53,7 @@ class Audio_Test extends Component_TestCase {
 				'components' => array(
 					array(
 						'role' => 'audio',
-						'URL' => 'https://www.someurl.com/Song-1.mp3',
+						'URL' => 'https://www.example.org/Song-1.mp3',
 					),
 					array(
 						'role' => 'caption',
@@ -71,7 +71,7 @@ class Audio_Test extends Component_TestCase {
 	 */
 	public function testFilter() {
 		$component = new Audio(
-			'<audio><source src="http://someurl.com/audio-file.mp3?some_query=string"></audio>',
+			'<audio><source src="https://www.example.org/audio-file.mp3?some_query=string"></audio>',
 			$this->workspace,
 			$this->settings,
 			$this->styles,
@@ -81,13 +81,13 @@ class Audio_Test extends Component_TestCase {
 		add_filter(
 			'apple_news_audio_json',
 			function( $json ) {
-				$json['URL'] = 'http://someurl.com/audio-file.mp3?some_query=string';
+				$json['URL'] = 'https://www.example.org/audio-file.mp3?some_query=string';
 				return $json;
 			}
 		);
 
 		$json = $component->to_array();
 		$this->assertEquals( 'audio', $json['role'] );
-		$this->assertEquals( 'http://someurl.com/audio-file.mp3?some_query=string', $json['URL'] );
+		$this->assertEquals( 'https://www.example.org/audio-file.mp3?some_query=string', $json['URL'] );
 	}
 }

--- a/tests/apple-exporter/components/test-class-body.php
+++ b/tests/apple-exporter/components/test-class-body.php
@@ -197,10 +197,10 @@ HTML
 	public function data_link_types() {
 		return [
 			// Standard link, non-https.
-			[ 'http://example.com', true ],
+			[ 'http://www.example.org', true ],
 
 			// Standard link, https.
-			[ 'https://example.com', true ],
+			[ 'https://www.example.org', true ],
 
 			// Root-relative URL. Should be permitted, but auto-converted to a fully qualified URL.
 			[ '/test', true ],
@@ -224,7 +224,7 @@ HTML
 			[ 'musics://abc123', true ],
 
 			// A mailto link.
-			[ 'mailto:example@example.com', true ],
+			[ 'mailto:example@example.org', true ],
 
 			// A hosted calendar.
 			[ 'webcal://abc123', true ],
@@ -384,7 +384,7 @@ HTML;
 
 		// Negotiate expected value and test.
 		if ( 0 === strpos( $link, '/' ) ) {
-			$link = 'http://example.org' . $link;
+			$link = 'https://www.example.org' . $link;
 		} elseif ( 0 === strpos( $link, '#' ) ) {
 			$link = get_permalink( $post_id ) . $link;
 		}

--- a/tests/apple-exporter/components/test-class-heading.php
+++ b/tests/apple-exporter/components/test-class-heading.php
@@ -137,7 +137,7 @@ HTML;
 
 		// Validate image split in generated JSON.
 		$this->assertEquals( 'photo', $json['components'][2]['role'] );
-		$this->assertEquals( 'http://example.org/example-image.jpg', $json['components'][2]['URL'] );
+		$this->assertEquals( 'https://www.example.org/example-image.jpg', $json['components'][2]['URL'] );
 	}
 
 	/**

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -150,11 +150,11 @@ HTML;
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'no' );
 		$this->prophecized_workspace->bundle_source(
-			'filename.jpg',
-			'http://someurl.com/filename.jpg'
+			'test-filter-filename.jpg',
+			'https://www.example.org/test-filter-filename.jpg'
 		)->shouldBeCalled();
 		$component = new Image(
-			'<img src="http://someurl.com/filename.jpg" alt="Example" />',
+			'<img src="https://www.example.org/test-filter-filename.jpg" alt="Example" />',
 			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
@@ -208,11 +208,11 @@ HTML;
 		// Setup.
 		$this->settings->set( 'use_remote_images', 'no' );
 		$this->prophecized_workspace->bundle_source(
-			'filename.jpg',
-			'http://someurl.com/filename.jpg'
+			'image-json-filename.jpg',
+			'https://www.example.org/image-json-filename.jpg'
 		)->shouldBeCalled();
 		$component = new Image(
-			'<img src="http://someurl.com/filename.jpg" alt="Example" align="left" />',
+			'<img src="https://www.example.org/image-json-filename.jpg" alt="Example" align="left" />',
 			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
@@ -222,7 +222,7 @@ HTML;
 
 		// Test.
 		$this->assertEquals( 'photo', $result['role'] );
-		$this->assertEquals( 'bundle://filename.jpg', $result['URL'] );
+		$this->assertEquals( 'bundle://image-json-filename.jpg', $result['URL'] );
 		$this->assertEquals( 'anchored-image', $result['layout'] );
 	}
 
@@ -237,10 +237,10 @@ HTML;
 		$this->settings->set( 'use_remote_images', 'yes' );
 		$this->prophecized_workspace->bundle_source(
 			'filename.jpg',
-			'http://someurl.com/filename.jpg'
+			'https://www.example.org/filename.jpg'
 		)->shouldNotBeCalled();
 		$component = new Image(
-			'<img src="http://someurl.com/filename.jpg" alt="Example" align="left" />',
+			'<img src="https://www.example.org/filename.jpg" alt="Example" align="left" />',
 			$this->prophecized_workspace->reveal(),
 			$this->settings,
 			$this->styles,
@@ -250,7 +250,7 @@ HTML;
 
 		// Test.
 		$this->assertEquals( 'photo', $result['role'] );
-		$this->assertEquals( 'http://someurl.com/filename.jpg', $result['URL'] );
+		$this->assertEquals( 'https://www.example.org/filename.jpg', $result['URL'] );
 		$this->assertEquals( 'anchored-image', $result['layout'] );
 	}
 
@@ -274,7 +274,7 @@ HTML;
 
 		// Test.
 		$this->assertEquals( 'photo', $result['role'] );
-		$this->assertEquals( 'http://example.org/relative/path/to/image.jpg', $result['URL'] );
+		$this->assertEquals( 'https://www.example.org/relative/path/to/image.jpg', $result['URL'] );
 		$this->assertEquals( 'anchored-image', $result['layout'] );
 	}
 
@@ -292,7 +292,7 @@ HTML;
 
 		$html = <<<HTML
 <figure>
-	<img src="https://example.org/filename.jpg" alt="Example">
+	<img src="https://www.example.org/filename.jpg" alt="Example">
 	<figcaption class="wp-caption-text">Caption Text</figcaption>
 </figure>
 HTML;
@@ -330,7 +330,7 @@ HTML;
 		);
 		$html = <<<HTML
 <figure>
-	<img src="http://someurl.com/filename.jpg" alt="Example">
+	<img src="https://www.example.org/filename.jpg" alt="Example">
 	<figcaption class="wp-caption-text">Caption Text</figcaption>
 </figure>
 HTML;

--- a/tests/apple-exporter/components/test-class-link-button.php
+++ b/tests/apple-exporter/components/test-class-link-button.php
@@ -55,7 +55,7 @@ class Link_Button_Test extends Component_TestCase {
 		return [
 			// A bare link should not match.
 			[
-				'<a href="https://example.org/">Test Button</a>',
+				'<a href="https://www.example.org/">Test Button</a>',
 				false,
 			],
 			// A button link with the button class but no href should not match.
@@ -70,12 +70,12 @@ class Link_Button_Test extends Component_TestCase {
 			],
 			// A button link with the button class and an href but no button text should not match.
 			[
-				'<a class="wp-block-button__link" href="https://example.org/"></a>',
+				'<a class="wp-block-button__link" href="https://www.example.org/"></a>',
 				false,
 			],
 			// A button link with the button class should match.
 			[
-				'<a class="wp-block-button__link" href="https://example.org/">Test Button</a>',
+				'<a class="wp-block-button__link" href="https://www.example.org/">Test Button</a>',
 				true,
 			],
 		];
@@ -90,11 +90,11 @@ class Link_Button_Test extends Component_TestCase {
 		return [
 			// Test a normal button.
 			[
-				'<a class="wp-block-button__link" href="https://example.org/">Test Button</a>',
+				'<a class="wp-block-button__link" href="https://www.example.org/">Test Button</a>',
 				[
 					'role'      => 'link_button',
 					'text'      => 'Test Button',
-					'URL'       => 'https://example.org/',
+					'URL'       => 'https://www.example.org/',
 					'style'     => 'default-link-button',
 					'layout'    => 'link-button-layout',
 					'textStyle' => 'default-link-button-text-style',
@@ -106,7 +106,7 @@ class Link_Button_Test extends Component_TestCase {
 				[
 					'role'      => 'link_button',
 					'text'      => 'Test Button',
-					'URL'       => 'http://example.org/test',
+					'URL'       => 'https://www.example.org/test',
 					'style'     => 'default-link-button',
 					'layout'    => 'link-button-layout',
 					'textStyle' => 'default-link-button-text-style',
@@ -118,7 +118,7 @@ class Link_Button_Test extends Component_TestCase {
 				[
 					'role'      => 'link_button',
 					'text'      => 'Test Button',
-					'URL'       => 'http://example.org/test-post/#test',
+					'URL'       => 'https://www.example.org/test-post/#test',
 					'style'     => 'default-link-button',
 					'layout'    => 'link-button-layout',
 					'textStyle' => 'default-link-button-text-style',

--- a/tests/apple-exporter/components/test-class-tweet.php
+++ b/tests/apple-exporter/components/test-class-tweet.php
@@ -25,11 +25,11 @@ class Tweet_Test extends Component_TestCase {
 	public function data_tweets() {
 		return [
 			[
-				'<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Swift will be open source later this year, available for iOS, OS X, and Linux. <a href="http://t.co/yQhyzxukTn">http://t.co/yQhyzxukTn</a></p>&mdash; Federico Ramirez (@gosukiwi) <a href="https://twitter.com/gosukiwi/status/608069908044390400">June 9, 2015</a></blockquote>',
+				'<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Swift will be open source later this year, available for iOS, OS X, and Linux. <a href="https://t.co/yQhyzxukTn">https://t.co/yQhyzxukTn</a></p>&mdash; Federico Ramirez (@gosukiwi) <a href="https://twitter.com/gosukiwi/status/608069908044390400">June 9, 2015</a></blockquote>',
 				'https://twitter.com/gosukiwi/status/608069908044390400',
 			],
 			[
-				'<blockquote class="twitter-tweet" lang="en">WordPress.com (@wordpressdotcom) <a href="http://twitter.com/#!/wordpressdotcom/status/204557548249026561" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+				'<blockquote class="twitter-tweet" lang="en">WordPress.com (@wordpressdotcom) <a href="https://twitter.com/#!/wordpressdotcom/status/204557548249026561" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
 				'https://twitter.com/wordpressdotcom/status/204557548249026561',
 			],
 			[
@@ -41,7 +41,7 @@ class Tweet_Test extends Component_TestCase {
 				'https://twitter.com/wordpressdotcom/status/204557548249026561',
 			],
 			[
-				'<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash; <br />WordPress.com (@wordpressdotcom) <a href="http://twitter.com/#!/wordpressdotcom/status/123" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+				'<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash; <br />WordPress.com (@wordpressdotcom) <a href="https://twitter.com/#!/wordpressdotcom/status/123" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
 				'https://twitter.com/wordpressdotcom/status/123',
 			],
 		];
@@ -97,7 +97,7 @@ class Tweet_Test extends Component_TestCase {
 	 */
 	public function testFilter() {
 		$component = new Tweet(
-			'<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash; <br />WordPress.com (@wordpressdotcom) <a href="http://twitter.com/#!/wordpressdotcom/status/123" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
+			'<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/foo/status/1111">twitter.com/foo/status/1111</a></p>&mdash; <br />WordPress.com (@wordpressdotcom) <a href="https://twitter.com/#!/wordpressdotcom/status/123" data-datetime="2012-05-21T13:01:34+00:00">May 21, 2012</a></blockquote>',
 			$this->workspace,
 			$this->settings,
 			$this->styles,

--- a/tests/apple-exporter/components/test-class-video.php
+++ b/tests/apple-exporter/components/test-class-video.php
@@ -24,9 +24,9 @@ class Video_Test extends Component_TestCase {
 	 * @var string
 	 */
 	private $video_content = <<<HTML
-<video class="wp-video-shortcode" id="video-71-1" width="525" height="295" poster="https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg" preload="metadata" controls="controls">
-	<source type="video/mp4" src="https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1" />
-	<a href="https://example.com/wp-content/uploads/2017/02/example-video.mp4">https://example.com/wp-content/uploads/2017/02/example-video.mp4</a>
+<video class="wp-video-shortcode" id="video-71-1" width="525" height="295" poster="https://www.example.org/wp-content/uploads/2017/02/ExamplePoster.jpg" preload="metadata" controls="controls">
+	<source type="video/mp4" src="https://www.example.org/wp-content/uploads/2017/02/example-video.mp4?_=1" />
+	<a href="https://www.example.org/wp-content/uploads/2017/02/example-video.mp4">https://www.example.org/wp-content/uploads/2017/02/example-video.mp4</a>
 </video>
 HTML;
 
@@ -39,7 +39,7 @@ HTML;
 	 * @return array The modified JSON.
 	 */
 	public function filter_apple_news_video_json( $json ) {
-		$json['URL'] = 'http://filter.me';
+		$json['URL'] = 'https://www.example.org/filter-me';
 
 		return $json;
 	}
@@ -61,7 +61,7 @@ HTML;
 		// Test.
 		$result = $component->to_array();
 		$this->assertEquals(
-			'http://filter.me',
+			'https://www.example.org/filter-me',
 			$result['URL']
 		);
 
@@ -78,7 +78,7 @@ HTML;
 	 * @access public
 	 */
 	public function testCaption() {
-		$component = $this->get_component( '<figure class="wp-block-video"><video controls="" src="http://www.url.com/test.mp4"/><figcaption>caption</figcaption></figure>' );
+		$component = $this->get_component( '<figure class="wp-block-video"><video controls="" src="https://www.example.org/test.mp4"/><figcaption>caption</figcaption></figure>' );
 
 		// Test.
 		$this->assertEquals(
@@ -87,7 +87,7 @@ HTML;
 				'components' => array(
 					array(
 						'role' => 'video',
-						'URL' => 'http://www.url.com/test.mp4',
+						'URL' => 'https://www.example.org/test.mp4',
 					),
 					array(
 						'role' => 'caption',
@@ -114,7 +114,7 @@ HTML;
 		// Test.
 		$result = $component->to_array();
 		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/ExamplePoster.jpg',
+			'https://www.example.org/wp-content/uploads/2017/02/ExamplePoster.jpg',
 			$result['stillURL']
 		);
 		$this->assertEquals(
@@ -122,7 +122,7 @@ HTML;
 			$result['role']
 		);
 		$this->assertEquals(
-			'https://example.com/wp-content/uploads/2017/02/example-video.mp4?_=1',
+			'https://www.example.org/wp-content/uploads/2017/02/example-video.mp4?_=1',
 			$result['URL']
 		);
 	}

--- a/tests/apple-exporter/test-class-exporter-content.php
+++ b/tests/apple-exporter/test-class-exporter-content.php
@@ -24,12 +24,12 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 	}
 
 	public function testCompleteContent() {
-		$content  = new \Apple_Exporter\Exporter_Content( 3, 'Title', '<p>Example content</p>', 'some intro', 'someurl.com' );
+		$content  = new \Apple_Exporter\Exporter_Content( 3, 'Title', '<p>Example content</p>', 'some intro', 'example.org' );
 		$this->assertEquals( '3', $content->id() );
 		$this->assertEquals( 'Title', $content->title() );
 		$this->assertEquals( '<p>Example content</p>', $content->content() );
 		$this->assertEquals( 'some intro', $content->intro() );
-		$this->assertEquals( 'someurl.com', $content->cover() );
+		$this->assertEquals( 'example.org', $content->cover() );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 	public function testCompleteContentWithCoverConfig() {
 		$cover = [
 			'caption' => 'Test Caption',
-			'url'     => 'https://example.org/wp-content/uploads/2020/07/test-image.jpg',
+			'url'     => 'https://www.example.org/wp-content/uploads/2020/07/test-image.jpg',
 		];
 		$content  = new \Apple_Exporter\Exporter_Content(
 			3,
@@ -59,8 +59,8 @@ class Exporter_Content_Test extends WP_UnitTestCase {
 	 */
 	public function test_format_src_url() {
 		$this->assertEquals(
-			'https://example.com/some.mp3?one=two&query=arg',
-			\Apple_Exporter\Exporter_Content::format_src_url( 'https://example.com/some.mp3?one=two&amp;query=arg' )
+			'https://www.example.org/some.mp3?one=two&query=arg',
+			\Apple_Exporter\Exporter_Content::format_src_url( 'https://www.example.org/some.mp3?one=two&amp;query=arg' )
 		);
 	}
 

--- a/tests/apple-exporter/test-class-parser.php
+++ b/tests/apple-exporter/test-class-parser.php
@@ -6,26 +6,26 @@ class Parser_Test extends WP_UnitTestCase {
 
 	public function testParseMarkdown() {
 		// Create a basic HTML post
-		$post = '<html><body><h2>A heading</h2><p><strong>This is strong.</strong><br><a href="http://apple.com">This is a link</a></p></body></html>';
+		$post = '<html><body><h2>A heading</h2><p><strong>This is strong.</strong><br><a href="https://www.apple.com">This is a link</a></p></body></html>';
 
 		// Convert to Markdown
 		$parser = new Parser( 'markdown' );
 		$markdown = $parser->parse( $post );
 
 		// Verify
-		$this->assertEquals( $markdown, "## A heading\n**This is strong.**\n[This is a link](http://apple.com)\n\n" );
+		$this->assertEquals( $markdown, "## A heading\n**This is strong.**\n[This is a link](https://www.apple.com)\n\n" );
 	}
 
 	public function testParseHTML() {
 		// Create a basic HTML post
-		$post = '<h2 class="someClass">A heading</h2><p><strong>This is strong.</strong><br><a href="http://apple.com" target="_blank">This is a link</a></p><div>The div tags will disappear.</div>';
+		$post = '<h2 class="someClass">A heading</h2><p><strong>This is strong.</strong><br><a href="https://www.apple.com" target="_blank">This is a link</a></p><div>The div tags will disappear.</div>';
 
 		// Parse only HTML that's valid for Apple News
 		$parser = new Parser( 'html' );
 		$markdown = $parser->parse( $post );
 
 		// Verify
-		$this->assertEquals( $markdown, 'A heading<p><strong>This is strong.</strong><br><a href="http://apple.com">This is a link</a></p>The div tags will disappear.' );
+		$this->assertEquals( $markdown, 'A heading<p><strong>This is strong.</strong><br><a href="https://www.apple.com">This is a link</a></p>The div tags will disappear.' );
 	}
 
 	/**
@@ -35,9 +35,6 @@ class Parser_Test extends WP_UnitTestCase {
 	 * @access public
 	 */
 	public function testCleanHTMLMarkdown() {
-		update_option( 'siteurl', 'http://wp.dev' );
-		update_option( 'home', 'http://wp.dev' );
-
 		// Create a post.
 		global $post;
 		$post_content = <<<HTML
@@ -69,7 +66,7 @@ HTML;
 		// Verify.
 		$this->assertEquals(
 			'[Absolute link](https://www.google.com)'
-			. '[Root-relative link](http://wp.dev/2018/05/03/an-92-test)'
+			. '[Root-relative link](https://www.example.org/2018/05/03/an-92-test)'
 			. 'Test Anchor'
 			. '[Anchor Link](' . $permalink . '#testanchor)'
 			. 'Legit empty link'
@@ -86,9 +83,6 @@ HTML;
 	 * @access public
 	 */
 	public function testCleanHTML() {
-		update_option( 'siteurl', 'http://wp.dev' );
-		update_option( 'home', 'http://wp.dev' );
-
 		// Create a post.
 		global $post;
 		$post_content = <<<HTML
@@ -120,7 +114,7 @@ HTML;
 		// Verify.
 		$this->assertEquals(
 			'<p><a href="https://www.google.com">Absolute link</a></p>'
-				. '<p><a href="http://wp.dev/2018/05/03/an-92-test">Root-relative link</a></p>'
+				. '<p><a href="https://www.example.org/2018/05/03/an-92-test">Root-relative link</a></p>'
 				. '<p>Test Anchor</p>'
 				. '<p><a href="' . $permalink . '#testanchor">Anchor Link</a></p>'
 				. '<p>Legit empty link</p>'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,8 +27,13 @@ function _manually_load_plugin() {
 		remove_action( 'init', [ WPCOM_VIP_Cache_Manager::instance(), 'init' ] );
 	}
 
-	// Set the permalink structure.
+	// Set the permalink structure and domain options.
+	update_option( 'home', 'https://www.example.org' );
 	update_option( 'permalink_structure', '/%postname%' );
+	update_option( 'siteurl', 'https://www.example.org' );
+
+	// Force WP to treat URLs as HTTPS during testing so the home and siteurl option protocols are honored.
+	$_SERVER['HTTPS'] = 1;
 
 	// Load mocks for integration tests.
 	require_once __DIR__ . '/mocks/class-bc-setup.php';

--- a/tests/test-class-apple-news.php
+++ b/tests/test-class-apple-news.php
@@ -23,9 +23,9 @@ class Apple_News_Test extends Apple_News_Testcase {
 	 * @access public
 	 */
 	public function testGetFilename() {
-		$url = 'http://someurl.com/image.jpg?w=150&h=150';
+		$url = 'https://www.example.org/test-get-filename.jpg?w=150&h=150';
 		$filename = Apple_News::get_filename( $url );
-		$this->assertEquals( 'image.jpg', $filename );
+		$this->assertEquals( 'test-get-filename.jpg', $filename );
 	}
 
 	/**


### PR DESCRIPTION
* Fixes an issue with bundling multiple images with the same filename but different URLs, where Apple News misunderstands which image should be used in which position, leading to a random shuffling of images with the same name.
* Standardizes test URLs to https://www.example.org throughout.
* Bumps plugin version to 2.3.1.

Fixes #600 