### PR TITLE
APPLE-150 Address v2.4.0 feedback

### DIFF
--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -180,15 +180,6 @@ class Admin_Apple_JSON extends Apple_News {
 		// Negotiate selected theme.
 		$selected_theme = $this->get_selected_theme();
 
-		// Extract theme layout configuration.
-		$layout_columns = 0;
-		$layout_width   = 0;
-		if ( ! empty( $selected_theme ) ) {
-			$theme_object   = Admin_Apple_Themes::get_theme_by_name( $selected_theme );
-			$layout_columns = $theme_object->get_layout_columns();
-			$layout_width   = $theme_object->get_value( 'layout_width' );
-		}
-
 		// Check if there is a valid selected component.
 		$selected_component = ( ! empty( $selected_theme ) )
 			? $this->get_selected_component()

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -86,18 +86,6 @@
 				</label>
 			</div>
 			<?php if ( ! empty( $selected_theme ) ) : ?>
-				<div class="theme-value-wrapper">
-				<?php if ( ! empty( $layout_columns ) ) : ?>
-					<div class="theme-value-row top">
-						<?php esc_html_e( 'Theme Columns', 'apple-news' ); ?>: <span><?php echo (int) $layout_columns; ?></span>
-					</div>
-				<?php endif; ?>
-				<?php if ( ! empty( $layout_width ) ) : ?>
-					<div class="theme-value-row">
-						<?php esc_html_e( 'Layout Width', 'apple-news' ); ?>: <span><?php echo (int) $layout_width; ?></span>
-					</div>
-				<?php endif; ?>
-				</div>
 				<div>
 					<label for="apple_news_theme">
 						<?php esc_html_e( 'Component', 'apple-news' ); ?>:

--- a/assets/css/json.css
+++ b/assets/css/json.css
@@ -4,18 +4,6 @@
 	display: block;
 }
 
-.apple-news-json .theme-value-wrapper {
-	margin-top: 15px;
-}
-
-.apple-news-json .theme-value-row span {
-	font-weight: bold;
-}
-
-.apple-news-json .theme-value-row.top {
-	margin-bottom: 3px;
-}
-
 .apple-news-json input[type="submit"] {
 	margin-right: 1em;
 }

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1115,10 +1115,16 @@ class Theme {
 				'hidden'  => true,
 				'type'    => 'array',
 			],
