### PR TITLE
Use falsy check in case the variable is not defined

### DIFF
--- a/assets/js/pluginsidebar/sidebar.jsx
+++ b/assets/js/pluginsidebar/sidebar.jsx
@@ -185,7 +185,7 @@ function Sidebar() {
         const data = await Promise.all(fetches);
         setState({
           ...state,
-          autoAssignCategories: (selectedSections === null || selectedSections.length === 0)
+          autoAssignCategories: (!selectedSections || selectedSections.length === 0)
             && data[2].automaticAssignment === true,
           ...data[0],
           sections: data[1],


### PR DESCRIPTION
Fixes #1106.

Using [a falsy check](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) will correctly set the `autoAssignCategories` when the post meta value associated with `selectedSections` is not set.

The `usePostMetaValue()` extracts the particular meta key from an object of all post meta values [via `meta[metaKey]`](https://github.com/alleyinteractive/alley-scripts/blob/f0f29b4a20e3d99c01515812581c37825fac84b5/packages/block-editor-tools/src/hooks/use-post-meta-value/index.js#L29C11-L29C24), and in case of a missing object key, it returns `undefined`:

```js
const meta = {
   'one-sample-meta': 'yes'
};
const key = 'a-different-key';
console.log( meta[key] ); // undefined
``` 