### PR TITLE
APPLE-153 Make Automation Rules Additive

### DIFF
--- a/admin/class-automation.php
+++ b/admin/class-automation.php
@@ -112,7 +112,7 @@ class Automation {
 			$rules = self::get_automation_for_post( $post_id );
 			foreach ( $rules as $rule ) {
 				if ( 'theme' === ( $rule['field'] ?? '' ) && ! empty( $rule['value'] ) ) {
-					return $rule['value'];
+					$theme_name = $rule['value'];
 				}
 			}
 		}
@@ -161,7 +161,7 @@ class Automation {
 		$rules = self::get_automation_for_post( $post_id );
 		foreach ( $rules as $rule ) {
 			if ( 'slug.#text#' === ( $rule['field'] ?? '' ) ) {
-				return $rule['value'] ?? '';
+				$slug = $rule['value'] ?? '';
 			}
 		}
 

--- a/tests/admin/test-class-automation.php
+++ b/tests/admin/test-class-automation.php
@@ -28,7 +28,7 @@ class Apple_News_Automation_Test extends Apple_News_Testcase {
 	}
 
 	/**
-	 * Tests automation priority (where multiple rules match and the first should be used).
+	 * Tests automation priority (where multiple rules match and the last should be used).
 	 */
 	public function test_automation_priority() {
 		$post_id = self::factory()->post->create();
@@ -46,13 +46,13 @@ class Apple_News_Automation_Test extends Apple_News_Testcase {
 					'field'    => 'slug.#text#',
 					'taxonomy' => 'category',
 					'term_id'  => $term_id_1,
-					'value'    => 'Top Priority',
+					'value'    => 'Lower Priority',
 				],
 				[
 					'field'    => 'slug.#text#',
 					'taxonomy' => 'category',
 					'term_id'  => $term_id_2,
-					'value'    => 'Lower Priority',
+					'value'    => 'Top Priority',
 				],
 			]
 		);
@@ -71,13 +71,13 @@ class Apple_News_Automation_Test extends Apple_News_Testcase {
 					'field'    => 'slug.#text#',
 					'taxonomy' => 'category',
 					'term_id'  => $term_id_2,
-					'value'    => 'Lower Priority',
+					'value'    => 'Top Priority',
 				],
 				[
 					'field'    => 'slug.#text#',
 					'taxonomy' => 'category',
 					'term_id'  => $term_id_1,
-					'value'    => 'Top Priority',
+					'value'    => 'Lower Priority',
 				],
 			]
 		);


### PR DESCRIPTION
If this PR is merged, it will:

- Change the behavior of Automation rules so that rules that are further down in the list that affect the same field will override matches made earlier. Previously, the first matching rule would cause the matching engine to stop, and with this change, the matching engine will continue matching and overwriting the value for as long as there are matches, meaning that the match that is furthest down on the list will be the one that takes effect.