### PR TITLE
APPLE-143 Prevent Yoast from cloning meta

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -184,12 +184,14 @@ class Admin_Apple_News extends Apple_News {
 			add_filter(
 				'duplicate_post_meta_keys_filter',
 				function( $meta_keys ) {
+					return is_array( $meta_keys ) ?
 					array_filter(
 						$meta_keys,
 						function( $key ) {
 							return substr( $key, 0, 11 ) !== 'apple_news_';
 						}
-					);
+					)
+					: $meta_keys;
 				} 
 			);
 

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -180,6 +180,13 @@ class Admin_Apple_News extends Apple_News {
 				apple_news_register_meta_helper( 'post', $post_types, $meta_key, $options );
 			}
 
+			// Prevent Yoast Duplicate Post plugin from cloning apple_news meta.
+			add_filter( 'duplicate_post_meta_keys_filter', function( $meta_keys ) {
+				array_filter( $meta_keys, function( $key ) {
+					return substr( $key, 0, 11 ) !== 'apple_news_';
+				});
+			} );
+
 			add_action(
 				'rest_api_init',
 				function() {

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -181,11 +181,17 @@ class Admin_Apple_News extends Apple_News {
 			}
 
 			// Prevent Yoast Duplicate Post plugin from cloning apple_news meta.
-			add_filter( 'duplicate_post_meta_keys_filter', function( $meta_keys ) {
-				array_filter( $meta_keys, function( $key ) {
-					return substr( $key, 0, 11 ) !== 'apple_news_';
-				});
-			} );
+			add_filter(
+				'duplicate_post_meta_keys_filter',
+				function( $meta_keys ) {
+					array_filter(
+						$meta_keys,
+						function( $key ) {
+							return substr( $key, 0, 11 ) !== 'apple_news_';
+						}
+					);
+				} 
+			);
 
 			add_action(
 				'rest_api_init',


### PR DESCRIPTION
## What does this PR do?

1. Hooks into a filter to prevent Yoast Duplicate Post plugin from cloning the Apple News plugin meta.