### PR TITLE
APPLE-166: Allow in-article modules similar to EOA module (release/v2.5.0)

### DIFF
--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -225,7 +225,7 @@ class Admin_Apple_Settings extends Apple_News {
 
 			// Merge settings in the option with defaults.
 			foreach ( $settings->all() as $key => $value ) {
-				$wp_value       = ( empty( $wp_settings[ $key ] ) )
+				$wp_value       = ( ! isset( $wp_settings[ $key ] ) )
 					? $value
 					: $wp_settings[ $key ];
 				$settings->$key = $wp_value;

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -32,22 +32,22 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 
 		// Add the settings.
 		$this->settings = [
-			'component_alerts'  => [
+			'component_alerts'    => [
 				'label'       => __( 'Component Alerts', 'apple-news' ),
 				'type'        => [ 'none', 'warn', 'fail' ],
 				'description' => __( 'If a post has a component that is unsupported by Apple News, choose "none" to generate no alert, "warn" to provide an admin warning notice, or "fail" to generate a notice and stop publishing.', 'apple-news' ),
 			],
-			'use_remote_images' => [
+			'use_remote_images'   => [
 				'label'       => __( 'Use Remote Images?', 'apple-news' ),
 				'type'        => [ 'yes', 'no' ],
 				'description' => __( 'Allow the Apple News API to retrieve images remotely rather than bundle them. This setting is recommended if you are having any issues with publishing images. If your images are not publicly accessible, such as on a development site, you cannot use this feature.', 'apple-news' ),
 			],
-			'full_bleed_images' => [
+			'full_bleed_images'   => [
 				'label'       => __( 'Use Full-Bleed Images?', 'apple-news' ),
 				'type'        => [ 'yes', 'no' ],
 				'description' => __( 'If set to yes, images that are centered or have no alignment will span edge-to-edge rather than being constrained within the body margins.', 'apple-news' ),
 			],
-			'html_support'      => [
+			'html_support'        => [
 				'label'       => __( 'Enable HTML support?', 'apple-news' ),
 				'type'        => [ 'yes', 'no' ],
 				'description' => sprintf(
@@ -56,6 +56,11 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 					'<a href="' . esc_url( 'https://developer.apple.com/documentation/apple_news/apple_news_format/components/using_html_with_apple_news_format' ) . '">',
 					'</a>'
 				),
+			],
+			'in_article_position' => [
+				'label'       => __( 'Position of In Article Module', 'apple-news' ),
+				'type'        => 'integer',
+				'description' => __( 'If you have configured an In Article module via Customize JSON, the position that the module should be inserted into. Defaults to 3, which is after the third content block in the article body (e.g., the third paragraph).', 'apple-news' ),
 			],
 		];
 
@@ -71,7 +76,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			],
 			'format' => [
 				'label'    => __( 'Format Settings', 'apple-news' ),
-				'settings' => [ 'html_support' ],
+				'settings' => [ 'html_support', 'in_article_position' ],
 			],
 		];
 

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -59,7 +59,10 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			],
 			'in_article_position' => [
 				'label'       => __( 'Position of In Article Module', 'apple-news' ),
-				'type'        => 'integer',
+				'type'        => 'number',
+				'min'         => 0,
+				'max'         => 99,
+				'step'        => 1,
 				'description' => __( 'If you have configured an In Article module via Customize JSON, the position that the module should be inserted into. Defaults to 3, which is after the third content block in the article body (e.g., the third paragraph).', 'apple-news' ),
 			],
 		];

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -376,9 +376,9 @@ class Admin_Apple_Settings_Section extends Apple_News {
 				esc_attr( $name ),
 				esc_attr( $value ),
 				5,
-				$this->get_min_for( $name ),
-				$this->get_max_for( $name ),
-				$this->get_step_for( $name ),
+				esc_attr( $this->get_min_for( $name ) ),
+				esc_attr( $this->get_max_for( $name ) ),
+				esc_attr( $this->get_step_for( $name ) ),
 				esc_attr( $this->is_required( $name ) )
 			);
 		} else {

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -122,6 +122,8 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'name'        => [],
 			'value'       => [],
 			'placeholder' => [],
+			'min'         => [],
+			'max'         => [],
 			'step'        => [],
 			'type'        => [],
 			'required'    => [],
@@ -260,7 +262,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 
 		$type = $this->get_type_for( $name );
 
-		// If the field has it's own render callback, use that here.
+		// If the field has its own render callback, use that here.
 		// This is because the options page doesn't actually use do_settings_section.
 		if ( ! empty( $callback ) ) {
 			return call_user_func( $callback, $type );
@@ -320,6 +322,8 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field = '<input type="file" id="%s" name="%s">';
 		} elseif ( 'textarea' === $type ) {
 			$field = '<textarea id="%s" name="%s">%s</textarea>';
+		} elseif ( 'number' === $type ) {
+			$field = '<input type="number" id="%s" name="%s" value="%s" size="%s" min="%s" max="%s" step="%s" %s>';
 		} else {
 			// If nothing else matches, it's a string.
 			$field = '<input type="text" id="%s" name="%s" value="%s" size="%s" %s>';
@@ -365,6 +369,18 @@ class Admin_Apple_Settings_Section extends Apple_News {
 				esc_attr( $name ),
 				esc_attr( $value )
 			);
+		} elseif ( 'number' === $type ) {
+			return sprintf(
+				$field,
+				esc_attr( $name ),
+				esc_attr( $name ),
+				esc_attr( $value ),
+				5,
+				$this->get_min_for( $name ),
+				$this->get_max_for( $name ),
+				$this->get_step_for( $name ),
+				esc_attr( $this->is_required( $name ) )
+			);
 		} else {
 			return sprintf(
 				$field,
@@ -374,7 +390,6 @@ class Admin_Apple_Settings_Section extends Apple_News {
 				intval( $size ),
 				esc_attr( $this->is_required( $name ) )
 			);
-
 		}
 	}
 
@@ -402,6 +417,45 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	 */
 	protected function get_description_for( $name ) {
 		return empty( $this->settings[ $name ]['description'] ) ? '' : $this->settings[ $name ]['description'];
+	}
+
+	/**
+	 * Get the maximum value for a field.
+	 *
+	 * @param string $name The name of the field for which to fetch a maximum value.
+	 *
+	 * @return int|float|string The maximum value, or an empty string if not set.
+	 */
+	protected function get_max_for( $name ) {
+		return isset( $this->settings[ $name ]['max'] ) && ( is_int( $this->settings[ $name ]['max'] ) || is_float( $this->settings[ $name ]['max'] ) )
+			? $this->settings[ $name ]['max']
+			: '';
+	}
+
+	/**
+	 * Get the minimum value for a field.
+	 *
+	 * @param string $name The name of the field for which to fetch a minimum value.
+	 *
+	 * @return int|float|string The minimum value, or an empty string if not set.
+	 */
+	protected function get_min_for( $name ) {
+		return isset( $this->settings[ $name ]['min'] ) && ( is_int( $this->settings[ $name ]['min'] ) || is_float( $this->settings[ $name ]['min'] ) )
+			? $this->settings[ $name ]['min']
+			: '';
+	}
+
+	/**
+	 * Get the stepping value for a field.
+	 *
+	 * @param string $name The name of the field for which to fetch a stepping value.
+	 *
+	 * @return int|float The stepping value, or a default value of 1 if not set.
+	 */
+	protected function get_step_for( $name ) {
+		return isset( $this->settings[ $name ]['step'] ) && ( is_int( $this->settings[ $name ]['step'] ) || is_float( $this->settings[ $name ]['step'] ) )
+			? $this->settings[ $name ]['step']
+			: 1;
 	}
 
 	/**

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -37,7 +37,7 @@ function get_settings_response( $data ) { // phpcs:ignore Generic.CodeAnalysis.U
 		'apiAutosyncUpdate'   => 'yes' === $settings->api_autosync_update,
 		'fullBleedImages'     => 'yes' === $settings->full_bleed_images,
 		'htmlSupport'         => 'yes' === $settings->html_support,
-		'inArticlePosition'   => is_int( $settings->in_article_position ) ? $settings->in_article_position : $default_settings['in_article_position'],
+		'inArticlePosition'   => is_numeric( $settings->in_article_position ) ? (int) $settings->in_article_position : $default_settings['in_article_position'],
 		'postTypes'           => ! empty( $settings->post_types ) && is_array( $settings->post_types ) ? array_map( 'sanitize_text_field', $settings->post_types ) : [],
 		'showMetabox'         => 'yes' === $settings->show_metabox,
 		'useRemoteImages'     => 'yes' === $settings->use_remote_images,

--- a/includes/REST/apple-news-get-settings.php
+++ b/includes/REST/apple-news-get-settings.php
@@ -7,6 +7,7 @@
 
 namespace Apple_News\REST;
 
+use Apple_Exporter\Settings;
 use Apple_News\Admin\Automation;
 
 /**
@@ -24,8 +25,9 @@ function get_settings_response( $data ) { // phpcs:ignore Generic.CodeAnalysis.U
 	}
 
 	// Compile non-sensitive plugin settings into a JS-friendly format and return.
-	$admin_settings = new \Admin_Apple_Settings();
-	$settings       = $admin_settings->fetch_settings();
+	$admin_settings   = new \Admin_Apple_Settings();
+	$settings         = $admin_settings->fetch_settings();
+	$default_settings = ( new Settings() )->all();
 	return [
 		'adminUrl'            => esc_url_raw( admin_url( 'admin.php?page=apple-news-options' ) ),
 		'automaticAssignment' => ! empty( Automation::get_automation_rules() ),
@@ -35,6 +37,7 @@ function get_settings_response( $data ) { // phpcs:ignore Generic.CodeAnalysis.U
 		'apiAutosyncUpdate'   => 'yes' === $settings->api_autosync_update,
 		'fullBleedImages'     => 'yes' === $settings->full_bleed_images,
 		'htmlSupport'         => 'yes' === $settings->html_support,
+		'inArticlePosition'   => is_int( $settings->in_article_position ) ? $settings->in_article_position : $default_settings['in_article_position'],
 		'postTypes'           => ! empty( $settings->post_types ) && is_array( $settings->post_types ) ? array_map( 'sanitize_text_field', $settings->post_types ) : [],
 		'showMetabox'         => 'yes' === $settings->show_metabox,
 		'useRemoteImages'     => 'yes' === $settings->use_remote_images,

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -909,7 +909,8 @@ class Components extends Builder {
 		// Insert in-article module at the proper position, if set.
 		if ( ! empty( $json_templates['in_article']['json'] ) ) {
 			$position = $this->get_setting( 'in_article_position' );
-			if ( is_int( $position ) ) {
+			if ( is_numeric( $position ) ) {
+				$position = (int) $position;
 				if ( $position < 0 ) {
 					$position = 0;
 				}

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -14,6 +14,7 @@ namespace Apple_Exporter\Builders;
 use Apple_Exporter\Component_Factory;
 use Apple_Exporter\Components\Component;
 use Apple_Exporter\Components\Image;
+use Apple_Exporter\Settings;
 use Apple_Exporter\Theme;
 use Apple_Exporter\Workspace;
 use Apple_News;
@@ -907,8 +908,15 @@ class Components extends Builder {
 
 		// Insert in-article module at the proper position, if set.
 		if ( ! empty( $json_templates['in_article']['json'] ) ) {
-			// TODO: Fetch this value from settings.
-			$position   = 3;
+			$position = $this->get_setting( 'in_article_position' );
+			if ( is_int( $position ) ) {
+				if ( $position < 0 ) {
+					$position = 0;
+				}
+			} else {
+				$default_settings = ( new Settings() )->all();
+				$position         = $default_settings['in_article_position'];
+			}
 			$components = array_merge(
 				array_slice( $components, 0, $position ),
 				[ Component_Factory::get_component( 'in-article', '' ) ],

--- a/includes/apple-exporter/builders/class-components.php
+++ b/includes/apple-exporter/builders/class-components.php
@@ -905,6 +905,18 @@ class Components extends Builder {
 		$theme          = Theme::get_used();
 		$json_templates = $theme->get_value( 'json_templates' );
 
+		// Insert in-article module at the proper position, if set.
+		if ( ! empty( $json_templates['in_article']['json'] ) ) {
+			// TODO: Fetch this value from settings.
+			$position   = 3;
+			$components = array_merge(
+				array_slice( $components, 0, $position ),
+				[ Component_Factory::get_component( 'in-article', '' ) ],
+				array_slice( $components, $position )
+			);
+		}
+
+		// Insert end of article module, if set.
 		if ( ! empty( $json_templates['end_of_article']['json'] ) ) {
 			$components[] = Component_Factory::get_component( 'end-of-article', '' );
 		}

--- a/includes/apple-exporter/class-component-factory.php
+++ b/includes/apple-exporter/class-component-factory.php
@@ -118,6 +118,7 @@ class Component_Factory {
 		self::register_component( 'slug', '\\Apple_Exporter\\Components\\Slug' );
 		self::register_component( 'advertisement', '\\Apple_Exporter\\Components\\Advertisement' );
 		self::register_component( 'end-of-article', '\\Apple_Exporter\\Components\\End_Of_Article' );
+		self::register_component( 'in-article', '\\Apple_Exporter\\Components\\In_Article' );
 
 		/**
 		 * Allows you to add custom component classes to the plugin.

--- a/includes/apple-exporter/class-settings.php
+++ b/includes/apple-exporter/class-settings.php
@@ -45,6 +45,7 @@ class Settings {
 		'component_alerts'            => 'none',
 		'full_bleed_images'           => 'no',
 		'html_support'                => 'yes',
+		'in_article_position'         => 3,
 		'post_types'                  => [ 'post' ],
 		'show_metabox'                => 'yes',
 		'use_remote_images'           => 'yes',

--- a/includes/apple-exporter/components/class-in-article.php
+++ b/includes/apple-exporter/components/class-in-article.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Publish to Apple News: \Apple_Exporter\Components\In_Article class
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter\Components
+ */
+
+namespace Apple_Exporter\Components;
+
+/**
+ * Represents an In Article module. The module initializes as empty and
+ * is defined by the user via the Customize JSON feature. If non-empty, it is
+ * inserted into the article body after the block occupying the specified position.
+ *
+ * @since 2.5.0
+ */
+class In_Article extends Component {
+	/**
+	 * Register all specs for the component.
+	 */
+	public function register_specs() {
+		$this->register_spec(
+			'json',
+			__( 'JSON', 'apple-news' ),
+			[]
+		);
+		$this->register_spec(
+			'layout',
+			__( 'Layout', 'apple-news' ),
+			[]
+		);
+	}
+
+	/**
+	 * Build the component.
+	 *
+	 * @param string $html The HTML to parse into text for processing.
+	 */
+	protected function build( $html ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->register_json(
+			'json',
+			[]
+		);
+
+		$this->set_layout();
+	}
+
+	/**
+	 * Set the layout for the component.
+	 *
+	 * @access private
+	 */
+	private function set_layout() {
+		$this->register_full_width_layout(
+			'in-article-layout',
+			'layout',
+			[],
+			'layout'
+		);
+	}
+}

--- a/tests/apple-exporter/components/test-class-in-article.php
+++ b/tests/apple-exporter/components/test-class-in-article.php
@@ -55,25 +55,26 @@ HTML,
 			[
 				'json_templates' => [
 					'in_article' => [
-						'json'     => [
+						'json'   => [
 							'role'      => 'heading',
 							'text'      => 'In Article Module Test',
 							'format'    => 'html',
 							'textStyle' => 'default-heading-1',
 							'layout'    => 'heading-layout',
 						],
-						'layout'   => [],
-						'position' => 3,
+						'layout' => [],
 					],
 				],
 			]
 		);
 
-		// Fetch the JSON for the article again and confirm that the in-article module is inserted at the proper position.
+		// Fetch the JSON for the article again and confirm that the in-article module is inserted at the default position (after the third item).
 		$json = $this->get_json_for_post( $post_id );
 		$this->assertEquals( 9, count( $json['components'] ) );
 		$this->assertEquals( '<p>Paragraph 1</p>', $json['components'][3]['text'] );
 		$this->assertEquals( 'In Article Module Test', $json['components'][6]['text'] );
 		$this->assertEquals( '<p>Paragraph 5</p>', $json['components'][8]['text'] );
+
+		// TODO: Test additional position values.
 	}
 }

