### PR TITLE
Prevent error by adding check before displaying notices

### DIFF
--- a/assets/js/pluginsidebar/sidebar.jsx
+++ b/assets/js/pluginsidebar/sidebar.jsx
@@ -201,7 +201,14 @@ function Sidebar() {
 
   // Display notices whenever they change.
   useEffect(() => {
-    notices.forEach((notice) => displayNotification(notice.message, notice.type));
+    /* Adding a conditional here to prevent a sporadic error.
+    Leaving a console log in place in case we need to debug this further.
+    See: https://github.com/alleyinteractive/apple-news/issues/1030 */
+    if (Array.isArray(notices) && notices.length) {
+      notices.forEach((notice) => displayNotification(notice.message, notice.type));
+    } else {
+      console.log('Notices dispatched, but none to display.'); // eslint-disable-line no-console
+    }
   }, [displayNotification, notices]);
 
   return (


### PR DESCRIPTION
Updated the useEffect in sidebar.jsx to ensure 'notices' is an array and has content before attempting to display notifications. This aims to prevent sporadic errors related to 'notices' being undefined or empty, with helpful logging added for potential future debugging needs.

Fixes #1030 