### PR TITLE
APPLE-165 Make custom fonts from channel available to the theme edit screen

### DIFF
--- a/admin/apple-actions/index/class-channel.php
+++ b/admin/apple-actions/index/class-channel.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Publish to Apple News: \Apple_Actions\Index\Channel class
+ *
+ * @package Apple_News
+ */
+
+namespace Apple_Actions\Index;
+
+require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
+
+use Apple_Actions\API_Action;
+
+/**
+ * A class to handle a channel request from the admin.
+ *
+ * @package Apple_News
+ */
+class Channel extends API_Action {
+	/**
+	 * Get the channel data from Apple News.
+	 *
+	 * @return object An object containing the response from the API.
+	 */
+	public function perform() {
+		return $this->get_api()->get_channel( $this->get_setting( 'api_channel' ) );
+	}
+}

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -353,6 +353,15 @@ class Admin_Apple_Themes extends Apple_News {
 			return;
 		}
 
+		// Get information about custom fonts from the channel.
+		require_once __DIR__ . '/apple-actions/index/class-channel.php';
+		$admin_settings = new Admin_Apple_Settings();
+		$channel_api    = new \Apple_Actions\Index\Channel( $admin_settings->fetch_settings() );
+		$channel        = $channel_api->perform();
+		$custom_fonts   = ! empty( $channel->data->fonts ) && is_array( $channel->data->fonts )
+			? wp_list_pluck( $channel->data->fonts, 'name' )
+			: [];
+
 		wp_enqueue_style(
 			'apple-news-themes-css',
 			plugin_dir_url( __FILE__ ) . '../assets/css/themes.css',
@@ -419,7 +428,8 @@ class Admin_Apple_Themes extends Apple_News {
 				'apple-news-theme-edit-js',
 				'appleNewsThemeEdit',
 				[
-					'fontNotice' => __( 'Font preview is only available on macOS', 'apple-news' ),
+					'customFonts' => $custom_fonts,
+					'fontNotice'  => __( 'Font preview is only available on macOS', 'apple-news' ),
 				]
 			);
 		}


### PR DESCRIPTION
Once merged, custom fonts will be available on the theme edit screen via the `appleNewsThemeEdit.customFonts` global property in JavaScript.