### PR TITLE
APPLE-165: Theme editor to reflect fonts uploaded to News Publisher (release/v2.5.0)

### DIFF
--- a/admin/apple-actions/index/class-channel.php
+++ b/admin/apple-actions/index/class-channel.php
@@ -20,9 +20,17 @@ class Channel extends API_Action {
 	/**
 	 * Get the channel data from Apple News.
 	 *
-	 * @return object An object containing the response from the API.
+	 * @return object|null An object containing the response from the API or null on failure.
 	 */
 	public function perform() {
-		return $this->get_api()->get_channel( $this->get_setting( 'api_channel' ) );
+		$channel = get_transient( 'apple_news_channel' );
+		if ( false === $channel ) {
+			if ( $this->is_api_configuration_valid() ) {
+				$channel = $this->get_api()->get_channel( $this->get_setting( 'api_channel' ) );
+				set_transient( 'apple_news_channel', $channel, 300 );
+			}
+		}
+
+		return ! empty( $channel ) ? $channel : null;
 	}
 }

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -428,8 +428,9 @@ class Admin_Apple_Themes extends Apple_News {
 				'apple-news-theme-edit-js',
 				'appleNewsThemeEdit',
 				[
-					'customFonts' => $custom_fonts,
-					'fontNotice'  => __( 'Font preview is only available on macOS', 'apple-news' ),
+					'customFonts'      => $custom_fonts,
+					'customFontNotice' => __( 'Font preview may not be available', 'apple-news' ),
+					'fontNotice'       => __( 'Font preview is only available on macOS', 'apple-news' ),
 				]
 			);
 		}

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -412,3 +412,22 @@ function appleNewsSupportsMacFeatures() {
 		return false;
 	}
 }
+
+/**
+ * Checks if a local font is installed.
+ *
+ * @async
+ * @param {string} selectedFont The PostScript name of the font to check.
+ * @returns {Promise<boolean>} A promise that resolves to true if it can be
+ *                             determined that the font is installed locally,
+ *                             false otherwise.
+ */
+async function appleNewsLocalFontInstalled( selectedFont ) {
+	let localFonts = [];
+	if ( 'queryLocalFonts' in window ) {
+		localFonts = await window.queryLocalFonts({
+			postscriptNames: [selectedFont],
+		});
+	}
+	return localFonts.length !== 0;
+}

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -412,22 +412,3 @@ function appleNewsSupportsMacFeatures() {
 		return false;
 	}
 }
-
-/**
- * Checks if a local font is installed.
- *
- * @async
- * @param {string} selectedFont The PostScript name of the font to check.
- * @returns {Promise<boolean>} A promise that resolves to true if it can be
- *                             determined that the font is installed locally,
- *                             false otherwise.
- */
-async function appleNewsLocalFontInstalled( selectedFont ) {
-	let localFonts = [];
-	if ( 'queryLocalFonts' in window ) {
-		localFonts = await window.queryLocalFonts({
-			postscriptNames: [selectedFont],
-		});
-	}
-	return localFonts.length !== 0;
-}

--- a/assets/js/theme-edit.js
+++ b/assets/js/theme-edit.js
@@ -138,3 +138,22 @@
 	}
 
 }( jQuery ) );
+
+/**
+ * Checks if a local font is installed.
+ *
+ * @async
+ * @param {string} selectedFont The PostScript name of the font to check.
+ * @returns {Promise<boolean>} A promise that resolves to true if it can be
+ *                             determined that the font is installed locally,
+ *                             false otherwise.
+ */
+async function appleNewsLocalFontInstalled( selectedFont ) {
+	let localFonts = [];
+	if ( 'queryLocalFonts' in window ) {
+		localFonts = await window.queryLocalFonts({
+			postscriptNames: [selectedFont],
+		});
+	}
+	return localFonts.length !== 0;
+}

