### PR TITLE
Release/v2.4.5

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.4.4
+ * Version:     2.4.5
  * Author:      Alley
  * Author URI:  https://alley.com
  * Text Domain: apple-news

--- a/includes/apple-exporter/components/class-heading.php
+++ b/includes/apple-exporter/components/class-heading.php
@@ -185,13 +185,13 @@ class Heading extends Component {
 	 */
 	protected function build( $html ): void {
 		// Match HTML headings, capture level, id value if set, and heading text.
-		if ( 0 === preg_match( '#<h(\d).*?(id=(["\'])(.*?)\2)?.*?>(.*?)</h\1>#si', $html, $matches ) ) {
+		if ( 0 === preg_match( '/<h(\d)(?:[^>]*?\sid="([^"]*?)")?[^>]*?>(.*?)<\/h\1>/si', $html, $matches ) ) {
 			return;
 		}
 
 		$level = intval( $matches[1] );
-		$text  = $matches[5];
-		$id    = $matches[4] ?? null;
+		$id    = $matches[2] ?? null;
+		$text  = $matches[3];
 
 		// Parse and trim the resultant text, and if there is nothing left, bail.
 		$text = trim( $this->parser->parse( $text ) );

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -50,7 +50,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static string $version = '2.4.4';
+	public static string $version = '2.4.5';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 6.3
 Tested up to: 6.4.2
 Requires PHP: 8.0
-Stable tag: 2.4.4
+Stable tag: 2.4.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.4.5 =
+* Fixes regular expression for adding identifiers.
 
 = 2.4.4 =
 


### PR DESCRIPTION
Bugfix only release. 

The previous regular expression (regex) for parsing HTML headings has been modified to make ID attributes optional. In addition, the order of matches variables for 'text' and 'id' in the ensuing code has also been updated correspondingly. This change fixes an issue where identifiers were not being successfully added to Apple News json output.
