### PR TITLE
APPLE-135 Add Theme width and columns to customize JSON page

### DIFF
--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -181,8 +181,8 @@ class Admin_Apple_JSON extends Apple_News {
 		$selected_theme = $this->get_selected_theme();
 
 		// Extract theme layout configuration.
-		$layout_columns = '';
-		$layout_width   = '';
+		$layout_columns = 0;
+		$layout_width   = 0;
 		if ( ! empty( $selected_theme ) ) {
 			$loaded_theme   = Admin_Apple_Themes::get_loaded_theme( $selected_theme );
 			$layout_columns = $loaded_theme->get_layout_columns();

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -181,12 +181,13 @@ class Admin_Apple_JSON extends Apple_News {
 		$selected_theme = $this->get_selected_theme();
 
 		// Extract theme layout configuration.
-		// $layout_columns = ( ! empty( $selected_theme ) )
-		// 	? $selected_theme->get_layout_columns()
-		// 	: '';
-		// $layout_width   = ( ! empty( $selected_theme ) )
-		// 	? $selected_theme->get_value( 'layout_width' )
-		// 	: '';
+		$layout_columns = '';
+		$layout_width   = '';
+		if ( ! empty( $selected_theme ) ) {
+			$loaded_theme   = Admin_Apple_Themes::get_loaded_theme( $selected_theme );
+			$layout_columns = $loaded_theme->get_layout_columns();
+			$layout_width   = $loaded_theme->get_value( 'layout_width' );
+		}
 
 		// Check if there is a valid selected component.
 		$selected_component = ( ! empty( $selected_theme ) )

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -180,6 +180,14 @@ class Admin_Apple_JSON extends Apple_News {
 		// Negotiate selected theme.
 		$selected_theme = $this->get_selected_theme();
 
+		// Extract theme layout configuration.
+		// $layout_columns = ( ! empty( $selected_theme ) )
+		// 	? $selected_theme->get_layout_columns()
+		// 	: '';
+		// $layout_width   = ( ! empty( $selected_theme ) )
+		// 	? $selected_theme->get_value( 'layout_width' )
+		// 	: '';
+
 		// Check if there is a valid selected component.
 		$selected_component = ( ! empty( $selected_theme ) )
 			? $this->get_selected_component()

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -184,9 +184,9 @@ class Admin_Apple_JSON extends Apple_News {
 		$layout_columns = 0;
 		$layout_width   = 0;
 		if ( ! empty( $selected_theme ) ) {
-			$loaded_theme   = Admin_Apple_Themes::get_loaded_theme( $selected_theme );
-			$layout_columns = $loaded_theme->get_layout_columns();
-			$layout_width   = $loaded_theme->get_value( 'layout_width' );
+			$theme_object   = Admin_Apple_Themes::get_theme_by_name( $selected_theme );
+			$layout_columns = $theme_object->get_layout_columns();
+			$layout_width   = $theme_object->get_value( 'layout_width' );
 		}
 
 		// Check if there is a valid selected component.

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -166,7 +166,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 * 
 	 * @return \Apple_Exporter\Theme $theme_object A Theme object loaded with db config.
 	 */
-	public static function get_loaded_theme( $theme_str ) {
+	public static function get_theme_by_name( $theme_str ) {
 		$theme_object = new \Apple_Exporter\Theme();
 		$theme_object->set_name( $theme_str );
 		$theme_object->load();

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -164,7 +164,8 @@ class Admin_Apple_Themes extends Apple_News {
 	 *
 	 * @param string $theme_str The name of theme.
 	 * 
-	 * @return \Apple_Exporter\Theme $theme_object A Theme object loaded with db config.
+	 * @return \Apple_Exporter\Theme|null $theme_object A Theme object loaded with db config,
+	 * or null if theme name not in registry.
 	 */
 	public static function get_loaded_theme( $theme_str ) {
 		// Make sure theme exists in registry before continuing.

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -164,7 +164,7 @@ class Admin_Apple_Themes extends Apple_News {
 	 *
 	 * @param string $theme_str The name of theme.
 	 * 
-	 * @return \Apple_Exporter\Theme @theme_object A Theme object loaded with db config.
+	 * @return \Apple_Exporter\Theme $theme_object A Theme object loaded with db config.
 	 */
 	public static function get_loaded_theme( $theme_str ) {
 		// Make sure theme exists in registry before continuing.

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -162,13 +162,14 @@ class Admin_Apple_Themes extends Apple_News {
 	/**
 	 * Return a Theme object loaded with db values based on the theme name string.
 	 *
-	 * @param string                 $theme_str The name of theme.
+	 * @param string $theme_str The name of theme.
+	 * 
 	 * @return \Apple_Exporter\Theme @theme_object A Theme object loaded with db config.
 	 */
 	public static function get_loaded_theme( $theme_str ) {
 		// Make sure theme exists in registry before continuing.
 		$registry = \Apple_Exporter\Theme::get_registry();
-		if ( empty( $registry ) || ! in_array( $theme_str, $registry ) ) {
+		if ( empty( $registry ) || ! in_array( $theme_str, $registry, true ) ) {
 			return;
 		}
 

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -164,16 +164,9 @@ class Admin_Apple_Themes extends Apple_News {
 	 *
 	 * @param string $theme_str The name of theme.
 	 * 
-	 * @return \Apple_Exporter\Theme|null $theme_object A Theme object loaded with db config,
-	 * or null if theme name not in registry.
+	 * @return \Apple_Exporter\Theme $theme_object A Theme object loaded with db config.
 	 */
 	public static function get_loaded_theme( $theme_str ) {
-		// Make sure theme exists in registry before continuing.
-		$registry = \Apple_Exporter\Theme::get_registry();
-		if ( empty( $registry ) || ! in_array( $theme_str, $registry, true ) ) {
-			return;
-		}
-
 		$theme_object = new \Apple_Exporter\Theme();
 		$theme_object->set_name( $theme_str );
 		$theme_object->load();

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -160,6 +160,26 @@ class Admin_Apple_Themes extends Apple_News {
 	}
 
 	/**
+	 * Return a Theme object loaded with db values based on the theme name string.
+	 *
+	 * @param string                 $theme_str The name of theme.
+	 * @return \Apple_Exporter\Theme @theme_object A Theme object loaded with db config.
+	 */
+	public static function get_loaded_theme( $theme_str ) {
+		// Make sure theme exists in registry before continuing.
+		$registry = \Apple_Exporter\Theme::get_registry();
+		if ( empty( $registry ) || ! in_array( $theme_str, $registry ) ) {
+			return;
+		}
+
+		$theme_object = new \Apple_Exporter\Theme();
+		$theme_object->set_name( $theme_str );
+		$theme_object->load();
+
+		return $theme_object;
+	}
+
+	/**
 	 * Constructor. Sets page names dynamically and registers actions.
 	 *
 	 * @access public

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -89,12 +89,12 @@
 				<div class="theme-value-wrapper">
 				<?php if ( ! empty( $layout_columns ) ) : ?>
 					<div class="theme-value-row top">
-						<?php esc_html_e( 'Theme Columns', 'apple-news' ); ?>: <span><?php echo esc_html( $layout_columns ); ?></span>
+						<?php esc_html_e( 'Theme Columns', 'apple-news' ); ?>: <span><?php echo (int) $layout_columns; ?></span>
 					</div>
 				<?php endif; ?>
 				<?php if ( ! empty( $layout_width ) ) : ?>
 					<div class="theme-value-row">
-						<?php esc_html_e( 'Layout Width', 'apple-news' ); ?>: <span><?php echo esc_html( $layout_width ); ?></span>
+						<?php esc_html_e( 'Layout Width', 'apple-news' ); ?>: <span><?php echo (int) $layout_width; ?></span>
 					</div>
 				<?php endif; ?>
 				</div>

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -86,6 +86,14 @@
 				</label>
 			</div>
 			<?php if ( ! empty( $selected_theme ) ) : ?>
+				<div class="theme-value-wrapper">
+					<div class="theme-value-row top">
+						<?php esc_html_e( 'Theme Columns', 'apple-news' ); ?>: <span><?php echo esc_html( $layout_columns ); ?></span>
+					</div>
+					<div class="theme-value-row">
+						<?php esc_html_e( 'Layout Width', 'apple-news' ); ?>: <span><?php echo esc_html( $layout_width ); ?></span>
+					</div>
+				</div>
 				<div>
 					<label for="apple_news_theme">
 						<?php esc_html_e( 'Component', 'apple-news' ); ?>:
@@ -99,10 +107,6 @@
 							<?php endforeach; ?>
 						</select>
 					</label>
-				</div>
-				<div>
-					<span><?php echo esc_html( $layout_columns ); ?></span>
-					<span><?php echo esc_html( $layout_width ); ?></span>
 				</div>
 			<?php endif; ?>
 

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -87,12 +87,16 @@
 			</div>
 			<?php if ( ! empty( $selected_theme ) ) : ?>
 				<div class="theme-value-wrapper">
+				<?php if ( ! empty( $layout_columns ) ) : ?>
 					<div class="theme-value-row top">
 						<?php esc_html_e( 'Theme Columns', 'apple-news' ); ?>: <span><?php echo esc_html( $layout_columns ); ?></span>
 					</div>
+				<?php endif; ?>
+				<?php if ( ! empty( $layout_width ) ) : ?>
 					<div class="theme-value-row">
 						<?php esc_html_e( 'Layout Width', 'apple-news' ); ?>: <span><?php echo esc_html( $layout_width ); ?></span>
 					</div>
+				<?php endif; ?>
 				</div>
 				<div>
 					<label for="apple_news_theme">

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -100,6 +100,10 @@
 						</select>
 					</label>
 				</div>
+				<div>
+					<span><?php echo esc_html( $layout_columns ); ?></span>
+					<span><?php echo esc_html( $layout_width ); ?></span>
+				</div>
 			<?php endif; ?>
 
 			<?php if ( ! empty( $specs ) ) : ?>

--- a/assets/css/json.css
+++ b/assets/css/json.css
@@ -4,6 +4,18 @@
 	display: block;
 }
 
+.apple-news-json .theme-value-wrapper {
+	margin-top: 15px;
+}
+
+.apple-news-json .theme-value-row span {
+	font-weight: bold;
+}
+
+.apple-news-json .theme-value-row.top {
+	margin-bottom: 3px;
+}
+
 .apple-news-json input[type="submit"] {
 	margin-right: 1em;
 }


### PR DESCRIPTION
## What does this PR do?

1. Creates static method to return a loaded Theme object given a string theme name.
2. Uses that method to retrieve a Theme and its column/width values.
3. Displays those values in the Customize JSON frontend template after a User selects a Theme.