--- a/assets/js/theme-edit.js
+++ b/assets/js/theme-edit.js
@@ -29,11 +29,11 @@
 			templateSelection: appleNewsFontSelectTemplate
 		}).on('select2:select', async function (e) {
 			// Check if font preview is available.
-			const selectedFont = e.params.data.text;
-			const isCustomFont = appleNewsThemeEdit.customFonts.includes(selectedFont);
-			const localFontInstalled = await appleNewsLocalFontInstalled( selectedFont );
-			const $fontNotice = $( 'span.select2' ).next( '.font-notice' );
-			let noticeText = '';
+			var selectedFont = e.params.data.text;
+			var isCustomFont = appleNewsThemeEdit.customFonts.includes(selectedFont);
+			var localFontInstalled = await appleNewsLocalFontInstalled( selectedFont );
+			var $fontNotice = $( 'span.select2' ).next( '.font-notice' );
+			var noticeText = '';
 
 			if ( localFontInstalled ) {
 				// Local font is installed. Remove any warnings.
@@ -149,7 +149,7 @@
  *                             false otherwise.
  */
 async function appleNewsLocalFontInstalled( selectedFont ) {
-	let localFonts = [];
+	var localFonts = [];
 	if ( 'queryLocalFonts' in window ) {
 		localFonts = await window.queryLocalFonts({
 			postscriptNames: [selectedFont],

--- a/assets/js/theme-edit.js
+++ b/assets/js/theme-edit.js
@@ -29,10 +29,10 @@
 			templateSelection: appleNewsFontSelectTemplate
 		}).on('select2:select', async function (e) {
 			// Check if font preview is available.
-			var selectedFont = e.params.data.text;
-			var isCustomFont = appleNewsThemeEdit.customFonts.includes(selectedFont);
-			var localFontInstalled = await appleNewsLocalFontInstalled( selectedFont );
-			var $fontNotice = $( 'span.select2' ).next( '.font-notice' );
+			const selectedFont = e.params.data.text;
+			const isCustomFont = appleNewsThemeEdit.customFonts.includes(selectedFont);
+			const localFontInstalled = await appleNewsLocalFontInstalled( selectedFont );
+			const $fontNotice = $( 'span.select2' ).next( '.font-notice' );
 			let noticeText = '';
 
 			if ( localFontInstalled ) {

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -361,6 +361,18 @@ class Theme {
 	 * @return array The list of iOS fonts.
 	 */
 	public static function get_fonts() {
+		// Get custom fonts from this channel.
+		require_once plugin_dir_path( __DIR__ ) . '../admin/apple-actions/index/class-channel.php';
+		$admin_settings = new \Admin_Apple_Settings();
+		$channel_api    = new \Apple_Actions\Index\Channel( $admin_settings->fetch_settings() );
+		$channel        = $channel_api->perform();
+		$custom_fonts   = ! empty( $channel->data->fonts ) && is_array( $channel->data->fonts )
+			? wp_list_pluck( $channel->data->fonts, 'name' )
+			: [];
+
+		$all_fonts = array_unique( array_merge( self::$fonts, $custom_fonts ) );
+		sort( $all_fonts );
+
 		/**
 		 * Allows the font list to be filtered, so that any custom
 		 * fonts that have been approved by Apple and added to your
@@ -375,7 +387,7 @@ class Theme {
 		 *
 		 * @param array $fonts An array of TrueType font names.
 		 */
-		return apply_filters( 'apple_news_fonts_list', self::$fonts );
+		return apply_filters( 'apple_news_fonts_list', $all_fonts );
 	}
 
 	/**

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -361,6 +361,7 @@ class Theme {
 	 * @return array The list of iOS fonts.
 	 */
 	public static function get_fonts() {
+		wp_die( 'get_fonts invoked' );
 		// Get custom fonts from this channel.
 		require_once plugin_dir_path( __DIR__ ) . '../admin/apple-actions/index/class-channel.php';
 		$admin_settings = new \Admin_Apple_Settings();

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -361,7 +361,6 @@ class Theme {
 	 * @return array The list of iOS fonts.
 	 */
 	public static function get_fonts() {
-		wp_die( 'get_fonts invoked' );
 		// Get custom fonts from this channel.
 		require_once plugin_dir_path( __DIR__ ) . '../admin/apple-actions/index/class-channel.php';
 		$admin_settings = new \Admin_Apple_Settings();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,6 +85,27 @@ apple_news_require_file( dirname( __DIR__, 1 ) . '/vendor/autoload.php' );
 				}
 			);
 
+			// Pre-populate the channel transient to prevent Apple News from making a request to the API for channel data.
+			$channel_api_response = <<<JSON
+{
+  "data": {
+    "createdAt": "1970-01-01T00:00:00Z",
+    "modifiedAt": "1970-01-01T00:00:00Z",
+    "id": "abcdef12-3456-7890-abcd-ef1234567890",
+    "type": "channel",
+    "shareUrl": "https:\/\/apple.news\/TESTAPPLENEWSCHANNELXYZ",
+    "links": {
+      "defaultSection": "https:\/\/news-api.apple.com\/sections\/abcdef12-3456-7890-abcd-ef1234567890",
+      "self": "https:\/\/news-api.apple.com\/channels\/abcdef12-3456-7890-abcd-ef1234567890"
+    },
+    "name": "Apple News Test Channel",
+    "website": "https:\/\/github.com/alleyinteractive/apple-news",
+    "fonts": []
+  }
+}
+JSON;
+			set_transient( 'apple_news_channel', wp_json_encode( $channel_api_response ) );
+
 			// Load the plugin.
 			require dirname( __DIR__, 1 ) . '/apple-news.php';
 		}


### PR DESCRIPTION
## Summary

Updates the Theme editor to reflect fonts uploaded to News Publisher.

## Changelog entries

### Changed

- Theme editor now reflects fonts uploaded to News Publisher.

Fixes #1067 