-			'layout_columns_override'            => [
-				'default' => null,
-				'label'   => __( 'Layout columns override', 'apple-news' ),
+			'layout_columns'                     => [
+				'default' => 0,
+				'label'   => __( 'Layout columns', 'apple-news' ),
 				'type'    => 'integer',
+			],
+			'layout_columns_override'            => [
+				'default' => 'no',
+				'label'   => __( 'Override computed value with user configured value set above?', 'apple-news' ),
+				'options' => [ 'yes', 'no' ],
+				'type'    => 'select',
 			],
 			'layout_gutter'                      => [
 				'default' => 20,
@@ -1557,14 +1563,15 @@ class Theme {
 	}
 
 	/**
-	 * Get the computed layout columns.
+	 * If user override enabled return layout_columns theme value.
+	 * Else return the computed layout columns value.
 	 *
 	 * @access public
 	 * @return int The number of layout columns to use.
 	 */
 	public function get_layout_columns() {
-		if ( $this->get_value( 'layout_columns_override' ) ) {
-			return $this->get_value( 'layout_columns_override' );
+		if ( 'yes' === $this->get_value( 'layout_columns_override' ) ) {
+			return $this->get_value( 'layout_columns' );
 		}
 		return ( 'center' === $this->get_value( 'body_orientation' ) ) ? 9 : 7;
 	}
@@ -2132,6 +2139,7 @@ class Theme {
 				'label'       => __( 'Layout Spacing', 'apple-news' ),
 				'description' => __( 'The spacing for the base layout of the exported articles', 'apple-news' ),
 				'settings'    => [
+					'layout_columns',
 					'layout_columns_override',
 					'layout_margin',
 					'layout_gutter',

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1570,7 +1570,7 @@ class Theme {
 	 * @return int The number of layout columns to use.
 	 */
 	public function get_layout_columns() {
-		if ( 'yes' === $this->get_value( 'layout_columns_override' ) ) {
+		if ( 'yes' === $this->get_value( 'layout_columns_override' ) && ! empty( $this->get_value( 'layout_columns' ) ) ) {
 			return $this->get_value( 'layout_columns' );
 		}
 		return ( 'center' === $this->get_value( 'body_orientation' ) ) ? 9 : 7;

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -1115,6 +1115,11 @@ class Theme {
 				'hidden'  => true,
 				'type'    => 'array',
 			],
+			'layout_columns_override'            => [
+				'default' => null,
+				'label'   => __( 'Layout columns override', 'apple-news' ),
+				'type'    => 'integer',
+			],
 			'layout_gutter'                      => [
 				'default' => 20,
 				'label'   => __( 'Layout gutter', 'apple-news' ),
@@ -1127,7 +1132,7 @@ class Theme {
 			],
 			'layout_width'                       => [
 				'default' => 1024,
-				'hidden'  => true,
+				'label'   => __( 'Layout width', 'apple-news' ),
 				'type'    => 'integer',
 			],
 			'meta_component_order'               => [
@@ -1558,6 +1563,9 @@ class Theme {
 	 * @return int The number of layout columns to use.
 	 */
 	public function get_layout_columns() {
+		if ( $this->get_value( 'layout_columns_override' ) ) {
+			return $this->get_value( 'layout_columns_override' );
+		}
 		return ( 'center' === $this->get_value( 'body_orientation' ) ) ? 9 : 7;
 	}
 
@@ -2123,7 +2131,12 @@ class Theme {
 			'layout'          => [
 				'label'       => __( 'Layout Spacing', 'apple-news' ),
 				'description' => __( 'The spacing for the base layout of the exported articles', 'apple-news' ),
-				'settings'    => [ 'layout_margin', 'layout_gutter' ],
+				'settings'    => [
+					'layout_columns_override',
+					'layout_margin',
+					'layout_gutter',
+					'layout_width',
+				],
 			],
 			'slug'            => [
 				'label'       => __( 'Slug', 'apple-news' ),

--- a/tests/apple-exporter/builders/test-class-layout.php
+++ b/tests/apple-exporter/builders/test-class-layout.php
@@ -48,13 +48,26 @@ class Apple_News_Layout_Test extends Apple_News_Testcase {
 
 		// Check default, override-less behavior.
 		$this->assertEquals( $theme->get_layout_columns(), $json['layout']['columns'] );
+		$this->assertEquals( 7, $json['layout']['columns'] );
 
-		$theme->set_value( 'layout_columns_override', 6 );
+		// Confirm override applies after 'layout_columns_override' is flipped to 'yes'.
+		$theme->set_value( 'layout_columns_override', 'yes' );
+		$theme->set_value( 'layout_columns', 6 );
 		$this->assertTrue( $theme->save() );
 		$json = $this->get_json_for_post( $post_id );
 
-		// Confirm override applies after 'layout_columns_override' theme value change.
 		$this->assertEquals( 6, $theme->get_layout_columns() );
 		$this->assertEquals( 6, $json['layout']['columns'] );
+
+		// Reset override and confirm that dynamic computed value is restored.
+		$theme->set_value( 'layout_columns_override', 'no' );
+		// Also set body_orientation to 'center' to ensure the computed value for layout_columns changes accordingly.
+		$theme->set_value( 'body_orientation', 'center' );
+		$this->assertTrue( $theme->save() );
+		$json = $this->get_json_for_post( $post_id );
+
+		// Confirm override applies after 'layout_columns' theme value change.
+		$this->assertEquals( $theme->get_layout_columns(), $json['layout']['columns'] );
+		$this->assertEquals( 9, $json['layout']['columns'] );
 	}
 }

--- a/tests/apple-exporter/builders/test-class-layout.php
+++ b/tests/apple-exporter/builders/test-class-layout.php
@@ -23,45 +23,38 @@ class Apple_News_Layout_Test extends Apple_News_Testcase {
 	 * Tests the behavior of registering a layout.
 	 */
 	public function test_register_layout() {
-		$theme                     = Theme::get_used();
-		$settings                  = $theme->all_settings();
-		$settings['layout_margin'] = 123;
-		$settings['layout_gutter'] = 222;
-		$settings['layout_width']  = 768;
-		$theme->load( $settings );
+		$theme = Theme::get_used();
+		$theme->set_value( 'layout_margin', 123 );
+		$theme->set_value( 'layout_gutter', 222 );
+		$theme->set_value( 'layout_width', 768 );
 		$this->assertTrue( $theme->save() );
-		$layout = new Layout( $this->content, $this->settings );
-		$result = $layout->to_array();
 
-		$this->assertEquals( $theme->get_layout_columns(), $result['columns'] );
-		$this->assertEquals( 768, $result['width'] );
-		$this->assertEquals( 123, $result['margin'] );
-		$this->assertEquals( 222, $result['gutter'] );
+		$post_id = self::factory()->post->create( [ 'post_content' => '' ] );
+		$json    = $this->get_json_for_post( $post_id );
+
+		$this->assertEquals( $theme->get_layout_columns(), $json['layout']['columns'] );
+		$this->assertEquals( 768, $json['layout']['width'] );
+		$this->assertEquals( 123, $json['layout']['margin'] );
+		$this->assertEquals( 222, $json['layout']['gutter'] );
 	}
 
 	/**
 	 * Test column override functionality.
 	 */
 	public function test_column_override() {
-		$theme                     = Theme::get_used();
-		$settings                  = $theme->all_settings();
-		$settings['layout_margin'] = 123;
-		$theme->load( $settings );
+		$theme   = Theme::get_used();
+		$post_id = self::factory()->post->create( [ 'post_content' => '' ] );
+		$json    = $this->get_json_for_post( $post_id );
+
+		// Check default, override-less behavior.
+		$this->assertEquals( $theme->get_layout_columns(), $json['layout']['columns'] );
+
+		$theme->set_value( 'layout_columns_override', 6 );
 		$this->assertTrue( $theme->save() );
-		$layout = new Layout( $this->content, $this->settings );
-		$result = $layout->to_array();
+		$json = $this->get_json_for_post( $post_id );
 
-		// Check default behavior.
-		$this->assertEquals( $theme->get_layout_columns(), $result['columns'] );
-
-		$settings['layout_columns_override'] = 6;
-		$theme->load( $settings );
-		$this->assertTrue( $theme->save() );
-		$layout = new Layout( $this->content, $this->settings );
-		$result = $layout->to_array();
-
-		// Confirm override works after theme value change.
+		// Confirm override applies after 'layout_columns_override' theme value change.
 		$this->assertEquals( 6, $theme->get_layout_columns() );
-		$this->assertEquals( 6, $result['columns'] );
+		$this->assertEquals( 6, $json['layout']['columns'] );
 	}
 }

--- a/tests/apple-exporter/builders/test-class-layout.php
+++ b/tests/apple-exporter/builders/test-class-layout.php
@@ -27,14 +27,41 @@ class Apple_News_Layout_Test extends Apple_News_Testcase {
 		$settings                  = $theme->all_settings();
 		$settings['layout_margin'] = 123;
 		$settings['layout_gutter'] = 222;
+		$settings['layout_width']  = 768;
 		$theme->load( $settings );
 		$this->assertTrue( $theme->save() );
 		$layout = new Layout( $this->content, $this->settings );
 		$result = $layout->to_array();
 
 		$this->assertEquals( $theme->get_layout_columns(), $result['columns'] );
-		$this->assertEquals( $theme->get_value( 'layout_width' ), $result['width'] );
+		$this->assertEquals( 768, $result['width'] );
 		$this->assertEquals( 123, $result['margin'] );
 		$this->assertEquals( 222, $result['gutter'] );
+	}
+
+	/**
+	 * Test column override functionality.
+	 */
+	public function test_column_override() {
+		$theme                     = Theme::get_used();
+		$settings                  = $theme->all_settings();
+		$settings['layout_margin'] = 123;
+		$theme->load( $settings );
+		$this->assertTrue( $theme->save() );
+		$layout = new Layout( $this->content, $this->settings );
+		$result = $layout->to_array();
+
+		// Check default behavior.
+		$this->assertEquals( $theme->get_layout_columns(), $result['columns'] );
+
+		$settings['layout_columns_override'] = 6;
+		$theme->load( $settings );
+		$this->assertTrue( $theme->save() );
+		$layout = new Layout( $this->content, $this->settings );
+		$result = $layout->to_array();
+
+		// Confirm override works after theme value change.
+		$this->assertEquals( 6, $theme->get_layout_columns() );
+		$this->assertEquals( 6, $result['columns'] );
 	}
 }


### PR DESCRIPTION
## What does this PR do?

1. Rolls back changes made in https://github.com/alleyinteractive/apple-news/pull/972 but retains the `get_theme_by_name` method introduced by it.
2. Makes `layout_width` visible and configurable in the theme settings page.
3. Creates a `layout_columns_override` to make `layout_columns` user configurable.  If the override is not set the original dynamic logic (based on `body_orientation`) takes over.
4. Updates layout tests.