### PR TITLE
APPLE-151 Add setting to delete on unpublish or trash

### DIFF
--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -81,7 +81,11 @@ class Admin_Apple_Post_Sync {
 		 * @param bool $should_delete Whether the post should be deleted via the Apple News API or not.
 		 * @param int  $post_id       The ID of the post that was moved to the trash.
 		 */
-		$delete_on_trash = apply_filters( 'apple_news_should_post_delete_on_trash', false, $post->ID );
+		$delete_on_trash = apply_filters(
+			'apple_news_should_post_delete_on_trash',
+			'yes' === $this->settings->api_autosync_trash,
+			$post->ID
+		);
 
 		/**
 		 * Determines whether to delete an article via the Apple News API if it is
@@ -93,7 +97,11 @@ class Admin_Apple_Post_Sync {
 		 * @param bool $should_delete Whether the post should be deleted via the Apple News API or not.
 		 * @param int  $post_id       The ID of the post that was unpublished.
 		 */
-		$delete_on_unpublish = apply_filters( 'apple_news_should_post_delete_on_unpublish', false, $post->ID );
+		$delete_on_unpublish = apply_filters(
+			'apple_news_should_post_delete_on_unpublish',
+			'yes' === $this->settings->api_autosync_unpublish,
+			$post->ID
+		);
 
 		// Determine whether to delete the article via the API.
 		if ( $old_status !== $new_status

--- a/admin/settings/class-admin-apple-settings-section-api.php
+++ b/admin/settings/class-admin-apple-settings-section-api.php
@@ -32,41 +32,49 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 
 		// Add the settings.
 		$this->settings = [
-			'api_config_file'       => [
+			'api_config_file'        => [
 				// translators: tokens fill in <a> tags.
 				'description' => sprintf( __( 'Having trouble? %1$sEnter the contents of your .papi file manually%2$s.', 'apple-news' ), '<a href="#api_config_file">', '</a>' ),
 				'type'        => 'file',
 			],
-			'api_config_file_input' => [
+			'api_config_file_input'  => [
 				'type' => 'textarea',
 			],
-			'api_channel'           => [
+			'api_channel'            => [
 				'type' => 'hidden',
 			],
-			'api_key'               => [
+			'api_key'                => [
 				'type' => 'hidden',
 			],
-			'api_secret'            => [
+			'api_secret'             => [
 				'type' => 'hidden',
 			],
-			'api_autosync'          => [
+			'api_autosync'           => [
 				'label' => __( 'Automatically publish to Apple News when published in WordPress', 'apple-news' ),
 				'type'  => [ 'yes', 'no' ],
 			],
-			'api_autosync_update'   => [
+			'api_autosync_update'    => [
 				'label' => __( 'Automatically update in Apple News when updated in WordPress', 'apple-news' ),
 				'type'  => [ 'yes', 'no' ],
 			],
-			'api_autosync_delete'   => [
+			'api_autosync_delete'    => [
 				'label' => __( 'Automatically delete from Apple News when deleted in WordPress', 'apple-news' ),
 				'type'  => [ 'yes', 'no' ],
 			],
-			'api_async'             => [
+			'api_autosync_unpublish' => [
+				'label' => __( 'Automatically delete from Apple News when unpublished in WordPress', 'apple-news' ),
+				'type'  => [ 'yes', 'no' ],
+			],
+			'api_autosync_trash'     => [
+				'label' => __( 'Automatically delete from Apple News when moved to the trash in WordPress', 'apple-news' ),
+				'type'  => [ 'yes', 'no' ],
+			],
+			'api_async'              => [
 				'label'       => __( 'Asynchronously publish to Apple News', 'apple-news' ),
 				'type'        => [ 'yes', 'no' ],
 				'description' => $this->get_async_description(),
 			],
-			'api_autosync_skip'     => [
+			'api_autosync_skip'      => [
 				'label'    => __( 'Skip auto-publishing for posts that have any of the following term IDs:', 'apple-news' ),
 				'required' => false,
 			],
@@ -80,7 +88,7 @@ class Admin_Apple_Settings_Section_API extends Admin_Apple_Settings_Section {
 			],
 			'apple_news_options'       => [
 				'label'    => __( 'Apple News API Options', 'apple-news' ),
-				'settings' => [ 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_async', 'api_autosync_skip' ],
+				'settings' => [ 'api_autosync', 'api_autosync_update', 'api_autosync_delete', 'api_autosync_unpublish', 'api_autosync_trash', 'api_async', 'api_autosync_skip' ],
 			],
 		];
 

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -33,6 +33,8 @@ class Settings {
 		'api_async'                   => 'no',
 		'api_autosync'                => 'yes',
 		'api_autosync_delete'         => 'yes',
+		'api_autosync_unpublish'      => 'yes',
+		'api_autosync_trash'          => 'yes',
 		'api_autosync_skip'           => '[]',
 		'api_autosync_update'         => 'yes',
 		'api_channel'                 => '',

--- a/tests/admin/apple-actions/index/test-class-delete.php
+++ b/tests/admin/apple-actions/index/test-class-delete.php
@@ -32,7 +32,7 @@ class Apple_News_Admin_Action_Index_Delete_Test extends Apple_News_Testcase {
 		wp_delete_post( $post_id, true );
 		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 
-		// Create a new article and move it to the trash and verify that the delete operation was not triggered.
+		// Create a new article, move it to the trash, and verify that the delete operation was triggered.
 		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
 		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
 		$post_id = self::factory()->post->create();
@@ -40,11 +40,31 @@ class Apple_News_Admin_Action_Index_Delete_Test extends Apple_News_Testcase {
 		$this->add_http_response( 'DELETE', 'https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456' );
 		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 		wp_delete_post( $post_id );
-		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
-		array_pop( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 
-		// Create a new article and move it to draft status and verify that the delete operation was not triggered.
+		// Create a new article, move it to draft, and verify that the delete operation was triggered.
+		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
+		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
+		$post = self::factory()->post->create_and_get();
+		$this->assertEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
+		$this->add_http_response( 'DELETE', 'https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456' );
+		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
+		$post->post_status = 'draft';
+		wp_update_post( $post );
+		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
+
+		// Create a new article, move it to the trash, and verify that the delete operation was triggered.
+		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
+		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
+		$post_id = self::factory()->post->create();
+		$this->assertEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
+		$this->add_http_response( 'DELETE', 'https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456' );
+		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
+		wp_delete_post( $post_id );
+		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
+
+		// Opt out of deleting on unpublish by filter, create a new article, move it to draft status, and verify that the delete operation was not triggered.
+		add_filter( 'apple_news_should_post_delete_on_unpublish', '__return_false' );
 		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
 		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
 		$post = self::factory()->post->create_and_get();
@@ -57,8 +77,8 @@ class Apple_News_Admin_Action_Index_Delete_Test extends Apple_News_Testcase {
 		array_pop( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 
-		// Opt in to delete on trash via filter, create a new article, move it to the trash, and verify that the delete operation was triggered.
-		add_filter( 'apple_news_should_post_delete_on_trash', '__return_true' );
+		// Opt out of deleting on trash by filter, create a new article, move it to the trash, and verify that the delete operation was not triggered.
+		add_filter( 'apple_news_should_post_delete_on_trash', '__return_false' );
 		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
 		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
 		$post_id = self::factory()->post->create();
@@ -66,32 +86,8 @@ class Apple_News_Admin_Action_Index_Delete_Test extends Apple_News_Testcase {
 		$this->add_http_response( 'DELETE', 'https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456' );
 		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 		wp_delete_post( $post_id );
-		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
-		remove_filter( 'apple_news_should_post_delete_on_trash', '__return_true' );
-
-		// Opt in to delete on unpublish via filter, create a new article, move it to draft, and verify that the delete operation was triggered.
-		add_filter( 'apple_news_should_post_delete_on_unpublish', '__return_true' );
-		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
-		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
-		$post = self::factory()->post->create_and_get();
-		$this->assertEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
-		$this->add_http_response( 'DELETE', 'https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456' );
 		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
-		$post->post_status = 'draft';
-		wp_update_post( $post );
+		array_pop( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
 		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
-		remove_filter( 'apple_news_should_post_delete_on_unpublish', '__return_true' );
-
-		// Opt in to delete on unpublish via filter, create a new article, move it to the trash, and verify that the delete operation was triggered.
-		add_filter( 'apple_news_should_post_delete_on_unpublish', '__return_true' );
-		$this->add_http_response( 'POST', 'https://news-api.apple.com/channels/foo/articles', wp_json_encode( $this->fake_article_response() ) );
-		$this->assertNotEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
-		$post_id = self::factory()->post->create();
-		$this->assertEmpty( $this->http_responses['POST']['https://news-api.apple.com/channels/foo/articles'] );
-		$this->add_http_response( 'DELETE', 'https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456' );
-		$this->assertNotEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
-		wp_delete_post( $post_id );
-		$this->assertEmpty( $this->http_responses['DELETE']['https://news-api.apple.com/articles/abcd1234-ef56-ab78-cd90-efabcdef123456'] );
-		remove_filter( 'apple_news_should_post_delete_on_unpublish', '__return_true' );
 	}
 }


### PR DESCRIPTION
If this PR is merged, it will:

- Add a setting to configure autodeleting articles on unpublish
- Add a setting to configure autodeleting articles on trash
- Default both of those settings to true
- Update the test governing this behavior to use the new defaults