### PR TITLE
Point to tag archive for changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See the wiki for [usage instructions](https://github.com/alleyinteractive/apple-
 ###	Source
 
 ###	Changelog
-See the wiki for the [changelog](https://github.com/alleyinteractive/apple-news/wiki/Changelog).
+See the tag archive for the [changelog](https://github.com/alleyinteractive/apple-news/tags).
 
 ## Development Process
 


### PR DESCRIPTION
Each tag automatically creates an accurate changelog, so pointing users there instead of the wiki page.