### PR TITLE
APPLE-136 Improve dupe errors

### DIFF
--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -153,13 +153,8 @@ class Admin_Apple_Notice {
 			$user_id = get_current_user_id();
 		}
 
-		$allowed_html = [
-			'a'  => [ 'href' => [] ],
-			'br' => [],
-		];
-
 		// Sanitize values.
-		$message = wp_kses( $message, $allowed_html );
+		$message = wp_kses_post( $message );
 		$type    = sanitize_text_field( $type );
 
 		// Pull usermeta and see if the message already exists.

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -154,7 +154,7 @@ class Admin_Apple_Notice {
 		}
 
 		// Sanitize values.
-		$message = wp_kses( $message, [ 'a' => [ 'href' => [] ] ] );
+		$message = wp_kses( $message, [ 'a' => [ 'href' => [] ], 'br' => [], ] );
 		$type    = sanitize_text_field( $type );
 
 		// Pull usermeta and see if the message already exists.

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -153,8 +153,13 @@ class Admin_Apple_Notice {
 			$user_id = get_current_user_id();
 		}
 
+		$allowed_html = [
+			'a'  => [ 'href' => [] ],
+			'br' => [],
+		];
+
 		// Sanitize values.
-		$message = wp_kses( $message, [ 'a' => [ 'href' => [] ], 'br' => [], ] );
+		$message = wp_kses( $message, $allowed_html );
 		$type    = sanitize_text_field( $type );
 
 		// Pull usermeta and see if the message already exists.

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -10,7 +10,7 @@
  * @package Apple_News
  */
 
