### PR TITLE
APPLE-179: Add Automation Option to Prepend to Headline

### DIFF
--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -58,20 +58,20 @@ class Admin_Apple_JSON extends Apple_News {
 	public function __construct() {
 		$this->json_page_name = $this->plugin_domain . '-json';
 
-		$this->valid_actions = array(
-			'apple_news_get_json'   => array(),
-			'apple_news_reset_json' => array(
-				'callback' => array( $this, 'reset_json' ),
-			),
-			'apple_news_save_json'  => array(
-				'callback' => array( $this, 'save_json' ),
-			),
-		);
+		$this->valid_actions = [
+			'apple_news_get_json'   => [],
+			'apple_news_reset_json' => [
+				'callback' => [ $this, 'reset_json' ],
+			],
+			'apple_news_save_json'  => [
+				'callback' => [ $this, 'save_json' ],
+			],
+		];
 
-		add_action( 'admin_menu', array( $this, 'setup_json_page' ), 99 );
-		add_action( 'admin_init', array( $this, 'action_router' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'register_assets' ) );
-		add_filter( 'admin_title', array( $this, 'set_title' ), 10, 2 );
+		add_action( 'admin_menu', [ $this, 'setup_json_page' ], 99 );
+		add_action( 'admin_init', [ $this, 'action_router' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_assets' ] );
+		add_filter( 'admin_title', [ $this, 'set_title' ], 10, 2 );
 	}
 
 	/**
@@ -152,7 +152,7 @@ class Admin_Apple_JSON extends Apple_News {
 			/** This filter is documented in admin/class-admin-apple-settings.php */
 			apply_filters( 'apple_news_settings_capability', 'manage_options' ),
 			$this->json_page_name,
-			array( $this, 'page_json_render' )
+			[ $this, 'page_json_render' ]
 		);
 	}
 
@@ -188,7 +188,7 @@ class Admin_Apple_JSON extends Apple_News {
 		// If we have a class, get its specs.
 		$specs = ( ! empty( $selected_component ) )
 			? $this->get_specs( $selected_component )
-			: array();
+			: [];
 
 		/* phpcs:enable */
 
@@ -210,14 +210,14 @@ class Admin_Apple_JSON extends Apple_News {
 		wp_enqueue_style(
 			'apple-news-json-css',
 			plugin_dir_url( __FILE__ ) . '../assets/css/json.css',
-			array(),
+			[],
 			self::$version
 		);
 
 		wp_enqueue_script(
 			'apple-news-json-js',
 			plugin_dir_url( __FILE__ ) . '../assets/js/json.js',
-			array( 'jquery' ),
+			[ 'jquery' ],
 			self::$version,
 			false
 		);
@@ -225,7 +225,7 @@ class Admin_Apple_JSON extends Apple_News {
 		wp_enqueue_script(
 			'ace-js',
 			'https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.6/ace.js',
-			array( 'jquery' ),
+			[ 'jquery' ],
 			'1.2.6',
 			false
 		);
@@ -334,7 +334,7 @@ class Admin_Apple_JSON extends Apple_News {
 
 		// Iterate over the specs and save each one.
 		// Keep track of which ones were updated.
-		$updates = array();
+		$updates = [];
 		foreach ( $specs as $spec ) {
 			// Ensure the value exists.
 			$key = 'apple_news_json_' . $spec->key_from_name( $spec->name );
@@ -374,7 +374,7 @@ class Admin_Apple_JSON extends Apple_News {
 	 */
 	private function get_specs( $component ) {
 		if ( empty( $component ) ) {
-			return array();
+			return [];
 		}
 
 		$classname       = $this->namespace . $component;
@@ -394,7 +394,7 @@ class Admin_Apple_JSON extends Apple_News {
 		$components = $component_factory::get_components();
 
 		// Make this alphabetized and pretty.
-		$components_sanitized = array();
+		$components_sanitized = [];
 		foreach ( $components as $component ) {
 			$component_key                          = str_replace( $this->namespace, '', $component );
 			$component_name                         = str_replace( '_', ' ', $component_key );

--- a/admin/class-automation.php
+++ b/admin/class-automation.php
@@ -58,6 +58,13 @@ class Automation {
 	];
 
 	/**
+	 * Keeps track of the original title of the post so we can refer to it when prepending.
+	 *
+	 * @var string
+	 */
+	private static string $original_title = '';
+
+	/**
 	 * Initialize functionality of this class by registering hooks.
 	 */
 	public static function init(): void {
@@ -66,6 +73,7 @@ class Automation {
 		add_filter( 'apple_news_active_theme', [ __CLASS__, 'filter__apple_news_active_theme' ], 0, 2 );
 		add_filter( 'apple_news_article_metadata', [ __CLASS__, 'filter__apple_news_article_metadata' ], 0, 2 );
 		add_filter( 'apple_news_exporter_slug', [ __CLASS__, 'filter__apple_news_exporter_slug' ], 0, 2 );
+		add_filter( 'apple_news_exporter_title', [ __CLASS__, 'filter__apple_news_exporter_title' ], 0, 2 );
 		add_filter( 'apple_news_generate_json', [ __CLASS__, 'filter__apple_news_generate_json' ], 0, 2 );
 		add_filter( 'apple_news_metadata', [ __CLASS__, 'filter__apple_news_metadata' ], 0, 2 );
 	}
@@ -171,6 +179,26 @@ class Automation {
 	}
 
 	/**
+	 * A callback function for the apple_news_exporter_title filter.
+	 *
+	 * @param string $title   The title to use.
+	 * @param int    $post_id The post ID associated with the title.
+	 *
+	 * @return string The filtered title value.
+	 */
+	public static function filter__apple_news_exporter_title( $title, $post_id ) {
+		self::$original_title = $title;
+		$rules                = self::get_automation_for_post( $post_id );
+		foreach ( $rules as $rule ) {
+			if ( 'headline.prepend' === ( $rule['field'] ?? '' ) ) {
+				$title = sprintf( '%s %s', $rule['value'] ?? '', self::$original_title );
+			}
+		}
+
+		return $title;
+	}
+
+	/**
 	 * Applies automation rules after the JSON has been generated.
 	 *
 	 * @param array $json    Generated JSON for the article.
@@ -179,11 +207,11 @@ class Automation {
 	 * @return array Filtered JSON for the article.
 	 */
 	public static function filter__apple_news_generate_json( $json, $post_id ) {
-		$title = $json['title'] ?? '';
-		$rules = self::get_automation_for_post( $post_id );
+		$rules         = self::get_automation_for_post( $post_id );
+		$json['title'] = self::$original_title;
 		foreach ( $rules as $rule ) {
 			if ( 'title.prepend' === ( $rule['field'] ?? '' ) ) {
-				$json['title'] = sprintf( '%s %s', $rule['value'] ?? '', $title );
+				$json['title'] = sprintf( '%s %s', $rule['value'] ?? '', self::$original_title );
 			}
 		}
 
@@ -264,6 +292,11 @@ class Automation {
 				'type'     => 'string',
 				'label'    => 'contentGenerationType',
 			],
+			'headline.prepend'      => [
+				'location' => 'component',
+				'type'     => 'string',
+				'label'    => __( 'Headline: Prepend Text', 'apple-news' ),
+			],
 			'isHidden'              => [
 				'location' => 'article_metadata',
 				'type'     => 'string',
@@ -284,6 +317,11 @@ class Automation {
 				'type'     => 'string',
 				'label'    => 'isSponsored',
 			],
+			'title.prepend'         => [
+				'location' => 'component',
+				'type'     => 'string',
+				'label'    => __( 'Metadata Title: Prepend Text', 'apple-news' ),
+			],
 			'links.sections'        => [
 				'location' => 'article_metadata',
 				'type'     => 'string',
@@ -298,11 +336,6 @@ class Automation {
 				'location' => 'exporter',
 				'type'     => 'string',
 				'label'    => __( 'Theme', 'apple-news' ),
-			],
-			'title.prepend'         => [
-				'location' => 'component',
-				'type'     => 'string',
-				'label'    => __( 'Title: Prepend Text', 'apple-news' ),
 			],
 		];
 	}

--- a/admin/partials/page-json.php
+++ b/admin/partials/page-json.php
@@ -34,11 +34,11 @@
 					'<a href="' . esc_url( $theme_admin_url ) . '">',
 					'</a>'
 				),
-				array(
-					'a' => array(
-						'href' => array(),
-					),
-				)
+				[
+					'a' => [
+						'href' => [],
+					],
+				]
 			)
 			?>
 			</p>
@@ -63,11 +63,11 @@
 					'<a href="https://developer.apple.com/documentation/apple_news/apple_news_format">',
 					'</a>'
 				),
-				array(
-					'a' => array(
-						'href' => array(),
-					),
-				)
+				[
+					'a' => [
+						'href' => [],
+					],
+				]
 			)
 			?>
 			</p>

--- a/tests/admin/test-class-admin-apple-themes.php
+++ b/tests/admin/test-class-admin-apple-themes.php
@@ -489,14 +489,8 @@ JSON;
 		$admin_json->action_router();
 
 		// Test.
-		$settings = new Admin_Apple_Settings();
-		$content  = new Exporter_Content(
-			1,
-			__( 'My Title', 'apple-news' ),
-			'<p>' . __( 'Hello, World!', 'apple-news' ) . '</p>'
-		);
-		$exporter = new Exporter( $content, null, $settings->fetch_settings() );
-		$json     = json_decode( $exporter->export(), true );
+		$post_id = self::factory()->post->create();
+		$json    = $this->get_json_for_post( $post_id );
 		$this->assertEquals(
 			20,
 			$json['componentLayouts']['body-layout']['margin']['bottom']
@@ -542,16 +536,9 @@ JSON;
 		$admin_json->action_router();
 
 		// Test.
-		$post_id  = $this->factory->post->create();
-		$settings = new Admin_Apple_Settings();
-		$content  = new Exporter_Content(
-			$post_id,
-			__( 'My Title', 'apple-news' ),
-			'<p>' . __( 'Hello, World!', 'apple-news' ) . '</p>'
-		);
+		$post_id = self::factory()->post->create();
 		add_post_meta( $post_id, 'apple_news_column_span', 2, true );
-		$exporter = new Exporter( $content, null, $settings->fetch_settings() );
-		$json     = json_decode( $exporter->export(), true );
+		$json = $this->get_json_for_post( $post_id );
 		$this->assertEquals(
 			2,
 			$json['componentLayouts']['body-layout']['columnSpan']


### PR DESCRIPTION
## Summary

Augments the Prepend Text option in Automation by allowing users to prepend to the metadata title or the headline or both (by using both options).

## Changelog entries

### Added

- Functionality to prepend text on the headline for publishers.