### PR TITLE
APPLE-178: Set smallest value for in article module position to 3

### DIFF
--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -149,8 +149,8 @@ class Admin_Apple_Post_Sync {
 
 		// Proceed based on the current settings for auto publish and update.
 		$updated = get_post_meta( $id, 'apple_news_api_id', true );
-		if ( $updated && 'yes' !== $this->settings->api_autosync_update
-			|| ! $updated && 'yes' !== $this->settings->api_autosync ) {
+		if ( ( $updated && 'yes' !== $this->settings->api_autosync_update )
+			|| ( ! $updated && 'yes' !== $this->settings->api_autosync ) ) {
 			return;
 		}
 

--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -60,7 +60,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 			'in_article_position' => [
 				'label'       => __( 'Position of In Article Module', 'apple-news' ),
 				'type'        => 'number',
-				'min'         => 0,
+				'min'         => 3,
 				'max'         => 99,
 				'step'        => 1,
 				'description' => __( 'If you have configured an In Article module via Customize JSON, the position that the module should be inserted into. Defaults to 3, which is after the third content block in the article body (e.g., the third paragraph).', 'apple-news' ),


### PR DESCRIPTION
## Summary

In order to prevent in article modules from appearing too high up in an article, set the minimum position in settings to 3.

## Changelog entries

### Changed

- Set the minimum position for an in-article module to 3.