### PR TITLE
APPLE-163: New Automation feature: prepend text to title

### DIFF
--- a/admin/class-automation.php
+++ b/admin/class-automation.php
@@ -66,6 +66,7 @@ class Automation {
 		add_filter( 'apple_news_active_theme', [ __CLASS__, 'filter__apple_news_active_theme' ], 0, 2 );
 		add_filter( 'apple_news_article_metadata', [ __CLASS__, 'filter__apple_news_article_metadata' ], 0, 2 );
 		add_filter( 'apple_news_exporter_slug', [ __CLASS__, 'filter__apple_news_exporter_slug' ], 0, 2 );
+		add_filter( 'apple_news_exporter_title', [ __CLASS__, 'filter__apple_news_exporter_title' ], 0, 2 );
 	}
 
 	/**
@@ -169,6 +170,25 @@ class Automation {
 	}
 
 	/**
+	 * Applies automation rules affecting the post title.
+	 *
+	 * @param string $title   The title the plugin wants to use.
+	 * @param int    $post_id The post ID associated with the title.
+	 *
+	 * @return string The filtered title value.
+	 */
+	public static function filter__apple_news_exporter_title( $title, $post_id ) {
+		$rules = self::get_automation_for_post( $post_id );
+		foreach ( $rules as $rule ) {
+			if ( 'title.prepend' === ( $rule['field'] ?? '' ) ) {
+				$title = sprintf( '%s %s', $rule['value'] ?? '', $title );
+			}
+		}
+
+		return $title;
+	}
+
+	/**
 	 * Given a post ID, returns an array of matching automation rules.
 	 *
 	 * @param int $post_id The post ID to query.
@@ -244,6 +264,11 @@ class Automation {
 				'location' => 'exporter',
 				'type'     => 'string',
 				'label'    => __( 'Theme', 'apple-news' ),
+			],
+			'title.prepend'  => [
+				'location' => 'component',
+				'type'     => 'string',
+				'label'    => __( 'Title: Prepend Text', 'apple-news' ),
 			],
 		];
 	}

--- a/assets/js/admin-settings/rule.jsx
+++ b/assets/js/admin-settings/rule.jsx
@@ -28,6 +28,16 @@ function Rule({
     taxonomies,
     themes,
   } = AppleNewsAutomationConfig;
+  let fieldType = '';
+  if (field === 'links.sections') {
+    fieldType = 'sections';
+  } else if (field === 'theme') {
+    fieldType = 'themes';
+  } else if (fields[field]?.type === 'boolean') {
+    fieldType = 'boolean';
+  } else if (fields[field]?.type === 'string') {
+    fieldType = 'string';
+  }
 
   return (
     <tr
@@ -72,7 +82,7 @@ function Rule({
         />
       </td>
       <td>
-        {fields[field]?.label === 'Section' ? (
+        {fieldType === 'sections' ? (
           <SelectControl
             aria-labelledby="apple-news-automation-column-value"
             disabled={busy}
@@ -84,15 +94,16 @@ function Rule({
             value={value}
           />
         ) : null}
-        {fields[field]?.type === 'boolean' ? (
+        {fieldType === 'boolean' ? (
           <ToggleControl
             aria-labelledby="apple-news-automation-column-value"
             checked={value === 'true'}
             disabled={busy}
+            label=""
             onChange={(next) => onUpdate('value', next.toString())}
           />
         ) : null}
-        {fields[field]?.label === 'Slug' ? (
+        {fieldType === 'string' ? (
           <TextControl
             aria-labelledby="apple-news-automation-column-value"
             disabled={busy}
@@ -100,7 +111,7 @@ function Rule({
             value={value}
           />
         ) : null}
-        {fields[field]?.label === 'Theme' ? (
+        {fieldType === 'themes' ? (
           <SelectControl
             aria-labelledby="apple-news-automation-column-value"
             disabled={busy}

--- a/tests/admin/test-class-automation.php
+++ b/tests/admin/test-class-automation.php
@@ -327,4 +327,31 @@ class Apple_News_Automation_Test extends Apple_News_Testcase {
 		$json = $this->get_json_for_post( $post_id );
 		$this->assertEquals( '#000000', $json['componentTextStyles']['default-title']['textColor'] );
 	}
+
+	/**
+	 * Tests the ability to prepend arbitrary text to the title of an article before it is published.
+	 */
+	public function test_title_automation() {
+		$post_id = self::factory()->post->create( [ 'post_title' => 'Lorem Ipsum Dolor Sit Amet' ] );
+
+		// Create an automation routine for the title component.
+		$result  = wp_insert_term( 'Opinion', 'category' );
+		$term_id = $result['term_id'];
+		update_option(
+			'apple_news_automation',
+			[
+				[
+					'field'    => 'title.prepend',
+					'taxonomy' => 'category',
+					'term_id'  => $term_id,
+					'value'    => 'Opinion:',
+				],
+			]
+		);
+
+		// Set the taxonomy term to trigger the automation routine and ensure the title value is set properly.
+		wp_set_post_terms( $post_id, [ $term_id ], 'category' );
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'Opinion: Lorem Ipsum Dolor Sit Amet', $json['title'] );
+	}
 }


### PR DESCRIPTION
## Summary

Adds a new Automation feature that allows a user to specify text that should be prepended to an article title on Apple News when it is published or updated based on taxonomy terms applied to the post. For example, an editor could specify that if a post has a category of `opinion` that the text `Opinion:` should be prepended to the title, producing a title on Apple News only of `Opinion: Lorem Ipsum Dolor Sit Amet`, for example.

## Notes for reviewers

None.

## Changelog entries

### Added

- A new Automation feature that allows arbitrary text to be prepended to article titles based on categorization, e.g., "Opinion" or "Commentary."

## Ticket(s)

Fixes #1065 