-$apple_allowed_html = [
+$apple_notice_html = [
 	'a'  => [ 'href' => [] ],
 	'br' => [],
 ]
@@ -21,5 +21,5 @@ $apple_allowed_html = [
 	data-nonce="<?php echo esc_attr( wp_create_nonce( 'apple_news_dismiss_notice' ) ); ?>"
 	data-type="<?php echo esc_attr( $type ); ?>"
 >
-	<p><strong><?php echo wp_kses( $message, $apple_allowed_html ); ?></strong></p>
+	<p><strong><?php echo wp_kses( $message, $apple_notice_html ); ?></strong></p>
 </div>

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -17,5 +17,5 @@
 	data-nonce="<?php echo esc_attr( wp_create_nonce( 'apple_news_dismiss_notice' ) ); ?>"
 	data-type="<?php echo esc_attr( $type ); ?>"
 >
-	<p><strong><?php echo wp_kses_post( $message ); ?></strong></p>
+	<p><strong><?php echo wp_kses( $message, [ 'a' => [ 'href' => [] ], 'br' => [], ] ); ?></strong></p>
 </div>

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -10,6 +10,10 @@
  * @package Apple_News
  */
 
+$allowed_html = [
+	'a'  => [ 'href' => [] ],
+	'br' => [],
+]
 ?>
 <div
 	class="notice <?php echo sanitize_html_class( 'notice-' . $type ); ?> apple-news-notice is-dismissible"
@@ -17,5 +21,5 @@
 	data-nonce="<?php echo esc_attr( wp_create_nonce( 'apple_news_dismiss_notice' ) ); ?>"
 	data-type="<?php echo esc_attr( $type ); ?>"
 >
-	<p><strong><?php echo wp_kses( $message, [ 'a' => [ 'href' => [] ], 'br' => [], ] ); ?></strong></p>
+	<p><strong><?php echo wp_kses( $message, $allowed_html ); ?></strong></p>
 </div>

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -10,7 +10,7 @@
  * @package Apple_News
  */
 
-$allowed_html = [
+$apple_allowed_html = [
 	'a'  => [ 'href' => [] ],
 	'br' => [],
 ]
@@ -21,5 +21,5 @@ $allowed_html = [
 	data-nonce="<?php echo esc_attr( wp_create_nonce( 'apple_news_dismiss_notice' ) ); ?>"
 	data-type="<?php echo esc_attr( $type ); ?>"
 >
-	<p><strong><?php echo wp_kses( $message, $allowed_html ); ?></strong></p>
+	<p><strong><?php echo wp_kses( $message, $apple_allowed_html ); ?></strong></p>
 </div>

--- a/admin/partials/notice.php
+++ b/admin/partials/notice.php
@@ -10,10 +10,6 @@
  * @package Apple_News
  */
 
-$apple_notice_html = [
-	'a'  => [ 'href' => [] ],
-	'br' => [],
-]
 ?>
 <div
 	class="notice <?php echo sanitize_html_class( 'notice-' . $type ); ?> apple-news-notice is-dismissible"
@@ -21,5 +17,5 @@ $apple_notice_html = [
 	data-nonce="<?php echo esc_attr( wp_create_nonce( 'apple_news_dismiss_notice' ) ); ?>"
 	data-type="<?php echo esc_attr( $type ); ?>"
 >
-	<p><strong><?php echo wp_kses( $message, $apple_notice_html ); ?></strong></p>
+	<p><strong><?php echo wp_kses_post( $message ); ?></strong></p>
 </div>

--- a/assets/js/pluginsidebar/sidebar.jsx
+++ b/assets/js/pluginsidebar/sidebar.jsx
@@ -118,7 +118,10 @@ const Sidebar = () => {
    */
   const displayNotification = useCallback((message, type = 'success') => (type === 'success'
     ? dispatchNotice.createInfoNotice(DOMPurify.sanitize(message), { type: 'snackbar' })
-    : dispatchNotice.createErrorNotice(DOMPurify.sanitize(message))
+    : dispatchNotice.createErrorNotice(
+      DOMPurify.sanitize(message, { ADD_TAGS: ['br'] }),
+      { __unstableHTML: true },
+    )
   ), [dispatchNotice]);
 
   /**

--- a/assets/js/pluginsidebar/sidebar.jsx
+++ b/assets/js/pluginsidebar/sidebar.jsx
@@ -118,10 +118,7 @@ const Sidebar = () => {
    */
   const displayNotification = useCallback((message, type = 'success') => (type === 'success'
     ? dispatchNotice.createInfoNotice(DOMPurify.sanitize(message), { type: 'snackbar' })
-    : dispatchNotice.createErrorNotice(
-      DOMPurify.sanitize(message, { ADD_TAGS: ['br'] }),
-      { __unstableHTML: true },
-    )
+    : dispatchNotice.createErrorNotice(message, { __unstableHTML: true })
   ), [dispatchNotice]);
 
   /**

--- a/includes/apple-exporter/components/class-podcast.php
+++ b/includes/apple-exporter/components/class-podcast.php
@@ -94,7 +94,7 @@ class Podcast extends Component {
 		// Pattern match src attribute for apple podcast url.
 		$url = $iframe->getAttribute( 'src' );
 
-		if ( empty( $url ) || ! str_contains( $url, 'podcasts.apple.com' ) ) {
+		if ( empty( $url ) || false === strpos( $url, 'podcasts.apple.com' ) ) {
 			return;
 		}
 

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -266,7 +266,10 @@ class Request {
 			}
 
 			if ( 'DUPLICATE_ARTICLE_FOUND' === $error->code ) {
-				$message .= '.<br>Original UUID: ' . $error->value;
+				$message .= '.<br>' . sprintf(
+					__( 'Original UUID: %s', 'apple-news' ),
+					sanitize_text_field( $error->value )
+				);
 			}
 
 			throw new Request_Exception( $message );

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -265,6 +265,10 @@ class Request {
 				$message = __( 'Unable to fetch information for the specified article. Was it deleted?', 'apple-news' );
 			}
 
+			if ( 'DUPLICATE_ARTICLE_FOUND' === $error->code ) {
+				$message .= '. Original UUID: ' . $error->value;
+			}
+
 			throw new Request_Exception( $message );
 		}
 

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -267,6 +267,7 @@ class Request {
 
 			if ( 'DUPLICATE_ARTICLE_FOUND' === $error->code ) {
 				$message .= '.<br>' . sprintf(
+					// translators: UUID of original article.
 					__( 'Original UUID: %s', 'apple-news' ),
 					sanitize_text_field( $error->value )
 				);

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -266,7 +266,7 @@ class Request {
 			}
 
 			if ( 'DUPLICATE_ARTICLE_FOUND' === $error->code ) {
-				$message .= '. Original UUID: ' . $error->value;
+				$message .= '.<br>Original UUID: ' . $error->value;
 			}
 
 			throw new Request_Exception( $message );


### PR DESCRIPTION
## What does this PR do?

1. Includes the original post's uuid in `DUPLICATE_ARTICLE_FOUND` errors returned from the Apple News api. 

#### Screenshot
![Screen Shot 2022-12-09 at 1 14 34 PM](https://user-images.githubusercontent.com/57693937/206766528-147863df-289a-4db7-80a8-a3e37d00e0b1.png)
