### PR TITLE
APPLE-142 Fix dark mode table styles

### DIFF
--- a/includes/apple-exporter/components/class-table.php
+++ b/includes/apple-exporter/components/class-table.php
@@ -240,6 +240,8 @@ class Table extends Component {
 				$dark_table_styles['tableStyle']['columns']['divider']['color'] = '#table_border_color_dark#';
 				// Row borders.
 				$dark_table_styles['tableStyle']['rows']['divider']['color'] = '#table_border_color_dark#';
+				// Header row borders.
+				$dark_table_styles['tableStyle']['headerRows']['divider']['color'] = '#table_border_color_dark#';
 			}
 
 			$this->register_spec(

--- a/includes/apple-exporter/components/class-table.php
+++ b/includes/apple-exporter/components/class-table.php
@@ -75,20 +75,17 @@ class Table extends Component {
 			! empty( $table_header_background_color_dark ) ||
 			! empty( $table_header_color_dark );
 
-		$dark_table_conditional = [];
-		if ( $this->dark_table_colors_exist ) {
-			$dark_table_conditional = [
-				'conditional' => [
-					[
-						'style'      => 'dark-table',
-						'conditions' => [
-							'minSpecVersion'       => '1.14',
-							'preferredColorScheme' => 'dark',
-						],
+		$dark_table_conditional = $this->dark_table_colors_exist ? [
+			'conditional' => [
+				[
+					'style'      => 'dark-table',
+					'conditions' => [
+						'minSpecVersion'       => '1.14',
+						'preferredColorScheme' => 'dark',
 					],
 				],
-			];
-		}
+			],
+		] : [];
 
 		// Register the JSON for the table itself.
 		$this->register_spec(

--- a/includes/apple-exporter/components/class-table.php
+++ b/includes/apple-exporter/components/class-table.php
@@ -16,6 +16,13 @@ namespace Apple_Exporter\Components;
 class Table extends Component {
 
 	/**
+	 * Whether dark mode table colors exist.
+	 *
+	 * @var boolean
+	 */
+	private $dark_table_colors_exist;
+
+	/**
 	 * Look for node matches for this component.
 	 *
 	 * @param \DOMElement $node The node to examine for matches.
@@ -53,30 +60,66 @@ class Table extends Component {
 		// Get information about the currently loaded theme.
 		$theme = \Apple_Exporter\Theme::get_used();
 
+		// Get Dark Table Colors.
+		$table_border_color_dark            = $theme->get_value( 'table_border_color_dark' );
+		$table_body_background_color_dark   = $theme->get_value( 'table_body_background_color_dark' );
+		$table_body_color_dark              = $theme->get_value( 'table_body_color_dark' );
+		$table_header_background_color_dark = $theme->get_value( 'table_header_background_color_dark' );
+		$table_header_color_dark            = $theme->get_value( 'table_header_color_dark' );
+
+		// If all dark table styles are empty, do not add conditional styles.
+		$this->dark_table_colors_exist =
+			! empty( $table_border_color_dark ) ||
+			! empty( $table_body_background_color_dark ) ||
+			! empty( $table_body_color_dark ) ||
+			! empty( $table_header_background_color_dark ) ||
+			! empty( $table_header_color_dark );
+
+		$dark_table_conditional = [];
+		if ( $this->dark_table_colors_exist ) {
+			$dark_table_conditional = [
+				'conditional' => [
+					[
+						'style'      => 'dark-table',
+						'conditions' => [
+							'minSpecVersion'       => '1.14',
+							'preferredColorScheme' => 'dark',
+						],
+					],
+				],
+			];
+		}
+
 		// Register the JSON for the table itself.
 		$this->register_spec(
 			'json',
 			__( 'JSON', 'apple-news' ),
-			[
-				'role'   => 'htmltable',
-				'html'   => '#html#',
-				'layout' => 'table-layout',
-				'style'  => 'default-table',
-			]
+			array_merge(
+				[
+					'role'   => 'htmltable',
+					'html'   => '#html#',
+					'layout' => 'table-layout',
+					'style'  => 'default-table',
+				],
+				$dark_table_conditional
+			)
 		);
 		$this->register_spec(
 			'json-with-caption-text',
 			__( 'JSON With Caption Text', 'apple-news' ),
 			[
 				'role'       => 'container',
-				// Table Component.
 				'components' => [
-					[
-						'role'   => 'htmltable',
-						'html'   => '#html#',
-						'layout' => 'table-layout',
-						'style'  => 'default-table',
-					],
+					// Table Component.
+					array_merge(
+						[
+							'role'   => 'htmltable',
+							'html'   => '#html#',
+							'layout' => 'table-layout',
+							'style'  => 'default-table',
+						],
+						$dark_table_conditional
+					),
 					// Caption Component.
 					[
 						'role'   => 'caption',
@@ -98,212 +141,113 @@ class Table extends Component {
 			]
 		);
 
-		// Register the JSON for the table style.
-		$table_cell_base_conditional    = [];
-		$table_row_col_base_conditional = [];
-		// Get Dark Table Colors.
-		$table_border_color_dark            = $theme->get_value( 'table_border_color_dark' );
-		$table_body_background_color_dark   = $theme->get_value( 'table_body_background_color_dark' );
-		$table_body_color_dark              = $theme->get_value( 'table_body_color_dark' );
-		$table_header_background_color_dark = $theme->get_value( 'table_header_background_color_dark' );
-		$table_header_color_dark            = $theme->get_value( 'table_header_color_dark' );
-
-		// If all are empty, do not add conditional styles.
-		$dark_table_colors_exist =
-			! empty( $table_border_color_dark ) ||
-			! empty( $table_body_background_color_dark ) ||
-			! empty( $table_body_color_dark ) ||
-			! empty( $table_header_background_color_dark ) ||
-			! empty( $table_header_color_dark );
-		if ( $dark_table_colors_exist ) {
-			$table_cell_base_conditional    = [
-				[
-					'selectors'  => [
-						[ 'evenRows' => true ],
-						[ 'oddRows' => true ],
+		$default_table_styles = [
+			'border'     => [
+				'all' => [
+					'color' => '#table_border_color#',
+					'style' => '#table_border_style#',
+					'width' => '#table_border_width#',
+				],
+			],
+			'tableStyle' => [
+				'cells'       => [
+					'backgroundColor'     => '#table_body_background_color#',
+					'horizontalAlignment' => '#table_body_horizontal_alignment#',
+					'padding'             => '#table_body_padding#',
+					'textStyle'           => [
+						'fontName'   => '#table_body_font#',
+						'fontSize'   => '#table_body_size#',
+						'lineHeight' => '#table_body_line_height#',
+						'textColor'  => '#table_body_color#',
+						'tracking'   => '#table_body_tracking#',
 					],
-					'conditions' => [
-						'minSpecVersion'       => '1.14',
-						'preferredColorScheme' => 'dark',
+					'verticalAlignment'   => '#table_body_vertical_alignment#',
+				],
+				'columns'     => [
+					'divider' => [
+						'color' => '#table_border_color#',
+						'style' => '#table_border_style#',
+						'width' => '#table_border_width#',
 					],
 				],
-			];
-			$table_row_col_base_conditional = [
-				[
-					'selectors'  => [
-						[ 'even' => true ],
-						[ 'odd' => true ],
+				'headerCells' => [
+					'backgroundColor'     => '#table_header_background_color#',
+					'horizontalAlignment' => '#table_header_horizontal_alignment#',
+					'padding'             => '#table_header_padding#',
+					'textStyle'           => [
+						'fontName'   => '#table_header_font#',
+						'fontSize'   => '#table_header_size#',
+						'lineHeight' => '#table_header_line_height#',
+						'textColor'  => '#table_header_color#',
+						'tracking'   => '#table_header_tracking#',
 					],
-					'conditions' => [
-						'minSpecVersion'       => '1.14',
-						'preferredColorScheme' => 'dark',
+					'verticalAlignment'   => '#table_header_vertical_alignment#',
+				],
+				'headerRows'  => [
+					'divider' => [
+						'color' => '#table_border_color#',
+						'style' => '#table_border_style#',
+						'width' => '#table_border_width#',
 					],
 				],
-			];
-		}
-
-		// The following block sets:
-		// Dark Background Color of Cells
-		// Dark Text Color of Cells.
-		$dark_bg_text_conditional = [];
-		if (
-			! empty( $table_body_background_color_dark ) ||
-			! empty( $table_body_color_dark )
-		) {
-			$dark_bg_text_conditional = [
-				'conditional' => [ $table_cell_base_conditional[0] ],
-			];
-		}
-
-		if ( ! empty( $table_body_background_color_dark ) ) {
-			$dark_bg_text_conditional['conditional'][0]['backgroundColor'] = '#table_body_background_color_dark#';
-		}
-
-		if ( ! empty( $table_body_color_dark ) ) {
-			$dark_bg_text_conditional['conditional'][0]['textStyle'] = [
-				'textColor' => '#table_body_color_dark#',
-			];
-		}
-
-		// The following block sets:
-		// Dark Header Background Color of Cells
-		// Dark Header Text Color of Cells.
-		$dark_header_bg_text_conditional = [];
-		if (
-			! empty( $table_body_background_color_dark ) ||
-			! empty( $table_body_color_dark )
-		) {
-			$dark_header_bg_text_conditional = [
-				'conditional' => [ $table_cell_base_conditional[0] ],
-			];
-		}
-
-		if ( ! empty( $table_header_background_color_dark ) ) {
-			$dark_header_bg_text_conditional['conditional'][0]['backgroundColor'] = '#table_header_background_color_dark#';
-		}
-
-		if ( ! empty( $table_header_color_dark ) ) {
-			$dark_header_bg_text_conditional['conditional'][0]['textStyle'] = [
-				'textColor' => '#table_header_color_dark#',
-			];
-		}
-
-		// Set Dark Border for Columns.
-		$dark_inner_border_conditional = [];
-		if ( ! empty( $table_border_color_dark ) ) {
-			$dark_inner_border_conditional = [
-				'conditional' => [
-					$table_row_col_base_conditional[0] + [
-						'divider' => [
-							'color' => '#table_border_color_dark#',
-							'style' => '#table_border_style#',
-							'width' => '#table_border_width#',
-						],
+				'rows'        => [
+					'divider' => [
+						'color' => '#table_border_color#',
+						'style' => '#table_border_style#',
+						'width' => '#table_border_width#',
 					],
 				],
-			];
-		}
-
-		// Set Dark Outer Border for Table.
-		$dark_outer_border_conditional = [];
-		if ( ! empty( $table_border_color_dark ) ) {
-			$dark_outer_border_conditional = [
-				'conditional' => [
-					'border'     => [
-						'all' => [
-							'color' => '#table_border_color_dark#',
-							'style' => '#table_border_style#',
-							'width' => '#table_border_width#',
-						],
-					],
-					'conditions' => [
-						'minSpecVersion'       => '1.14',
-						'preferredColorScheme' => 'dark',
-					],
-				],
-			];
-		}
+			],
+		];
 
 		$this->register_spec(
 			'default-table',
 			__( 'Table Style', 'apple-news' ),
-			array_merge(
-				[
-					'border'     => [
-						'all' => [
-							'color' => '#table_border_color#',
-							'style' => '#table_border_style#',
-							'width' => '#table_border_width#',
-						],
-					],
-					'tableStyle' => [
-						'cells'       => array_merge(
-							[
-								'backgroundColor'     => '#table_body_background_color#',
-								'horizontalAlignment' => '#table_body_horizontal_alignment#',
-								'padding'             => '#table_body_padding#',
-								'textStyle'           => [
-									'fontName'   => '#table_body_font#',
-									'fontSize'   => '#table_body_size#',
-									'lineHeight' => '#table_body_line_height#',
-									'textColor'  => '#table_body_color#',
-									'tracking'   => '#table_body_tracking#',
-								],
-								'verticalAlignment'   => '#table_body_vertical_alignment#',
-							],
-							$dark_bg_text_conditional
-						),
-						'columns'     => array_merge(
-							[
-								'divider' => [
-									'color' => '#table_border_color#',
-									'style' => '#table_border_style#',
-									'width' => '#table_border_width#',
-								],
-							],
-							$dark_inner_border_conditional
-						),
-						'headerCells' => array_merge(
-							[
-								'backgroundColor'     => '#table_header_background_color#',
-								'horizontalAlignment' => '#table_header_horizontal_alignment#',
-								'padding'             => '#table_header_padding#',
-								'textStyle'           => [
-									'fontName'   => '#table_header_font#',
-									'fontSize'   => '#table_header_size#',
-									'lineHeight' => '#table_header_line_height#',
-									'textColor'  => '#table_header_color#',
-									'tracking'   => '#table_header_tracking#',
-								],
-								'verticalAlignment'   => '#table_header_vertical_alignment#',
-							],
-							$dark_header_bg_text_conditional
-						),
-						'headerRows'  => array_merge(
-							[
-								'divider' => [
-									'color' => '#table_border_color#',
-									'style' => '#table_border_style#',
-									'width' => '#table_border_width#',
-								],
-							],
-							$dark_inner_border_conditional
-						),
-						'rows'        => array_merge(
-							[
-								'divider' => [
-									'color' => '#table_border_color#',
-									'style' => '#table_border_style#',
-									'width' => '#table_border_width#',
-								],
-							],
-							$dark_inner_border_conditional
-						),
-					],
-				],
-				$dark_outer_border_conditional
-			)
+			$default_table_styles
 		);
+
+		if ( $this->dark_table_colors_exist ) {
+
+			// Start with default-table styles as a base.
+			// Then modify dark styles where applicable.
+			$dark_table_styles = $default_table_styles;
+
+			// Set cell background color.
+			if ( ! empty( $table_body_background_color_dark ) ) {
+				$dark_table_styles['tableStyle']['cells']['backgroundColor'] = '#table_body_background_color_dark#';
+			}
+
+			// Set cell text color.
+			if ( ! empty( $table_body_color_dark ) ) {
+				$dark_table_styles['tableStyle']['cells']['textStyle']['textColor'] = '#table_body_color_dark#';
+			}
+
+			// Set header cell background color.
+			if ( ! empty( $table_header_background_color_dark ) ) {
+				$dark_table_styles['tableStyle']['headerCells']['backgroundColor'] = '#table_header_background_color_dark#';
+			}
+
+			// Set header text color.
+			if ( ! empty( $table_header_color_dark ) ) {
+				$dark_table_styles['tableStyle']['headerCells']['textStyle']['textColor'] = '#table_header_color_dark#';
+			}
+
+			// Set border colors.
+			if ( ! empty( $table_border_color_dark ) ) {
+				// Table outer border.
+				$dark_table_styles['border']['all']['color'] = '#table_border_color_dark#';
+				// Column borders.
+				$dark_table_styles['tableStyle']['columns']['divider']['color'] = '#table_border_color_dark#';
+				// Row borders.
+				$dark_table_styles['tableStyle']['rows']['divider']['color'] = '#table_border_color_dark#';
+			}
+
+			$this->register_spec(
+				'dark-table',
+				__( 'Dark Table Style', 'apple-news' ),
+				$dark_table_styles
+			);
+		}
 	}
 
 	/**
@@ -358,6 +302,14 @@ class Table extends Component {
 			'default-table',
 			'default-table'
 		);
+
+		// Register dark mode styles, if applicable.
+		if ( $this->dark_table_colors_exist ) {
+			$this->register_component_style(
+				'dark-table',
+				'dark-table'
+			);
+		}
 	}
 
 	/**

--- a/tests/apple-exporter/components/test-class-table.php
+++ b/tests/apple-exporter/components/test-class-table.php
@@ -118,7 +118,7 @@ HTML;
 
 
 	/**
-	 * Tests table settings.
+	 * Tests dark mode colors.
 	 */
 	public function test_dark_colors() {
 
@@ -146,54 +146,92 @@ HTML;
 		$this->ensure_tokens_replaced( $json );
 		$json = json_decode( $json, true );
 
-		// Ensure conditionals are set
-		// Outer Table Border.
-		$this->assertTrue( isset( $json['componentStyles']['default-table']['conditional'] ) );
-		// Background Color, Text Color.
-		$this->assertTrue( isset( $json['componentStyles']['default-table']['tableStyle']['cells']['conditional'] ) );
-		// Column Border.
-		$this->assertTrue( isset( $json['componentStyles']['default-table']['tableStyle']['columns']['conditional'] ) );
-		// Row Border.
-		$this->assertTrue( isset( $json['componentStyles']['default-table']['tableStyle']['rows']['conditional'] ) );
-		// Header Border.
-		$this->assertTrue( isset( $json['componentStyles']['default-table']['tableStyle']['headerRows']['conditional'] ) );
-		// Header Background, Header Text Color.
-		$this->assertTrue( isset( $json['componentStyles']['default-table']['tableStyle']['headerCells']['conditional'] ) );
+		// Ensure component level conditional is set.
+		$this->assertEquals(
+			'dark-table',
+			$json['components'][1]['conditional'][0]['style'],
+		);
 
-		// Ensure Color Values match.
+		// Ensure border color values match.
 		$this->assertEquals(
 			'#abcdef',
-			$json['componentStyles']['default-table']['conditional']['border']['all']['color']
+			$json['componentStyles']['dark-table']['border']['all']['color']
 		);
 		$this->assertEquals(
+			'#abcdef',
+			$json['componentStyles']['dark-table']['tableStyle']['columns']['divider']['color']
+		);
+		$this->assertEquals(
+			'#abcdef',
+			$json['componentStyles']['dark-table']['tableStyle']['rows']['divider']['color']
+		);
+		$this->assertEquals(
+			'#abcdef',
+			$json['componentStyles']['dark-table']['tableStyle']['headerRows']['divider']['color']
+		);
+
+		// Ensure cell background and text colors match.
+		$this->assertEquals(
 			'#fedcba',
-			$json['componentStyles']['default-table']['tableStyle']['cells']['conditional'][0]['backgroundColor']
+			$json['componentStyles']['dark-table']['tableStyle']['cells']['backgroundColor']
 		);
 		$this->assertEquals(
 			'#123456',
-			$json['componentStyles']['default-table']['tableStyle']['cells']['conditional'][0]['textStyle']['textColor']
+			$json['componentStyles']['dark-table']['tableStyle']['cells']['textStyle']['textColor']
 		);
 
-		$this->assertEquals(
-			'#abcdef',
-			$json['componentStyles']['default-table']['tableStyle']['columns']['conditional'][0]['divider']['color']
-		);
-		$this->assertEquals(
-			'#abcdef',
-			$json['componentStyles']['default-table']['tableStyle']['rows']['conditional'][0]['divider']['color']
-		);
-		$this->assertEquals(
-			'#abcdef',
-			$json['componentStyles']['default-table']['tableStyle']['headerRows']['conditional'][0]['divider']['color']
-		);
-
+		// Ensure header background and text colors match.
 		$this->assertEquals(
 			'#654321',
-			$json['componentStyles']['default-table']['tableStyle']['headerCells']['conditional'][0]['backgroundColor']
+			$json['componentStyles']['dark-table']['tableStyle']['headerCells']['backgroundColor']
 		);
 		$this->assertEquals(
 			'#987654',
-			$json['componentStyles']['default-table']['tableStyle']['headerCells']['conditional'][0]['textStyle']['textColor']
+			$json['componentStyles']['dark-table']['tableStyle']['headerCells']['textStyle']['textColor']
+		);
+
+		// Test partial dark mode styles.
+		// Set table settings.
+		$this->set_theme_settings(
+			[
+				// Set default-table style.
+				'table_border_color'               => '#111111',
+				'table_body_background_color'      => '#000000',
+				// Reset dark mode style.
+				'table_body_background_color_dark' => '',
+			]
+		);
+
+		// Run the export.
+		$exporter = new Exporter( $content, $this->workspace, $this->settings );
+		$json     = $exporter->export();
+		$this->ensure_tokens_replaced( $json );
+		$json = json_decode( $json, true );
+
+		// Ensure component level conditional is still set.
+		$this->assertEquals(
+			'dark-table',
+			$json['components'][1]['conditional'][0]['style'],
+		);
+
+		// Ensure unset dark mode style falls back to default-table style.
+		$this->assertEquals(
+			'#000000',
+			$json['componentStyles']['dark-table']['tableStyle']['cells']['backgroundColor']
+		);
+		$this->assertEquals(
+			'#000000',
+			$json['componentStyles']['default-table']['tableStyle']['cells']['backgroundColor']
+		);
+
+		// Ensure dark mode styles still differentiated from default-styles for fields with set values.
+		$this->assertEquals(
+			'#abcdef',
+			$json['componentStyles']['dark-table']['border']['all']['color']
+		);
+		$this->assertEquals(
+			'#111111',
+			$json['componentStyles']['default-table']['border']['all']['color']
 		);
 	}
 

--- a/tests/apple-exporter/components/test-class-table.php
+++ b/tests/apple-exporter/components/test-class-table.php
@@ -26,7 +26,7 @@ class Apple_News_Table_Test extends Apple_News_Component_TestCase {
 		parent::setup();
 
 		// Create an example table to use in tests.
-		$this->html = '<table><thead><tr><th>Column Header 1</th><th>Column Header 2</th></tr></thead><tbody><tr><td>Column Data 1</td><td>Column Data 2</td></tr></tbody><tfoot><tr><td>Column Footer 1</td><td>Column Footer 2</td></tr></tfoot></table>';
+		$this->html         = '<table><thead><tr><th>Column Header 1</th><th>Column Header 2</th></tr></thead><tbody><tr><td>Column Data 1</td><td>Column Data 2</td></tr></tbody><tfoot><tr><td>Column Footer 1</td><td>Column Footer 2</td></tr></tfoot></table>';
 		$this->html_caption = '<figure class="wp-block-table"><table><thead><tr><th>Column Header 1</th><th>Column Header 2</th></tr></thead><tbody><tr><td>Column Data 1</td><td>Column Data 2</td></tr></tbody><tfoot><tr><td>Column Footer 1</td><td>Column Footer 2</td></tr></tfoot></table><figcaption>Caption</figcaption></figure>';
 	}
 

--- a/tests/apple-exporter/components/test-class-table.php
+++ b/tests/apple-exporter/components/test-class-table.php
@@ -149,7 +149,7 @@ HTML;
 		// Ensure component level conditional is set.
 		$this->assertEquals(
 			'dark-table',
-			$json['components'][1]['conditional'][0]['style'],
+			$json['components'][1]['conditional'][0]['style']
 		);
 
 		// Ensure border color values match.
@@ -211,7 +211,7 @@ HTML;
 		// Ensure component level conditional is still set.
 		$this->assertEquals(
 			'dark-table',
-			$json['components'][1]['conditional'][0]['style'],
+			$json['components'][1]['conditional'][0]['style']
 		);
 
 		// Ensure unset dark mode style falls back to default-table style.

--- a/tests/apple-exporter/components/test-class-table.php
+++ b/tests/apple-exporter/components/test-class-table.php
@@ -26,29 +26,7 @@ class Apple_News_Table_Test extends Apple_News_Component_TestCase {
 		parent::setup();
 
 		// Create an example table to use in tests.
-		$this->html = <<<HTML
-<table>
-	<thead>
-		<tr>
-			<th>Column Header 1</th>
-			<th>Column Header 2</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>Column Data 1</td>
-			<td>Column Data 2</td>
-		</tr>
-	</tbody>
-	<tfoot>
-		<tr>
-			<td>Column Footer 1</td>
-			<td>Column Footer 2</td>
-		</tr>
-	</tfoot>
-</table>
-HTML;
-
+		$this->html = '<table><thead><tr><th>Column Header 1</th><th>Column Header 2</th></tr></thead><tbody><tr><td>Column Data 1</td><td>Column Data 2</td></tr></tbody><tfoot><tr><td>Column Footer 1</td><td>Column Footer 2</td></tr></tfoot></table>';
 		$this->html_caption = '<figure class="wp-block-table"><table><thead><tr><th>Column Header 1</th><th>Column Header 2</th></tr></thead><tbody><tr><td>Column Data 1</td><td>Column Data 2</td></tr></tbody><tfoot><tr><td>Column Footer 1</td><td>Column Footer 2</td></tr></tfoot></table><figcaption>Caption</figcaption></figure>';
 	}
 
@@ -92,17 +70,13 @@ HTML;
 	 * Tests HTML formatting.
 	 */
 	public function test_html() {
+		// Create post, generate json.
+		$post_id = self::factory()->post->create( [ 'post_content' => $this->html ] );
+		$json    = $this->get_json_for_post( $post_id );
+		$result  = $json['components'][3];
 
-		// Setup.
-		$component = new Table(
-			$this->html,
-			$this->workspace,
-			$this->settings,
-			$this->styles,
-			$this->layouts,
-			null,
-			$this->component_styles
-		);
+		// Remove newlines from table html.
+		$result['html'] = str_replace( "\n", '', $json['components'][3]['html'] );
 
 		// Test.
 		$this->assertEquals(
@@ -112,7 +86,7 @@ HTML;
 				'role'   => 'htmltable',
 				'style'  => 'default-table',
 			],
-			$component->to_array()
+			$result
 		);
 	}
 
@@ -121,14 +95,6 @@ HTML;
 	 * Tests dark mode colors.
 	 */
 	public function test_dark_colors() {
-
-		// Setup.
-		$content = new Exporter_Content(
-			3,
-			'Title',
-			$this->html
-		);
-
 		// Set table settings.
 		$this->set_theme_settings(
 			[
@@ -140,16 +106,14 @@ HTML;
 			]
 		);
 
-		// Run the export.
-		$exporter = new Exporter( $content, $this->workspace, $this->settings );
-		$json     = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
+		// Create post, generate json.
+		$post_id = self::factory()->post->create( [ 'post_content' => $this->html ] );
+		$json    = $this->get_json_for_post( $post_id );
 
 		// Ensure component level conditional is set.
 		$this->assertEquals(
 			'dark-table',
-			$json['components'][1]['conditional'][0]['style']
+			$json['components'][3]['conditional'][0]['style']
 		);
 
 		// Ensure border color values match.
@@ -202,16 +166,13 @@ HTML;
 			]
 		);
 
-		// Run the export.
-		$exporter = new Exporter( $content, $this->workspace, $this->settings );
-		$json     = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
+		// Regenerate json after theme setting changes.
+		$json = $this->get_json_for_post( $post_id );
 
 		// Ensure component level conditional is still set.
 		$this->assertEquals(
 			'dark-table',
-			$json['components'][1]['conditional'][0]['style']
+			$json['components'][3]['conditional'][0]['style']
 		);
 
 		// Ensure unset dark mode style falls back to default-table style.
@@ -239,14 +200,6 @@ HTML;
 	 * Tests table settings.
 	 */
 	public function test_settings() {
-
-		// Setup.
-		$content = new Exporter_Content(
-			3,
-			'Title',
-			$this->html
-		);
-
 		// Set table settings.
 		$this->set_theme_settings(
 			[
@@ -274,11 +227,9 @@ HTML;
 			]
 		);
 
-		// Run the export.
-		$exporter = new Exporter( $content, $this->workspace, $this->settings );
-		$json     = $exporter->export();
-		$this->ensure_tokens_replaced( $json );
-		$json = json_decode( $json, true );
+		// Create post, generate json.
+		$post_id = self::factory()->post->create( [ 'post_content' => $this->html ] );
+		$json    = $this->get_json_for_post( $post_id );
 
 		// Validate table layout in generated JSON.
 		$this->assertEquals(


### PR DESCRIPTION
## What does this PR do?

1. Revises the way dark mode table styles are registered to circumvent limitations in the AN json conditional style logic.  Moves the conditional up to the component level and applies an entirely different `componentStyle` (either `default-table` or `dark-table`) based on the `preferredColorScheme` (light or dark mode).
2. Updates tests as needed.