### PR TITLE
Date data should be in UTC before passing to strtotime()

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -341,8 +341,8 @@ class Export extends Action {
 		}
 
 		// Get the date.
-		if ( empty( $date ) && ! empty( $post->post_date ) ) {
-			$date = $post->post_date;
+		if ( empty( $date ) && ! empty( $post->post_date_gmt ) ) {
+			$date = $post->post_date_gmt;
 		}
 
 		// Set the default date format.


### PR DESCRIPTION
PHP's `strtotime()` uses the epoch time which is expecting the time format in UTC instead of local time. 

This PR updates `$date` to use `$post->post_date_gmt` instead of `$post->post_date` for proper timezone conversations. 

Fixes #1006