--- a/tests/apple-exporter/components/test-class-in-article.php
+++ b/tests/apple-exporter/components/test-class-in-article.php
@@ -75,6 +75,19 @@ HTML,
 		$this->assertEquals( 'In Article Module Test', $json['components'][6]['text'] );
 		$this->assertEquals( '<p>Paragraph 5</p>', $json['components'][8]['text'] );
 
-		// TODO: Test additional position values.
+		// Test insertion at the beginning.
+		$this->settings->in_article_position = 0;
+		$json                                = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'In Article Module Test', $json['components'][3]['text'] );
+
+		// Test insertion at the end.
+		$this->settings->in_article_position = 5;
+		$json                                = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'In Article Module Test', $json['components'][8]['text'] );
+
+		// Test overflow insertion.
+		$this->settings->in_article_position = 99;
+		$json                                = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 'In Article Module Test', $json['components'][8]['text'] );
 	}
 }

--- a/tests/apple-exporter/components/test-class-in-article.php
+++ b/tests/apple-exporter/components/test-class-in-article.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Publish to Apple News tests: Test_In_Article class
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+
+/**
+ * A class to test the behavior of the Apple_Exporter\Components\In_Article class.
+ *
+ * @package Apple_News
+ * @subpackage Tests
+ */
+class Apple_News_In_Article_Test extends Apple_News_Component_TestCase {
+	/**
+	 * Ensures that an in-article component is inserted at the proper place if configured.
+	 */
+	public function test_in_article_insertion() {
+		// Create some sample content with five paragraphs so we can test insertion between them.
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => <<<HTML
+<!-- wp:paragraph -->
+<p>Paragraph 1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 3</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 4</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 5</p>
+<!-- /wp:paragraph -->
+HTML,
+			]
+		);
+
+		// Ensure that an in-article component does not exist if it isn't configured.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 8, count( $json['components'] ) );
+		$this->assertEquals( '<p>Paragraph 1</p>', $json['components'][3]['text'] );
+		$this->assertEquals( '<p>Paragraph 5</p>', $json['components'][7]['text'] );
+
+		// Configure an in-article component in theme settings.
+		$this->set_theme_settings(
+			[
+				'json_templates' => [
+					'in_article' => [
+						'json'     => [
+							'role'      => 'heading',
+							'text'      => 'In Article Module Test',
+							'format'    => 'html',
+							'textStyle' => 'default-heading-1',
+							'layout'    => 'heading-layout',
+						],
+						'layout'   => [],
+						'position' => 3,
+					],
+				],
+			]
+		);
+
+		// Fetch the JSON for the article again and confirm that the in-article module is inserted at the proper position.
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals( 9, count( $json['components'] ) );
+		$this->assertEquals( '<p>Paragraph 1</p>', $json['components'][3]['text'] );
+		$this->assertEquals( 'In Article Module Test', $json['components'][6]['text'] );
+		$this->assertEquals( '<p>Paragraph 5</p>', $json['components'][8]['text'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds an in-article module similar to the End-of-Article module. Configurable via Customize JSON. Insertion position is configurable on the settings screen.

## Changelog entries

### Added

- In-article module functionality similar to the End-of-Article module.

Fixes #1068 