### PR TITLE
Detect images inside links inside figures

### DIFF
--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -8,6 +8,8 @@
 
 namespace Apple_Exporter\Components;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Represents a simple image.
  *
@@ -26,13 +28,12 @@ class Image extends Component {
 		/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
 
 		$has_image_child = false;
-		// If this is a figure and it has children, see if we can find an image.
+
+		// If this is a figure, and it has children, see if we can find an image at any depth.
 		if ( $node->hasChildNodes() && 'figure' === $node->tagName ) {
-			foreach ( $node->childNodes as $child ) {
-				if ( 'img' === $child->nodeName ) {
-					$has_image_child = true;
-				}
-			}
+			$html            = $node->ownerDocument->saveHTML( $node );
+			$proc            = new WP_HTML_Tag_Processor( $html );
+			$has_image_child = false !== $proc->next_tag( 'img' );
 		}
 
 		// Is this an image node?

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -41,11 +41,11 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 			]
 		);
 
-		// Create a new attachment and assign it as the featured image for the cover component. 
-		set_post_thumbnail( 
-			$post_id, 
-			$this->get_new_attachment( 0 ) 
-		); 
+		// Create a new attachment and assign it as the featured image for the cover component.
+		set_post_thumbnail(
+			$post_id,
+			$this->get_new_attachment( 0 )
+		);
 
 		// Check that the default component role is 'photo'.
 		$json = $this->get_json_for_post( $post_id );
@@ -93,6 +93,37 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 		// Test the JSON.
 		$this->assertEquals( 'photo', $json['role'] );
 		$this->assertEquals( 'https://placeimg.com/640/480/any', $json['URL'] );
+	}
+
+	/**
+	 * Test Image component matching with HTML markup for an image deeply nested in a figure tag.
+	 *
+	 * @see https://github.com/alleyinteractive/apple-news/issues/867.
+	 */
+	public function test_transform_linked_image() {
+		$this->settings->set( 'html_support', 'yes' );
+		$this->settings->set( 'use_remote_images', 'yes' );
+
+		$html = <<<HTML
+<figure>
+	<a href="#">
+		<img src="https://placeimg.com/640/480/any" alt="Example" align="left" />
+</a>
+</figure>
+HTML;
+
+		$component = new Image(
+			$html,
+			$this->workspace,
+			$this->settings,
+			$this->styles,
+			$this->layouts
+		);
+
+		// Build the node.
+		$node = self::build_node( $html );
+
+		$this->assertSame( $node, $component->node_matches( $node ) );
 	}
 
 	/**


### PR DESCRIPTION
Currently, images inside figure tags are detected only when the image is a direct child of the figure, but if a link is added to an image, the image tag becomes a child of the link.

Fixes #867.