### PR TITLE
Make image comp type configurable

### DIFF
--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -181,6 +181,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 			'apple_news_pullquote_position' => 'string',
 			'apple_news_slug'               => 'string',
 			'apple_news_suppress_video_url' => 'boolean',
+			'apple_news_use_image_component' => 'boolean',
 		];
 		foreach ( $fields as $meta_key => $type ) {
 			switch ( $type ) {
@@ -335,18 +336,19 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Only show the publish feature if the user is authorized and auto sync is not enabled.
 		// Also check if the post has been previously published and/or deleted.
-		$api_id             = get_post_meta( $post->ID, 'apple_news_api_id', true );
-		$deleted            = get_post_meta( $post->ID, 'apple_news_api_deleted', true );
-		$pending            = get_post_meta( $post->ID, 'apple_news_api_pending', true );
-		$is_paid            = get_post_meta( $post->ID, 'apple_news_is_paid', true );
-		$is_preview         = get_post_meta( $post->ID, 'apple_news_is_preview', true );
-		$is_hidden          = get_post_meta( $post->ID, 'apple_news_is_hidden', true );
-		$maturity_rating    = get_post_meta( $post->ID, 'apple_news_maturity_rating', true );
-		$is_sponsored       = get_post_meta( $post->ID, 'apple_news_is_sponsored', true );
-		$pullquote          = get_post_meta( $post->ID, 'apple_news_pullquote', true );
-		$pullquote_position = get_post_meta( $post->ID, 'apple_news_pullquote_position', true );
-		$slug               = get_post_meta( $post->ID, 'apple_news_slug', true );
-		$suppress_video_url = get_post_meta( $post->ID, 'apple_news_suppress_video_url', true );
+		$api_id              = get_post_meta( $post->ID, 'apple_news_api_id', true );
+		$deleted             = get_post_meta( $post->ID, 'apple_news_api_deleted', true );
+		$pending             = get_post_meta( $post->ID, 'apple_news_api_pending', true );
+		$is_paid             = get_post_meta( $post->ID, 'apple_news_is_paid', true );
+		$is_preview          = get_post_meta( $post->ID, 'apple_news_is_preview', true );
+		$is_hidden           = get_post_meta( $post->ID, 'apple_news_is_hidden', true );
+		$maturity_rating     = get_post_meta( $post->ID, 'apple_news_maturity_rating', true );
+		$is_sponsored        = get_post_meta( $post->ID, 'apple_news_is_sponsored', true );
+		$pullquote           = get_post_meta( $post->ID, 'apple_news_pullquote', true );
+		$pullquote_position  = get_post_meta( $post->ID, 'apple_news_pullquote_position', true );
+		$slug                = get_post_meta( $post->ID, 'apple_news_slug', true );
+		$suppress_video_url  = get_post_meta( $post->ID, 'apple_news_suppress_video_url', true );
+		$use_image_component = get_post_meta( $post->ID, 'apple_news_use_image_component', true );
 
 		// Set default values.
 		if ( empty( $pullquote_position ) ) {

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -171,16 +171,16 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		// Save straightforward fields.
 		$fields = [
-			'apple_news_coverimage'         => 'integer',
-			'apple_news_coverimage_caption' => 'textarea',
-			'apple_news_is_hidden'          => 'boolean',
-			'apple_news_is_paid'            => 'boolean',
-			'apple_news_is_preview'         => 'boolean',
-			'apple_news_is_sponsored'       => 'boolean',
-			'apple_news_pullquote'          => 'string',
-			'apple_news_pullquote_position' => 'string',
-			'apple_news_slug'               => 'string',
-			'apple_news_suppress_video_url' => 'boolean',
+			'apple_news_coverimage'          => 'integer',
+			'apple_news_coverimage_caption'  => 'textarea',
+			'apple_news_is_hidden'           => 'boolean',
+			'apple_news_is_paid'             => 'boolean',
+			'apple_news_is_preview'          => 'boolean',
+			'apple_news_is_sponsored'        => 'boolean',
+			'apple_news_pullquote'           => 'string',
+			'apple_news_pullquote_position'  => 'string',
+			'apple_news_slug'                => 'string',
+			'apple_news_suppress_video_url'  => 'boolean',
 			'apple_news_use_image_component' => 'boolean',
 		];
 		foreach ( $fields as $meta_key => $type ) {

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -169,6 +169,10 @@ class Admin_Apple_News extends Apple_News {
 					'default' => false,
 					'type'    => 'boolean',
 				],
+				'apple_news_use_image_component' => [
+					'default' => false,
+					'type'    => 'boolean',
+				],
 			];
 
 			// Loop over postmeta fields and register each.

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -99,48 +99,48 @@ class Admin_Apple_News extends Apple_News {
 
 			// Define custom postmeta fields to register.
 			$postmeta = [
-				'apple_news_api_created_at'     => [
+				'apple_news_api_created_at'      => [
 					'default' => '',
 				],
-				'apple_news_api_id'             => [
+				'apple_news_api_id'              => [
 					'default' => '',
 				],
-				'apple_news_api_modified_at'    => [
+				'apple_news_api_modified_at'     => [
 					'default' => '',
 				],
-				'apple_news_api_revision'       => [
+				'apple_news_api_revision'        => [
 					'default' => '',
 				],
-				'apple_news_api_share_url'      => [
+				'apple_news_api_share_url'       => [
 					'default' => '',
 				],
-				'apple_news_coverimage'         => [
+				'apple_news_coverimage'          => [
 					'default' => 0,
 					'type'    => 'integer',
 				],
-				'apple_news_coverimage_caption' => [
+				'apple_news_coverimage_caption'  => [
 					'default' => '',
 				],
-				'apple_news_is_hidden'          => [
+				'apple_news_is_hidden'           => [
 					'default' => false,
 					'type'    => 'boolean',
 				],
-				'apple_news_is_paid'            => [
+				'apple_news_is_paid'             => [
 					'default' => false,
 					'type'    => 'boolean',
 				],
-				'apple_news_is_preview'         => [
+				'apple_news_is_preview'          => [
 					'default' => false,
 					'type'    => 'boolean',
 				],
-				'apple_news_is_sponsored'       => [
+				'apple_news_is_sponsored'        => [
 					'default' => false,
 					'type'    => 'boolean',
 				],
-				'apple_news_maturity_rating'    => [
+				'apple_news_maturity_rating'     => [
 					'default' => '',
 				],
-				'apple_news_metadata'           => [
+				'apple_news_metadata'            => [
 					'default'           => '',
 					'sanitize_callback' => function ( $value ) {
 						return ! empty( $value ) && is_string( $value ) ? json_decode( $value, true ) : $value;
@@ -149,23 +149,23 @@ class Admin_Apple_News extends Apple_News {
 						'prepare_callback' => 'apple_news_json_encode',
 					],
 				],
-				'apple_news_pullquote'          => [
+				'apple_news_pullquote'           => [
 					'default' => '',
 				],
-				'apple_news_pullquote_position' => [
+				'apple_news_pullquote_position'  => [
 					'default' => '',
 				],
-				'apple_news_slug'               => [
+				'apple_news_slug'                => [
 					'default' => '',
 				],
-				'apple_news_sections'           => [
+				'apple_news_sections'            => [
 					'default'           => '',
 					'sanitize_callback' => 'apple_news_sanitize_selected_sections',
 					'show_in_rest'      => [
 						'prepare_callback' => 'apple_news_json_encode',
 					],
 				],
-				'apple_news_suppress_video_url' => [
+				'apple_news_suppress_video_url'  => [
 					'default' => false,
 					'type'    => 'boolean',
 				],

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -72,6 +72,11 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 			<strong><?php esc_html_e( 'Do not set videoURL metadata for this article', 'apple-news' ); ?></strong>
 		</label>
 		<p><?php esc_html_e( 'Check this to prevent video thumbnails for this article.', 'apple-news' ); ?></p>
+		<label for="apple-news-use-image-component">
+			<input id="apple-news-use-image-component" name="apple_news_use_image_component" type="checkbox" value="1" <?php checked( $use_image_component ); ?>>
+			<strong><?php esc_html_e( 'Image component type toggle', 'apple-news' ); ?></strong>
+		</label>
+		<p><?php esc_html_e( 'Check this to use Image instead of Photo components for parsed images.', 'apple-news' ); ?></p>
 		<h4><?php esc_html_e( 'Custom Metadata', 'apple-news' ); ?></h4>
 		<?php Admin_Apple_Meta_Boxes::build_metadata( $post->ID ); ?>
 		<button class="button-primary apple-news-metadata-add">

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -74,9 +74,9 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 		<p><?php esc_html_e( 'Check this to prevent video thumbnails for this article.', 'apple-news' ); ?></p>
 		<label for="apple-news-use-image-component">
 			<input id="apple-news-use-image-component" name="apple_news_use_image_component" type="checkbox" value="1" <?php checked( $use_image_component ); ?>>
-			<strong><?php esc_html_e( 'Image component type toggle', 'apple-news' ); ?></strong>
+			<strong><?php esc_html_e( 'Use Image component for images', 'apple-news' ); ?></strong>
 		</label>
-		<p><?php esc_html_e( 'Check this to use Image instead of Photo components for parsed images.', 'apple-news' ); ?></p>
+		<p><?php esc_html_e( 'Check this to use an Image instead of a Photo component for images in this article.', 'apple-news' ); ?></p>
 		<h4><?php esc_html_e( 'Custom Metadata', 'apple-news' ); ?></h4>
 		<?php Admin_Apple_Meta_Boxes::build_metadata( $post->ID ); ?>
 		<button class="button-primary apple-news-metadata-add">

--- a/assets/js/pluginsidebar/panels/metadata.jsx
+++ b/assets/js/pluginsidebar/panels/metadata.jsx
@@ -68,8 +68,8 @@ const Metadata = ({
     />
     <CheckboxControl
       checked={useImageComponent}
-      help={__('Check this to use Image instead of Photo components for parsed images.', 'apple-news')}
-      label={__('Image component type toggle.', 'apple-news')}
+      help={__('Check this to use an Image instead of a Photo component for images in this article.', 'apple-news')}
+      label={__('Use Image component for images.', 'apple-news')}
       onChange={onChangeUseImageComponent}
     />
     <h3>{__('Custom Metadata', 'apple-news')}</h3>

--- a/assets/js/pluginsidebar/panels/metadata.jsx
+++ b/assets/js/pluginsidebar/panels/metadata.jsx
@@ -28,7 +28,9 @@ const Metadata = ({
   onChangeIsSponsored,
   onChangeMetadata,
   onChangeSuppressVideoURL,
+  onChangeUseImageComponent,
   suppressVideoURL,
+  useImageComponent,
 }) => (
   <PanelBody
     initialOpen={false}
@@ -63,6 +65,12 @@ const Metadata = ({
       help={__('Check this to prevent video thumbnails for this article.', 'apple-news')}
       label={__('Do not set videoURL metadata for this article', 'apple-news')}
       onChange={onChangeSuppressVideoURL}
+    />
+    <CheckboxControl
+      checked={useImageComponent}
+      help={__('Check this to use Image instead of Photo components for parsed images.', 'apple-news')}
+      label={__('Image component type toggle.', 'apple-news')}
+      onChange={onChangeUseImageComponent}
     />
     <h3>{__('Custom Metadata', 'apple-news')}</h3>
     {metadata.map(({ key, type, value }, index) => (
@@ -133,7 +141,9 @@ Metadata.propTypes = {
   onChangeIsSponsored: PropTypes.func.isRequired,
   onChangeMetadata: PropTypes.func.isRequired,
   onChangeSuppressVideoURL: PropTypes.func.isRequired,
+  onChangeUseImageComponent: PropTypes.func.isRequired,
   suppressVideoURL: PropTypes.bool.isRequired,
+  useImageComponent: PropTypes.bool.isRequired,
 };
 
 export default Metadata;

--- a/assets/js/pluginsidebar/sidebar.jsx
+++ b/assets/js/pluginsidebar/sidebar.jsx
@@ -94,6 +94,7 @@ const Sidebar = () => {
   const [selectedSectionsRaw, setSelectedSectionsRaw] = usePostMetaValue('apple_news_sections');
   const [slug, setSlug] = usePostMetaValue('apple_news_slug');
   const [suppressVideoURL, setSuppressVideoURL] = usePostMetaValue('apple_news_suppress_video_url');
+  const [useImageComponent, setUseImageComponent] = usePostMetaValue('apple_news_use_image_component');
 
   // Decode selected sections.
   const metadata = safeJsonParseArray(metadataRaw);
@@ -238,7 +239,9 @@ const Sidebar = () => {
           onChangeIsSponsored={setIsSponsored}
           onChangeMetadata={setMetadata}
           onChangeSuppressVideoURL={setSuppressVideoURL}
+          onChangeUseImageComponent={setUseImageComponent}
           suppressVideoURL={suppressVideoURL}
+          useImageComponent={useImageComponent}
         />
         <MaturityRating
           maturityRating={maturityRating}

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -461,7 +461,6 @@ class Components extends Builder {
 
 			// Add some buffer for the caption.
 			$ratio /= 1.2;
-			// Here...
 		} elseif ( ( 'photo' === $component['role'] || 'image' === $component['role'] ) && ! empty( $component['URL'] ) ) {
 			$ratio = $this->get_image_ratio( $component['URL'] );
 		}

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -461,7 +461,8 @@ class Components extends Builder {
 
 			// Add some buffer for the caption.
 			$ratio /= 1.2;
-		} elseif ( 'photo' === $component['role'] && ! empty( $component['URL'] ) ) {
+			// Here...
+		} elseif ( ( 'photo' === $component['role'] || 'image' === $component['role'] ) && ! empty( $component['URL'] ) ) {
 			$ratio = $this->get_image_ratio( $component['URL'] );
 		}
 

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -172,7 +172,7 @@ class Cover extends Component {
 			return;
 		}
 
-		// Use postmeta to determine if component will be registered as an Image or Photo.
+		// Use postmeta to determine if component role should be registered as 'image' or 'photo'.
 		$use_image = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
 		$role      = $use_image ? 'image' : 'photo';
 

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -37,7 +37,7 @@ class Cover extends Component {
 				'layout'     => 'headerPhotoLayout',
 				'components' => [
 					[
-						'role'   => 'photo',
+						'role'   => '#role#',
 						'layout' => 'headerPhotoLayout',
 						'URL'    => '#url#',
 					],
@@ -70,7 +70,7 @@ class Cover extends Component {
 				'layout'     => 'headerPhotoLayout',
 				'components' => [
 					[
-						'role'    => 'photo',
+						'role'    => '#role#',
 						'layout'  => 'headerPhotoLayoutWithCaption',
 						'URL'     => '#url#',
 						'caption' => [
@@ -172,6 +172,10 @@ class Cover extends Component {
 			return;
 		}
 
+		// Use postmeta to determine if component will be registered as an Image or Photo.
+		$use_image = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$role      = $use_image ? 'image' : 'photo';
+
 		// Fork for caption vs. not.
 		if ( ! empty( $options['caption'] )
 			&& true === $theme->get_value( 'cover_caption' )
@@ -180,6 +184,7 @@ class Cover extends Component {
 				'jsonWithCaption',
 				[
 					'#caption#'          => $options['caption'],
+					'#role#'             => $role,
 					'#url#'              => $url,
 					'#caption_tracking#' => intval( $theme->get_value( 'caption_tracking' ) ) / 100,
 				]
@@ -188,7 +193,8 @@ class Cover extends Component {
 			$this->register_json(
 				'json',
 				[
-					'#url#' => $url,
+					'#role#' => $role,
+					'#url#'  => $url,
 				]
 			);
 		}

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -173,16 +173,8 @@ class Cover extends Component {
 		}
 
 		// Use postmeta to determine if component role should be registered as 'image' or 'photo'.
-		$use_image  = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
-		$image_type = $use_image ? 'image' : 'photo';
-
-		/**
-		 * Allows for an image src value to be filtered before being applied.
-		 *
-		 * @param string $image_type The image component type as determined by postmeta ('image' or 'photo').
-		 * @param string $options    The options based to the cover's build method.
-		 */
-		$role = apply_filters( 'apple_news_build_cover_img_role', $image_type, $options );
+		$use_image = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$role      = $use_image ? 'image' : 'photo';
 
 		// Fork for caption vs. not.
 		if ( ! empty( $options['caption'] )

--- a/includes/apple-exporter/components/class-cover.php
+++ b/includes/apple-exporter/components/class-cover.php
@@ -173,8 +173,16 @@ class Cover extends Component {
 		}
 
 		// Use postmeta to determine if component role should be registered as 'image' or 'photo'.
-		$use_image = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
-		$role      = $use_image ? 'image' : 'photo';
+		$use_image  = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$image_type = $use_image ? 'image' : 'photo';
+
+		/**
+		 * Allows for an image src value to be filtered before being applied.
+		 *
+		 * @param string $image_type The image component type as determined by postmeta ('image' or 'photo').
+		 * @param string $options    The options based to the cover's build method.
+		 */
+		$role = apply_filters( 'apple_news_build_cover_img_role', $image_type, $options );
 
 		// Fork for caption vs. not.
 		if ( ! empty( $options['caption'] )

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -194,16 +194,8 @@ class Image extends Component {
 		];
 
 		// Use postmeta to determine if component role should be registered as 'image' or 'photo'.
-		$use_image  = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
-		$image_type = $use_image ? 'image' : 'photo';
-
-		/**
-		 * Allows for an image src value to be filtered before being applied.
-		 *
-		 * @param string $image_type The image component type as determined by postmeta ('image' or 'photo').
-		 * @param string $text       The raw text that was parsed from the article.
-		 */
-		$values['#role#'] = apply_filters( 'apple_news_build_img_role', $image_type, $html );
+		$use_image        = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$values['#role#'] = $use_image ? 'image' : 'photo';
 
 		// Determine image alignment.
 		if ( false !== stripos( $html, 'align="left"' )

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -61,7 +61,7 @@ class Image extends Component {
 			'json-without-caption',
 			__( 'JSON without caption', 'apple-news' ),
 			[
-				'role'   => 'photo',
+				'role'   => '#role#',
 				'URL'    => '#url#',
 				'layout' => '#layout#',
 			]
@@ -87,7 +87,7 @@ class Image extends Component {
 				'role'       => 'container',
 				'components' => [
 					[
-						'role'    => 'photo',
+						'role'    => '#role#',
 						'URL'     => '#url#',
 						'layout'  => '#layout#',
 						'caption' => [
@@ -192,6 +192,10 @@ class Image extends Component {
 		$values   = [
 			'#url#' => $this->maybe_bundle_source( $url, $filename ),
 		];
+
+		// Use postmeta to determine if component will be registered as an Image or Photo.
+		$use_image = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$values['#role#'] = $use_image ? 'image' : 'photo';
 
 		// Determine image alignment.
 		if ( false !== stripos( $html, 'align="left"' )

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -194,8 +194,16 @@ class Image extends Component {
 		];
 
 		// Use postmeta to determine if component role should be registered as 'image' or 'photo'.
-		$use_image        = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
-		$values['#role#'] = $use_image ? 'image' : 'photo';
+		$use_image  = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$image_type = $use_image ? 'image' : 'photo';
+
+		/**
+		 * Allows for an image src value to be filtered before being applied.
+		 *
+		 * @param string $image_type The image component type as determined by postmeta ('image' or 'photo').
+		 * @param string $text       The raw text that was parsed from the article.
+		 */
+		$values['#role#'] = apply_filters( 'apple_news_build_img_role', $image_type, $html );
 
 		// Determine image alignment.
 		if ( false !== stripos( $html, 'align="left"' )

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -194,7 +194,7 @@ class Image extends Component {
 		];
 
 		// Use postmeta to determine if component will be registered as an Image or Photo.
-		$use_image = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
+		$use_image        = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
 		$values['#role#'] = $use_image ? 'image' : 'photo';
 
 		// Determine image alignment.

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -193,7 +193,7 @@ class Image extends Component {
 			'#url#' => $this->maybe_bundle_source( $url, $filename ),
 		];
 
-		// Use postmeta to determine if component will be registered as an Image or Photo.
+		// Use postmeta to determine if component role should be registered as 'image' or 'photo'.
 		$use_image        = get_post_meta( $this->workspace->content_id, 'apple_news_use_image_component', true );
 		$values['#role#'] = $use_image ? 'image' : 'photo';
 

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -57,6 +57,28 @@ class Apple_News_Cover_Test extends Apple_News_Testcase {
 		remove_filter( 'apple_news_cover_json', [ $this, 'filter_apple_news_cover_json' ] );
 	}
 
+	public function test_cover_role() {
+		// Create test post.
+		$post_id = self::factory()->post->create();
+
+		// Create a new attachment and assign it as the featured image for the cover component. 
+		set_post_thumbnail( 
+			$post_id, 
+			$this->get_new_attachment( 0 ) 
+		);
+
+		// Check that the cover component's default role is 'photo'.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'photo', $json['components'][0]['components'][0]['role'] );
+
+		// Toggle component type meta.
+		update_post_meta( $post_id, 'apple_news_use_image_component', true );
+
+		// Check that the cover component's role is now 'image' after meta toggle.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'image', $json['components'][0]['components'][0]['role'] );
+	}
+
 	/**
 	 * Ensures that the lightbox font is set to the same font face as the image caption.
 	 */

--- a/tests/apple-exporter/components/test-class-cover.php
+++ b/tests/apple-exporter/components/test-class-cover.php
@@ -57,6 +57,9 @@ class Apple_News_Cover_Test extends Apple_News_Testcase {
 		remove_filter( 'apple_news_cover_json', [ $this, 'filter_apple_news_cover_json' ] );
 	}
 
+	/**
+	 * Test cover component role ('image' or 'photo') based on postmeta selection.
+	 */
 	public function test_cover_role() {
 		// Create test post.
 		$post_id = self::factory()->post->create();

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -31,24 +31,31 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 	}
 
 	/**
-	 * Test component type ('image' or 'photo') postmeta selection.
+	 * Test component role ('image' or 'photo') postmeta selection.
 	 */
-	public function test_component_type() {
+	public function test_component_role() {
 		// Create test post.
 		$post_id = self::factory()->post->create(
 			[
-				// First img becomes cover, second img is output as standard json component.
-				'post_content' => '<img src="https://placeimg.com/640/480/any" alt="Example Cover" /><img src="https://placeimg.com/640/480/any" alt="Example Image" />',
+				'post_content' => '<img src="https://placeimg.com/640/480/any" alt="Example" />',
 			]
 		);
+
+		// Create a new attachment and assign it as the featured image for the cover component. 
+		set_post_thumbnail( 
+			$post_id, 
+			$this->get_new_attachment( 0 ) 
+		); 
+
+		// Check that the default component role is 'photo'.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'photo', $json['components'][1]['components'][3]['role'] );
 
 		// Toggle component type meta.
 		update_post_meta( $post_id, 'apple_news_use_image_component', true );
 
+		// Check that the component role is now 'image' after meta toggle.
 		$json = $this->get_json_for_post( $post_id );
-		// Test cover image role.
-		$this->assertEquals( 'image', $json['components'][0]['components'][0]['role'] );
-		// Test second image role.
 		$this->assertEquals( 'image', $json['components'][1]['components'][3]['role'] );
 	}
 

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -31,6 +31,28 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 	}
 
 	/**
+	 * Test component type ('image' or 'photo') postmeta selection.
+	 */
+	public function test_component_type() {
+		// Create test post.
+		$post_id = self::factory()->post->create(
+			[
+				// First img becomes cover, second img is output as json component.
+				'post_content' => '<img src="https://placeimg.com/640/480/any" alt="Example Cover" /><img src="https://placeimg.com/640/480/any" alt="Example Image" />',
+			]
+		);
+
+		// Toggle component type meta.
+		update_post_meta( $post_id, 'apple_news_use_image_component', true );
+
+		$json = $this->get_json_for_post( $post_id );
+		// Test cover image role.
+		$this->assertEquals( 'image', $json['components'][0]['components'][0]['role'] );
+		// Test second image role.
+		$this->assertEquals( 'image', $json['components'][1]['components'][3]['role'] );
+	}
+
+	/**
 	 * Test Image component matching and JSON
 	 * output with HTML markup for an image.
 	 */

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -31,7 +31,7 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 	}
 
 	/**
-	 * Test component role ('image' or 'photo') postmeta selection.
+	 * Test component role ('image' or 'photo') based on postmeta selection.
 	 */
 	public function test_component_role() {
 		// Create test post.

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -37,7 +37,7 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 		// Create test post.
 		$post_id = self::factory()->post->create(
 			[
-				// First img becomes cover, second img is output as json component.
+				// First img becomes cover, second img is output as standard json component.
 				'post_content' => '<img src="https://placeimg.com/640/480/any" alt="Example Cover" /><img src="https://placeimg.com/640/480/any" alt="Example Image" />',
 			]
 		);


### PR DESCRIPTION
## What does this PR do?

1. Creates user configurable `apple_news_use_image_component` postmeta (adds checkbox to classic and block editor pages).
2. Uses new postmeta value to conditionally apply `'image'` or `'photo'` roles to parsed `class-image` and `class-cover` component json.
3. Adds tests to `test-class-image` and `test-class-cover` to check new logic.

