### PR TITLE
Switch apple_news_metadata back to string

### DIFF
--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -141,14 +141,14 @@ class Admin_Apple_News extends Apple_News {
 					'default' => '',
 				],
 				'apple_news_metadata'            => [
-					'default'           => [],
+					'default'           => '',
 					'sanitize_callback' => function ( $value ) {
 						return ! empty( $value ) && is_string( $value ) ? json_decode( $value, true ) : $value;
 					},
 					'show_in_rest'      => [
 						'prepare_callback' => 'apple_news_json_encode',
 					],
-					'type'              => 'array',
+					'type'              => 'string',
 				],
 				'apple_news_pullquote'           => [
 					'default' => '',

--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.4.7
+ * Version:     2.4.8
  * Author:      Alley
  * Author URI:  https://alley.com
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -50,7 +50,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static string $version = '2.4.7';
+	public static string $version = '2.4.8';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-to-apple-news",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "hasInstallScript": true,
       "license": "GPLv3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 6.3
 Tested up to: 6.4.2
 Requires PHP: 8.0
-Stable tag: 2.4.7
+Stable tag: 2.4.8
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -45,6 +45,10 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.4.8 =
+
+* Bugfix: #1089 - Resolve notice thrown with registering `apple_news_metadata` meta.
 
 = 2.4.7 =
 


### PR DESCRIPTION
Resolves #1087

Converts the meta data back to string given that it is being JSON-encoded.