### PR TITLE
APPLE-167: Convert is* Flags to true/false/not set

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -331,21 +331,21 @@ class Push extends API_Action {
 			$meta['data']['links'] = [ 'sections' => $this->sections ];
 		}
 
-		// Get the isPreview setting.
-		$is_paid                = (bool) get_post_meta( $this->id, 'apple_news_is_paid', true );
-		$meta['data']['isPaid'] = $is_paid;
-
-		// Get the isPreview setting.
-		$is_preview                = (bool) get_post_meta( $this->id, 'apple_news_is_preview', true );
-		$meta['data']['isPreview'] = $is_preview;
-
-		// Get the isHidden setting.
-		$is_hidden                = (bool) get_post_meta( $this->id, 'apple_news_is_hidden', true );
-		$meta['data']['isHidden'] = $is_hidden;
-
-		// Get the isSponsored setting.
-		$is_sponsored                = (bool) get_post_meta( $this->id, 'apple_news_is_sponsored', true );
-		$meta['data']['isSponsored'] = $is_sponsored;
+		// Set boolean metadata. Don't set values at all if they are not set in postmeta, or are set to empty string.
+		$metadata_keys = [
+			'isHidden'    => 'apple_news_is_hidden',
+			'isPaid'      => 'apple_news_is_paid',
+			'isPreview'   => 'apple_news_is_preview',
+			'isSponsored' => 'apple_news_is_sponsored',
+		];
+		foreach ( $metadata_keys as $metadata_property => $meta_key ) {
+			$meta_value = get_post_meta( $this->id, $meta_key, true );
+			if ( 'true' === $meta_value || '1' === $meta_value ) {
+				$meta['data'][ $metadata_property ] = true;
+			} elseif ( 'false' === $meta_value || '0' === $meta_value ) {
+				$meta['data'][ $metadata_property ] = false;
+			}
+		}
 
 		// Get the maturity rating setting.
 		$maturity_rating = get_post_meta( $this->id, 'apple_news_maturity_rating', true );

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -175,10 +175,10 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		$fields = [
 			'apple_news_coverimage'          => 'integer',
 			'apple_news_coverimage_caption'  => 'textarea',
-			'apple_news_is_hidden'           => 'boolean',
-			'apple_news_is_paid'             => 'boolean',
-			'apple_news_is_preview'          => 'boolean',
-			'apple_news_is_sponsored'        => 'boolean',
+			'apple_news_is_hidden'           => 'string',
+			'apple_news_is_paid'             => 'string',
+			'apple_news_is_preview'          => 'string',
+			'apple_news_is_sponsored'        => 'string',
 			'apple_news_pullquote'           => 'string',
 			'apple_news_pullquote_position'  => 'string',
 			'apple_news_slug'                => 'string',
@@ -356,6 +356,12 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 		if ( empty( $pullquote_position ) ) {
 			$pullquote_position = 'middle';
 		}
+
+		// Handle backwards compatibility for is* fields that were previously stored as booleans.
+		$is_hidden    = '1' === $is_hidden ? 'true' : $is_hidden;
+		$is_paid      = '1' === $is_paid ? 'true' : $is_paid;
+		$is_preview   = '1' === $is_preview ? 'true' : $is_preview;
+		$is_sponsored = '1' === $is_sponsored ? 'true' : $is_sponsored;
 
 		// Create local copies of values to pass into the partial.
 		$publish_action = self::PUBLISH_ACTION;

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -122,20 +122,16 @@ class Admin_Apple_News extends Apple_News {
 					'default' => '',
 				],
 				'apple_news_is_hidden'           => [
-					'default' => false,
-					'type'    => 'boolean',
+					'default' => '',
 				],
 				'apple_news_is_paid'             => [
-					'default' => false,
-					'type'    => 'boolean',
+					'default' => '',
 				],
 				'apple_news_is_preview'          => [
-					'default' => false,
-					'type'    => 'boolean',
+					'default' => '',
 				],
 				'apple_news_is_sponsored'        => [
-					'default' => false,
-					'type'    => 'boolean',
+					'default' => '',
 				],
 				'apple_news_maturity_rating'     => [
 					'default' => '',
@@ -192,7 +188,7 @@ class Admin_Apple_News extends Apple_News {
 						}
 					)
 					: $meta_keys;
-				} 
+				}
 			);
 
 			add_action(

--- a/admin/class-automation.php
+++ b/admin/class-automation.php
@@ -266,22 +266,22 @@ class Automation {
 			],
 			'isHidden'              => [
 				'location' => 'article_metadata',
-				'type'     => 'boolean',
+				'type'     => 'string',
 				'label'    => 'isHidden',
 			],
 			'isPaid'                => [
 				'location' => 'article_metadata',
-				'type'     => 'boolean',
+				'type'     => 'string',
 				'label'    => 'isPaid',
 			],
 			'isPreview'             => [
 				'location' => 'article_metadata',
-				'type'     => 'boolean',
+				'type'     => 'string',
 				'label'    => 'isPreview',
 			],
 			'isSponsored'           => [
 				'location' => 'article_metadata',
-				'type'     => 'boolean',
+				'type'     => 'string',
 				'label'    => 'isSponsored',
 			],
 			'links.sections'        => [

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -48,25 +48,41 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 	<div id="apple-news-metabox-metadata" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
 		<h3><?php esc_html_e( 'Metadata', 'apple-news' ); ?></h3>
 		<label for="apple-news-is-paid">
-			<input id="apple-news-is-paid" name="apple_news_is_paid" type="checkbox" value="1" <?php checked( $is_paid ); ?>>
 			<strong><?php esc_html_e( 'Paid Article', 'apple-news' ); ?></strong>
+			<select id="apple-news-is-paid" name="apple_news_is_paid">
+				<option value=""><?php esc_html_e( 'Channel Default', 'apple-news' ); ?></option>
+				<option value="true" <?php selected( 'true', $is_paid ); ?>><?php esc_html_e( 'True', 'apple-news' ); ?></option>
+				<option value="false" <?php selected( 'false', $is_paid ); ?>><?php esc_html_e( 'False', 'apple-news' ); ?></option>
+			</select>
 		</label>
-		<p><?php esc_html_e( 'Check this to indicate that viewing the article requires a paid subscription. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news' ); ?></p>
+		<p><?php esc_html_e( 'Set this setting to true to indicate that viewing the article requires a paid subscription, false to indicate that it does not, or leave it empty to use the channel default value. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news' ); ?></p>
 		<label for="apple-news-is-preview">
-			<input id="apple-news-is-preview" name="apple_news_is_preview" type="checkbox" value="1" <?php checked( $is_preview ); ?>>
 			<strong><?php esc_html_e( 'Preview Article', 'apple-news' ); ?></strong>
+			<select id="apple-news-is-preview" name="apple_news_is_preview">
+				<option value=""><?php esc_html_e( 'Channel Default', 'apple-news' ); ?></option>
+				<option value="true" <?php selected( 'true', $is_preview ); ?>><?php esc_html_e( 'True', 'apple-news' ); ?></option>
+				<option value="false" <?php selected( 'false', $is_preview ); ?>><?php esc_html_e( 'False', 'apple-news' ); ?></option>
+			</select>
 		</label>
-		<p><?php esc_html_e( 'Check this to publish the article as a draft.', 'apple-news' ); ?></p>
+		<p><?php esc_html_e( 'Set this setting to true to publish the article as a draft.', 'apple-news' ); ?></p>
 		<label for="apple-news-is-hidden">
-			<input id="apple-news-is-hidden" name="apple_news_is_hidden" type="checkbox" value="1" <?php checked( $is_hidden ); ?>>
 			<strong><?php esc_html_e( 'Hidden Article', 'apple-news' ); ?></strong>
+			<select id="apple-news-is-hidden" name="apple_news_is_hidden">
+				<option value=""><?php esc_html_e( 'Channel Default', 'apple-news' ); ?></option>
+				<option value="true" <?php selected( 'true', $is_hidden ); ?>><?php esc_html_e( 'True', 'apple-news' ); ?></option>
+				<option value="false" <?php selected( 'false', $is_hidden ); ?>><?php esc_html_e( 'False', 'apple-news' ); ?></option>
+			</select>
 		</label>
-		<p><?php esc_html_e( 'Check this to publish the article as a hidden article. Hidden articles are visible to users who have a link to the article, but do not appear in feeds.', 'apple-news' ); ?></p>
+		<p><?php esc_html_e( 'Set this setting to true to publish the article as a hidden article. Hidden articles are visible to users who have a link to the article, but do not appear in feeds.', 'apple-news' ); ?></p>
 		<label for="apple-news-is-sponsored">
-			<input id="apple-news-is-sponsored" name="apple_news_is_sponsored" type="checkbox" value="1" <?php checked( $is_sponsored ); ?>>
 			<strong><?php esc_html_e( 'Sponsored Article', 'apple-news' ); ?></strong>
+			<select id="apple-news-is-sponsored" name="apple_news_is_sponsored">
+				<option value=""><?php esc_html_e( 'Channel Default', 'apple-news' ); ?></option>
+				<option value="true" <?php selected( 'true', $is_sponsored ); ?>><?php esc_html_e( 'True', 'apple-news' ); ?></option>
+				<option value="false" <?php selected( 'false', $is_sponsored ); ?>><?php esc_html_e( 'False', 'apple-news' ); ?></option>
+			</select>
 		</label>
-		<p><?php esc_html_e( 'Check this to indicate this article is sponsored content.', 'apple-news' ); ?></p>
+		<p><?php esc_html_e( 'Set this setting to true to indicate this article is sponsored content.', 'apple-news' ); ?></p>
 		<label for="apple-news-suppress-video-url">
 			<input id="apple-news-suppress-video-url" name="apple_news_suppress_video_url" type="checkbox" value="1" <?php checked( $suppress_video_url ); ?>>
 			<strong><?php esc_html_e( 'Do not set videoURL metadata for this article', 'apple-news' ); ?></strong>

--- a/assets/js/admin-settings/rule.jsx
+++ b/assets/js/admin-settings/rule.jsx
@@ -31,6 +31,8 @@ function Rule({
   let fieldType = '';
   if (field === 'contentGenerationType') {
     fieldType = 'contentGenerationType';
+  } else if (['isHidden', 'isPaid', 'isPreview', 'isSponsored'].includes(field)) {
+    fieldType = 'boolean-select';
   } else if (field === 'links.sections') {
     fieldType = 'sections';
   } else if (field === 'theme') {
@@ -104,6 +106,19 @@ function Rule({
             options={[
               { value: '', label: __('Select Section', 'apple-news') },
               ...sections.map((sect) => ({ value: sect.id, label: sect.name })),
+            ]}
+            value={value}
+          />
+        ) : null}
+        {fieldType === 'boolean-select' ? (
+          <SelectControl
+            aria-labelledby="apple-news-automation-column-value"
+            disabled={busy}
+            onChange={(next) => onUpdate('value', next)}
+            options={[
+              { value: '', label: __('Channel Default', 'apple-news') },
+              { value: 'true', label: __('True', 'apple-news') },
+              { value: 'false', label: __('False', 'apple-news') },
             ]}
             value={value}
           />

--- a/assets/js/pluginsidebar/panels/metadata.jsx
+++ b/assets/js/pluginsidebar/panels/metadata.jsx
@@ -37,29 +37,49 @@ function Metadata({
       initialOpen={false}
       title={__('Metadata', 'apple-news')}
     >
-      <CheckboxControl
-        checked={isPaid}
-        help={__('Check this to indicate that viewing the article requires a paid subscription. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news')}
+      <SelectControl
+        help={__('Set this setting to true to indicate that viewing the article requires a paid subscription, false to indicate that it does not, or leave it empty to use the channel default value. Note that Apple must approve your channel for paid content before using this feature.', 'apple-news')}
         label={__('Paid Article', 'apple-news')}
         onChange={onChangeIsPaid}
+        options={[
+          { label: __('Channel Default', 'apple-news'), value: '' },
+          { label: __('True', 'apple-news'), value: 'true' },
+          { label: __('False', 'apple-news'), value: 'false' },
+        ]}
+        value={isPaid === '1' ? 'true' : isPaid}
       />
-      <CheckboxControl
-        checked={isPreview}
-        help={__('Check this to publish the article as a draft.', 'apple-news')}
+      <SelectControl
+        help={__('Set this setting to true to publish the article as a draft.', 'apple-news')}
         label={__('Preview Article', 'apple-news')}
         onChange={onChangeIsPreview}
+        options={[
+          { label: __('Channel Default', 'apple-news'), value: '' },
+          { label: __('True', 'apple-news'), value: 'true' },
+          { label: __('False', 'apple-news'), value: 'false' },
+        ]}
+        value={isPreview === '1' ? 'true' : isPreview}
       />
-      <CheckboxControl
-        checked={isHidden}
-        help={__('Check this to publish the article as a hidden article. Hidden articles are visible to users who have a link to the article, but do not appear in feeds.', 'apple-news')}
+      <SelectControl
+        help={__('Set this setting to true to publish the article as a hidden article. Hidden articles are visible to users who have a link to the article, but do not appear in feeds.', 'apple-news')}
         label={__('Hidden Article', 'apple-news')}
         onChange={onChangeIsHidden}
+        options={[
+          { label: __('Channel Default', 'apple-news'), value: '' },
+          { label: __('True', 'apple-news'), value: 'true' },
+          { label: __('False', 'apple-news'), value: 'false' },
+        ]}
+        value={isHidden === '1' ? 'true' : isHidden}
       />
-      <CheckboxControl
-        checked={isSponsored}
-        help={__('Check this to indicate this article is sponsored content.', 'apple-news')}
+      <SelectControl
+        help={__('Set this setting to true to indicate this article is sponsored content.', 'apple-news')}
         label={__('Sponsored Article', 'apple-news')}
         onChange={onChangeIsSponsored}
+        options={[
+          { label: __('Channel Default', 'apple-news'), value: '' },
+          { label: __('True', 'apple-news'), value: 'true' },
+          { label: __('False', 'apple-news'), value: 'false' },
+        ]}
+        value={isSponsored === '1' ? 'true' : isSponsored}
       />
       <CheckboxControl
         checked={suppressVideoURL}

--- a/tests/admin/apple-actions/index/test-class-push.php
+++ b/tests/admin/apple-actions/index/test-class-push.php
@@ -21,10 +21,26 @@ class Apple_News_Admin_Action_Index_Push_Test extends Apple_News_Testcase {
 	 */
 	public function data_metadata() {
 		return [
-			[ 'apple_news_is_hidden', true, false, false, false ],
-			[ 'apple_news_is_paid', false, true, false, false ],
-			[ 'apple_news_is_preview', false, false, true, false ],
-			[ 'apple_news_is_sponsored', false, false, false, true ],
+			[ 'apple_news_is_hidden', 'true', 'isHidden', true ],
+			[ 'apple_news_is_hidden', 'false', 'isHidden', false ],
+			[ 'apple_news_is_hidden', '1', 'isHidden', true ],
+			[ 'apple_news_is_hidden', '0', 'isHidden', false ],
+			[ 'apple_news_is_hidden', null, 'isHidden', null ],
+			[ 'apple_news_is_paid', 'true', 'isPaid', true ],
+			[ 'apple_news_is_paid', 'false', 'isPaid', false ],
+			[ 'apple_news_is_paid', '1', 'isPaid', true ],
+			[ 'apple_news_is_paid', '0', 'isPaid', false ],
+			[ 'apple_news_is_paid', null, 'isPaid', null ],
+			[ 'apple_news_is_preview', 'true', 'isPreview', true ],
+			[ 'apple_news_is_preview', 'false', 'isPreview', false ],
+			[ 'apple_news_is_preview', '1', 'isPreview', true ],
+			[ 'apple_news_is_preview', '0', 'isPreview', false ],
+			[ 'apple_news_is_preview', null, 'isPreview', null ],
+			[ 'apple_news_is_sponsored', 'true', 'isSponsored', true ],
+			[ 'apple_news_is_sponsored', 'false', 'isSponsored', false ],
+			[ 'apple_news_is_sponsored', '1', 'isSponsored', true ],
+			[ 'apple_news_is_sponsored', '0', 'isSponsored', false ],
+			[ 'apple_news_is_sponsored', null, 'isSponsored', null ],
 		];
 	}
 
@@ -194,23 +210,23 @@ class Apple_News_Admin_Action_Index_Push_Test extends Apple_News_Testcase {
 	 *
 	 * @dataProvider data_metadata
 	 *
-	 * @param string $meta_key     The meta key to set to true (e.g., apple_news_is_hidden).
-	 * @param bool   $is_hidden    The expected value for isHidden in the request.
-	 * @param bool   $is_paid      The expected value for isPaid in the request.
-	 * @param bool   $is_preview   The expected value for isPreview in the request.
-	 * @param bool   $is_sponsored The expected value for isSponsored in the request.
+	 * @param string      $meta_key   The meta key to set (e.g., apple_news_is_hidden).
+	 * @param string|null $meta_value The meta value to set, or null if the meta key should not be set at all.
+	 * @param string      $property   The metadata property to check.
+	 * @param string|null $expected   The expected value for the property, or null if it is expected to not be set.
 	 */
-	public function test_metadata( $meta_key, $is_hidden, $is_paid, $is_preview, $is_sponsored ) {
+	public function test_metadata( $meta_key, $meta_value, $property, $expected ) {
 		$post_id = self::factory()->post->create();
-		add_post_meta( $post_id, $meta_key, true );
+		if ( ! is_null( $meta_value ) ) {
+			add_post_meta( $post_id, $meta_key, $meta_value );
+		}
 		$request  = $this->get_request_for_post( $post_id );
 		$metadata = $this->get_metadata_from_request( $request );
-
-		// Check the values for the four metadata keys against expected values.
-		$this->assertEquals( $is_hidden, $metadata['data']['isHidden'] );
-		$this->assertEquals( $is_paid, $metadata['data']['isPaid'] );
-		$this->assertEquals( $is_preview, $metadata['data']['isPreview'] );
-		$this->assertEquals( $is_sponsored, $metadata['data']['isSponsored'] );
+		if ( ! is_null( $expected ) ) {
+			$this->assertEquals( $expected, $metadata['data'][ $property ], sprintf( 'Expected property %s to be %s given meta key %s and meta value %s', $property, $expected, $meta_key, $meta_value ) );
+		} else {
+			$this->assertArrayNotHasKey( $property, $metadata['data'] ?? [], sprintf( 'Expected property %s to not exist, but it does', $property ) );
+		}
 	}
 
 	/**

--- a/tests/admin/test-class-admin-apple-meta-boxes.php
+++ b/tests/admin/test-class-admin-apple-meta-boxes.php
@@ -31,9 +31,10 @@ class Apple_News_Admin_Apple_Meta_Boxes_Test extends Apple_News_Testcase {
 		/* phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
 		$_POST['post_ID']                       = $post_id;
 		$_POST['apple_news_sections']           = [ 'https://news-api.apple.com/sections/1234567890' ];
-		$_POST['apple_news_is_paid']            = 0;
-		$_POST['apple_news_is_preview']         = 0;
-		$_POST['apple_news_is_sponsored']       = 0;
+		$_POST['apple_news_is_hidden']          = '';
+		$_POST['apple_news_is_paid']            = '';
+		$_POST['apple_news_is_preview']         = '';
+		$_POST['apple_news_is_sponsored']       = '';
 		$_POST['apple_news_maturity_rating']    = 'MATURE';
 		$_POST['apple_news_pullquote']          = 'test pullquote';
 		$_POST['apple_news_pullquote_position'] = 'middle';
@@ -51,9 +52,10 @@ class Apple_News_Admin_Apple_Meta_Boxes_Test extends Apple_News_Testcase {
 
 		// Check the meta values.
 		$this->assertEquals( [ 'https://news-api.apple.com/sections/1234567890' ], get_post_meta( $post_id, 'apple_news_sections', true ) );
-		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_paid', true ) );
-		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_preview', true ) );
-		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_sponsored', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_hidden', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_paid', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_preview', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_sponsored', true ) );
 		$this->assertEquals( 'MATURE', get_post_meta( $post_id, 'apple_news_maturity_rating', true ) );
 		$this->assertEquals( 'test pullquote', get_post_meta( $post_id, 'apple_news_pullquote', true ) );
 		$this->assertEquals( 'middle', get_post_meta( $post_id, 'apple_news_pullquote_position', true ) );
@@ -74,9 +76,10 @@ class Apple_News_Admin_Apple_Meta_Boxes_Test extends Apple_News_Testcase {
 		/* phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
 		$_POST['post_ID']                       = $post_id;
 		$_POST['apple_news_sections']           = [ 'https://news-api.apple.com/sections/1234567890' ];
-		$_POST['apple_news_is_paid']            = 0;
-		$_POST['apple_news_is_preview']         = 0;
-		$_POST['apple_news_is_sponsored']       = 0;
+		$_POST['apple_news_is_hidden']          = '';
+		$_POST['apple_news_is_paid']            = '';
+		$_POST['apple_news_is_preview']         = '';
+		$_POST['apple_news_is_sponsored']       = '';
 		$_POST['apple_news_maturity_rating']    = 'MATURE';
 		$_POST['apple_news_pullquote']          = 'test pullquote';
 		$_POST['apple_news_pullquote_position'] = 'middle';
@@ -94,9 +97,10 @@ class Apple_News_Admin_Apple_Meta_Boxes_Test extends Apple_News_Testcase {
 
 		// Check the meta values.
 		$this->assertEquals( [ 'https://news-api.apple.com/sections/1234567890' ], get_post_meta( $post_id, 'apple_news_sections', true ) );
-		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_paid', true ) );
-		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_preview', true ) );
-		$this->assertEquals( false, get_post_meta( $post_id, 'apple_news_is_sponsored', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_hidden', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_paid', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_preview', true ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'apple_news_is_sponsored', true ) );
 		$this->assertEquals( 'MATURE', get_post_meta( $post_id, 'apple_news_maturity_rating', true ) );
 		$this->assertEquals( 'test pullquote', get_post_meta( $post_id, 'apple_news_pullquote', true ) );
 		$this->assertEquals( 'middle', get_post_meta( $post_id, 'apple_news_pullquote_position', true ) );


### PR DESCRIPTION
## Summary

Converts the is* flags, like isPaid and isHidden, to dropdowns so they can either be `true`, `false`, or not set, in which case the channel default will be used (e.g., for a channel that has isPaid set to true as the default).

Also removes the last vestiges of the old manual publish interface, which has been fully replaced with metadata management within articles (one click publishes the article from the article list using metadata already set on the article).

## Changelog entries

### Changed

- Handling of `isHidden`, `isPaid`, `isPreview`, and `isSponsored` metadata flags for articles to support dropdown selection for true, false, or channel default.

Fixes #1069