### PR TITLE
Fix issue with apple_news_section throwing notice when being cast as a string

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -141,13 +141,14 @@ class Admin_Apple_News extends Apple_News {
 					'default' => '',
 				],
 				'apple_news_metadata'            => [
-					'default'           => '',
+					'default'           => [],
 					'sanitize_callback' => function ( $value ) {
 						return ! empty( $value ) && is_string( $value ) ? json_decode( $value, true ) : $value;
 					},
 					'show_in_rest'      => [
 						'prepare_callback' => 'apple_news_json_encode',
 					],
+					'type'              => 'array',
 				],
 				'apple_news_pullquote'           => [
 					'default' => '',
@@ -159,11 +160,16 @@ class Admin_Apple_News extends Apple_News {
 					'default' => '',
 				],
 				'apple_news_sections'            => [
-					'default'           => '',
-					'sanitize_callback' => 'apple_news_sanitize_selected_sections',
-					'show_in_rest'      => [
-						'prepare_callback' => 'apple_news_json_encode',
+					'default'      => [],
+					'show_in_rest' => [
+						'schema' => [
+							'items' => [
+								'type' => 'string',
+							],
+							'type'  => 'array',
+						],
 					],
+					'type'         => 'array',
 				],
 				'apple_news_suppress_video_url'  => [
 					'default' => false,
@@ -192,7 +198,7 @@ class Admin_Apple_News extends Apple_News {
 						}
 					)
 					: $meta_keys;
-				} 
+				}
 			);
 
 			add_action(

--- a/assets/js/pluginsidebar/sidebar.jsx
+++ b/assets/js/pluginsidebar/sidebar.jsx
@@ -91,14 +91,13 @@ function Sidebar() {
   const [metadataRaw, setMetadataRaw] = usePostMetaValue('apple_news_metadata');
   const [pullquoteText, setPullquoteText] = usePostMetaValue('apple_news_pullquote');
   const [pullquotePosition, setPullquotePosition] = usePostMetaValue('apple_news_pullquote_position');
-  const [selectedSectionsRaw, setSelectedSectionsRaw] = usePostMetaValue('apple_news_sections');
+  const [selectedSections, setSelectedSectionsRaw] = usePostMetaValue('apple_news_sections');
   const [slug, setSlug] = usePostMetaValue('apple_news_slug');
   const [suppressVideoURL, setSuppressVideoURL] = usePostMetaValue('apple_news_suppress_video_url');
   const [useImageComponent, setUseImageComponent] = usePostMetaValue('apple_news_use_image_component');
 
   // Decode selected sections.
   const metadata = safeJsonParseArray(metadataRaw);
-  const selectedSections = safeJsonParseArray(selectedSectionsRaw);
 
   /**
    * A helper function for setting metadata.
@@ -110,7 +109,7 @@ function Sidebar() {
    * A helper function for setting selected sections.
    * @param {Array} next - The array of selected sections to set.
    */
-  const setSelectedSections = (next) => setSelectedSectionsRaw(JSON.stringify(next));
+  const setSelectedSections = (next) => setSelectedSectionsRaw(next);
 
   /**
    * A helper function for displaying a notification to the user.


### PR DESCRIPTION
Continues the work started in #1046 by @msawicki to fix a PHP notice reported in #963.

From #963:

> NOTICE: PHP message: PHP Notice: Array to string conversion in /var/www/html/public/wp/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php on line 424

This change will make `apple_news_sections` act as an array within the REST API instead of converting it to JSON for transmission to the front-end. This allows it to play better with the rest of the REST API.