### PR TITLE
APPLE-154 Suppress thumbnailURL alongside videoURL

### DIFF
--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -94,16 +94,14 @@ class Metadata extends Builder {
 				// Try to match an MP4 source URL.
 				if ( preg_match( '/src="([^\?"]+\.(mp4|m3u8)[^"]*)"/', $matches[0][ $i ], $src ) ) {
 
-					// Include the thumbnail and video URL if the video URL is valid.
-					$url = Exporter_Content::format_src_url( $src[1] );
-					if ( ! empty( $url ) ) {
+					// Include the thumbnail and video URL if the video URL is valid and the suppression meta is absent.
+					$url           = Exporter_Content::format_src_url( $src[1] );
+					$suppress_video = get_post_meta( $this->content_id(), 'apple_news_suppress_video_url', true );
+					if ( ! empty( $url ) && ! $suppress_video ) {
 						$meta['thumbnailURL'] = $this->maybe_bundle_source(
 							$matches[1][ $i ]
 						);
-
-						if ( ! get_post_meta( $this->content_id(), 'apple_news_suppress_video_url', true ) ) {
-							$meta['videoURL'] = esc_url_raw( $url );
-						}
+						$meta['videoURL'] = esc_url_raw( $url );
 
 						break;
 					}

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -95,13 +95,13 @@ class Metadata extends Builder {
 				if ( preg_match( '/src="([^\?"]+\.(mp4|m3u8)[^"]*)"/', $matches[0][ $i ], $src ) ) {
 
 					// Include the thumbnail and video URL if the video URL is valid and the suppression meta is absent.
-					$url           = Exporter_Content::format_src_url( $src[1] );
+					$url            = Exporter_Content::format_src_url( $src[1] );
 					$suppress_video = get_post_meta( $this->content_id(), 'apple_news_suppress_video_url', true );
 					if ( ! empty( $url ) && ! $suppress_video ) {
+						$meta['videoURL']     = esc_url_raw( $url );
 						$meta['thumbnailURL'] = $this->maybe_bundle_source(
 							$matches[1][ $i ]
 						);
-						$meta['videoURL'] = esc_url_raw( $url );
 
 						break;
 					}

--- a/tests/apple-exporter/builders/test-class-metadata.php
+++ b/tests/apple-exporter/builders/test-class-metadata.php
@@ -141,13 +141,25 @@ class Apple_News_Metadata_Test extends Apple_News_Testcase {
 				'post_content' => '<figure class="wp-block-video"><video controls="" poster="' . $poster . '" src="' . $video . '"></video></figure>',
 			]
 		);
+		$image   = $this->get_new_attachment( $post_id );
+		set_post_thumbnail( $post_id, $image );
+		$result   = $this->get_json_for_post( $post_id );
+		$metadata = $result['metadata'];
+		
+		// Pre meta suppresion assertions.
+		$this->assertEquals( $poster, $metadata['thumbnailURL'] );
+		$this->assertArrayHasKey( 'videoURL', $metadata );
+
 		// Toggle suppression meta value.
 		update_post_meta( $post_id, 'apple_news_suppress_video_url', true );
 		$result   = $this->get_json_for_post( $post_id );
 		$metadata = $result['metadata'];
 
-		// Assertions.
-		$this->assertEquals( $poster, $metadata['thumbnailURL'] );
+		// Post meta suppresion assertions.
+		$this->assertEquals(
+			wp_get_attachment_url( $image ),
+			$metadata['thumbnailURL']
+		);
 		$this->assertArrayNotHasKey( 'videoURL', $metadata );
 	}
 }


### PR DESCRIPTION
## What does this PR do?

1. Extends the logic written in [PR 970](https://github.com/alleyinteractive/apple-news/pull/970/files) to suppress the `thumbnailURL` alongside the `videoURL` when users toggle the `apple_news_suppress_video_url` meta.