### PR TITLE
APPLE-164: New Automation feature: set contentGenerationType

### DIFF
--- a/admin/class-automation.php
+++ b/admin/class-automation.php
@@ -67,6 +67,7 @@ class Automation {
 		add_filter( 'apple_news_article_metadata', [ __CLASS__, 'filter__apple_news_article_metadata' ], 0, 2 );
 		add_filter( 'apple_news_exporter_slug', [ __CLASS__, 'filter__apple_news_exporter_slug' ], 0, 2 );
 		add_filter( 'apple_news_exporter_title', [ __CLASS__, 'filter__apple_news_exporter_title' ], 0, 2 );
+		add_filter( 'apple_news_metadata', [ __CLASS__, 'filter__apple_news_metadata' ], 0, 2 );
 	}
 
 	/**
@@ -189,6 +190,33 @@ class Automation {
 	}
 
 	/**
+	 * Adds or sets metadata based on automation rules.
+	 *
+	 * @param array $meta    Apple News metadata for a post.
+	 * @param int   $post_id The ID of the post.
+	 *
+	 * @return array The modified array of metadata.
+	 */
+	public static function filter__apple_news_metadata( $meta, $post_id ) {
+		// Trim down the list of matched rules to only those affecting metadata.
+		$metadata_rules = array_values(
+			array_filter(
+				self::get_automation_for_post( $post_id ),
+				function ( $rule ) {
+					return 'metadata' === self::get_fields()[ $rule['field'] ]['location'] ?? '';
+				}
+			)
+		);
+
+		// Loop through each matched rule and apply the value to metadata.
+		foreach ( $metadata_rules as $rule ) {
+			$meta[ $rule['field'] ] = $rule['value'];
+		}
+
+		return $meta;
+	}
+
+	/**
 	 * Given a post ID, returns an array of matching automation rules.
 	 *
 	 * @param int $post_id The post ID to query.
@@ -230,42 +258,47 @@ class Automation {
 	 */
 	public static function get_fields(): array {
 		return [
-			'isHidden'       => [
+			'contentGenerationType' => [
+				'location' => 'metadata',
+				'type'     => 'string',
+				'label'    => __( 'contentGenerationType', 'apple-news' ),
+			],
+			'isHidden'              => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
 				'label'    => __( 'isHidden', 'apple-news' ),
 			],
-			'isPaid'         => [
+			'isPaid'                => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
 				'label'    => __( 'isPaid', 'apple-news' ),
 			],
-			'isPreview'      => [
+			'isPreview'             => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
 				'label'    => __( 'isPreview', 'apple-news' ),
 			],
-			'isSponsored'    => [
+			'isSponsored'           => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
 				'label'    => __( 'isSponsored', 'apple-news' ),
 			],
-			'links.sections' => [
+			'links.sections'        => [
 				'location' => 'article_metadata',
 				'type'     => 'string',
 				'label'    => __( 'Section', 'apple-news' ),
 			],
-			'slug.#text#'    => [
+			'slug.#text#'           => [
 				'location' => 'component',
 				'type'     => 'string',
 				'label'    => __( 'Slug', 'apple-news' ),
 			],
-			'theme'          => [
+			'theme'                 => [
 				'location' => 'exporter',
 				'type'     => 'string',
 				'label'    => __( 'Theme', 'apple-news' ),
 			],
-			'title.prepend'  => [
+			'title.prepend'         => [
 				'location' => 'component',
 				'type'     => 'string',
 				'label'    => __( 'Title: Prepend Text', 'apple-news' ),

--- a/admin/class-automation.php
+++ b/admin/class-automation.php
@@ -261,27 +261,27 @@ class Automation {
 			'contentGenerationType' => [
 				'location' => 'metadata',
 				'type'     => 'string',
-				'label'    => __( 'contentGenerationType', 'apple-news' ),
+				'label'    => 'contentGenerationType',
 			],
 			'isHidden'              => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
-				'label'    => __( 'isHidden', 'apple-news' ),
+				'label'    => 'isHidden',
 			],
 			'isPaid'                => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
-				'label'    => __( 'isPaid', 'apple-news' ),
+				'label'    => 'isPaid',
 			],
 			'isPreview'             => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
-				'label'    => __( 'isPreview', 'apple-news' ),
+				'label'    => 'isPreview',
 			],
 			'isSponsored'           => [
 				'location' => 'article_metadata',
 				'type'     => 'boolean',
-				'label'    => __( 'isSponsored', 'apple-news' ),
+				'label'    => 'isSponsored',
 			],
 			'links.sections'        => [
 				'location' => 'article_metadata',

--- a/assets/js/admin-settings/rule.jsx
+++ b/assets/js/admin-settings/rule.jsx
@@ -29,7 +29,9 @@ function Rule({
     themes,
   } = AppleNewsAutomationConfig;
   let fieldType = '';
-  if (field === 'links.sections') {
+  if (field === 'contentGenerationType') {
+    fieldType = 'contentGenerationType';
+  } else if (field === 'links.sections') {
     fieldType = 'sections';
   } else if (field === 'theme') {
     fieldType = 'themes';
@@ -82,6 +84,18 @@ function Rule({
         />
       </td>
       <td>
+        {fieldType === 'contentGenerationType' ? (
+          <SelectControl
+            aria-labelledby="apple-news-automation-column-value"
+            disabled={busy}
+            onChange={(next) => onUpdate('value', next)}
+            options={[
+              { value: '', label: __('None', 'apple-news') },
+              { value: 'AI', label: __('AI', 'apple-news') },
+            ]}
+            value={value}
+          />
+        ) : null}
         {fieldType === 'sections' ? (
           <SelectControl
             aria-labelledby="apple-news-automation-column-value"

--- a/tests/admin/test-class-automation.php
+++ b/tests/admin/test-class-automation.php
@@ -115,6 +115,33 @@ class Apple_News_Automation_Test extends Apple_News_Testcase {
 	}
 
 	/**
+	 * Tests the functionality of using Automation to set the value of the contentGenerationType metadata.
+	 */
+	public function test_content_generation_type() {
+		$post_id = self::factory()->post->create();
+
+		// Create an automation routine for the slug component.
+		$result  = wp_insert_term( 'AI Generated', 'category' );
+		$term_id = $result['term_id'];
+		update_option(
+			'apple_news_automation',
+			[
+				[
+					'field'    => 'contentGenerationType',
+					'taxonomy' => 'category',
+					'term_id'  => $term_id,
+					'value'    => 'AI',
+				],
+			]
+		);
+
+		// Set the taxonomy term to trigger the automation routine and ensure the contentGenerationType is properly set.
+		wp_set_post_terms( $post_id, [ $term_id ], 'category' );
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'AI', $json['metadata']['contentGenerationType'] );
+	}
+
+	/**
 	 * Ensures that named metadata is properly set via an automation process.
 	 *
 	 * @dataProvider data_metadata_automation


### PR DESCRIPTION
## Summary

Adds a new Automation feature to allow publishers to set `contentGenerationType` to `AI` for posts that are AI generated using taxonomy.

## Changelog entries

### Added

- A new Automation feature that allows publishers to set `contentGenerationType` to `AI` using taxonomy classification.

## Ticket(s)

Fixes #1066