### PR TITLE
Convert all require/include statements to use __DIR__ and dirname()

### DIFF
--- a/admin/apple-actions/class-api-action.php
+++ b/admin/apple-actions/class-api-action.php
@@ -8,9 +8,9 @@
 
 namespace Apple_Actions;
 
-require_once plugin_dir_path( __FILE__ ) . 'class-action.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-action-exception.php';
-require_once plugin_dir_path( __FILE__ ) . '../../includes/apple-push-api/autoload.php';
+require_once __DIR__ . '/class-action.php';
+require_once __DIR__ . '/class-action-exception.php';
+require_once dirname( __DIR__, 2 ) . '/includes/apple-push-api/autoload.php';
 
 use Apple_Actions\Action;
 use Apple_Push_API\API;

--- a/admin/apple-actions/index/class-channel.php
+++ b/admin/apple-actions/index/class-channel.php
@@ -7,7 +7,7 @@
 
 namespace Apple_Actions\Index;
 
-require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
+require_once dirname( __DIR__ ) . '/class-api-action.php';
 
 use Apple_Actions\API_Action;
 

--- a/admin/apple-actions/index/class-delete.php
+++ b/admin/apple-actions/index/class-delete.php
@@ -8,7 +8,7 @@
 
 namespace Apple_Actions\Index;
 
-require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
+require_once dirname( __DIR__ ) . '/class-api-action.php';
 
 use Apple_Actions\API_Action;
 

--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -8,9 +8,9 @@
 
 namespace Apple_Actions\Index;
 
-require_once plugin_dir_path( __FILE__ ) . '../class-action.php';
-require_once plugin_dir_path( __FILE__ ) . '../class-action-exception.php';
-require_once plugin_dir_path( __FILE__ ) . '../../../includes/apple-exporter/autoload.php';
+require_once dirname( __DIR__ ) . '/class-action.php';
+require_once dirname( __DIR__ ) . '/class-action-exception.php';
+require_once dirname( __DIR__, 3 ) . '/includes/apple-exporter/autoload.php';
 
 use Apple_Actions\Action;
 use Apple_Exporter\Exporter;

--- a/admin/apple-actions/index/class-get.php
+++ b/admin/apple-actions/index/class-get.php
@@ -8,7 +8,7 @@
 
 namespace Apple_Actions\Index;
 
-require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
+require_once dirname( __DIR__ ) . '/class-api-action.php';
 
 use Apple_Actions\API_Action;
 

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -8,8 +8,8 @@
 
 namespace Apple_Actions\Index;
 
-require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-export.php';
+require_once dirname( __DIR__ ) . '/class-api-action.php';
+require_once __DIR__ . '/class-export.php';
 
 use Admin_Apple_Async;
 use Admin_Apple_Notice;

--- a/admin/apple-actions/index/class-section.php
+++ b/admin/apple-actions/index/class-section.php
@@ -8,7 +8,7 @@
 
 namespace Apple_Actions\Index;
 
-require_once plugin_dir_path( __FILE__ ) . '../class-api-action.php';
+require_once dirname( __DIR__ ) . '/class-api-action.php';
 
 use Apple_Actions\API_Action;
 use Apple_Exporter\Settings;

--- a/admin/class-admin-apple-bulk-export-page.php
+++ b/admin/class-admin-apple-bulk-export-page.php
@@ -6,7 +6,7 @@
  */
 
 // Include dependencies.
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-push.php';
+require_once __DIR__ . '/apple-actions/index/class-push.php';
 
 /**
  * Bulk export page. Display progress on multiple articles export process.
@@ -105,7 +105,7 @@ class Admin_Apple_Bulk_Export_Page extends Apple_News {
 			}
 		}
 
-		require_once plugin_dir_path( __FILE__ ) . 'partials/page-bulk-export.php';
+		require_once __DIR__ . '/partials/page-bulk-export.php';
 	}
 
 	/**

--- a/admin/class-admin-apple-index-page.php
+++ b/admin/class-admin-apple-index-page.php
@@ -8,12 +8,12 @@
  */
 
 // Include dependencies.
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-get.php';
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-push.php';
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-delete.php';
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-export.php';
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-section.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-news-list-table.php';
+require_once __DIR__ . '/apple-actions/index/class-get.php';
+require_once __DIR__ . '/apple-actions/index/class-push.php';
+require_once __DIR__ . '/apple-actions/index/class-delete.php';
+require_once __DIR__ . '/apple-actions/index/class-export.php';
+require_once __DIR__ . '/apple-actions/index/class-section.php';
+require_once __DIR__ . '/class-admin-apple-news-list-table.php';
 
 use Apple_Exporter\Workspace;
 
@@ -98,7 +98,7 @@ class Admin_Apple_Index_Page extends Apple_News {
 	public function admin_page() {
 		$table = new Admin_Apple_News_List_Table( $this->settings );
 		$table->prepare_items();
-		include plugin_dir_path( __FILE__ ) . 'partials/page-index.php';
+		include __DIR__ . '/partials/page-index.php';
 	}
 
 	/**

--- a/admin/class-admin-apple-json.php
+++ b/admin/class-admin-apple-json.php
@@ -193,7 +193,7 @@ class Admin_Apple_JSON extends Apple_News {
 		/* phpcs:enable */
 
 		// Load the template.
-		include plugin_dir_path( __FILE__ ) . 'partials/page-json.php';
+		include __DIR__ . '/partials/page-json.php';
 	}
 
 	/**

--- a/admin/class-admin-apple-meta-boxes.php
+++ b/admin/class-admin-apple-meta-boxes.php
@@ -368,7 +368,7 @@ class Admin_Apple_Meta_Boxes extends Apple_News {
 
 		/* phpcs:enable */
 
-		include plugin_dir_path( __FILE__ ) . 'partials/metabox-publish.php';
+		include __DIR__ . '/partials/metabox-publish.php';
 	}
 
 	/**

--- a/admin/class-admin-apple-news.php
+++ b/admin/class-admin-apple-news.php
@@ -8,28 +8,28 @@
  */
 
 // Include dependencies.
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-settings.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-post-sync.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-index-page.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-bulk-export-page.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-notice.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-meta-boxes.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-async.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-sections.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-themes.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-preview.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-admin-apple-json.php';
-require_once plugin_dir_path( __FILE__ ) . 'class-automation.php';
+require_once __DIR__ . '/class-admin-apple-settings.php';
+require_once __DIR__ . '/class-admin-apple-post-sync.php';
+require_once __DIR__ . '/class-admin-apple-index-page.php';
+require_once __DIR__ . '/class-admin-apple-bulk-export-page.php';
+require_once __DIR__ . '/class-admin-apple-notice.php';
+require_once __DIR__ . '/class-admin-apple-meta-boxes.php';
+require_once __DIR__ . '/class-admin-apple-async.php';
+require_once __DIR__ . '/class-admin-apple-sections.php';
+require_once __DIR__ . '/class-admin-apple-themes.php';
+require_once __DIR__ . '/class-admin-apple-preview.php';
+require_once __DIR__ . '/class-admin-apple-json.php';
+require_once __DIR__ . '/class-automation.php';
 
 // REST Includes.
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-delete.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-published-state.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-get-settings.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-modify-post.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-publish.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-sections.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-update.php';
-require_once plugin_dir_path( __FILE__ ) . '../includes/REST/apple-news-user-can-publish.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-delete.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-get-published-state.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-get-settings.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-modify-post.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-publish.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-sections.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-update.php';
+require_once dirname( __DIR__ ) . '/includes/REST/apple-news-user-can-publish.php';
 
 /**
  * Entry-point class for the plugin.

--- a/admin/class-admin-apple-notice.php
+++ b/admin/class-admin-apple-notice.php
@@ -404,7 +404,7 @@ class Admin_Apple_Notice {
 		$message = apply_filters( 'apple_news_notice_message', $message, $type );
 
 		// Load the partial for the notice.
-		include plugin_dir_path( __FILE__ ) . 'partials/notice.php';
+		include __DIR__ . '/partials/notice.php';
 	}
 
 	/**

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -6,8 +6,8 @@
  */
 
 // Include dependencies.
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-push.php';
-require_once plugin_dir_path( __FILE__ ) . 'apple-actions/index/class-delete.php';
+require_once __DIR__ . '/apple-actions/index/class-push.php';
+require_once __DIR__ . '/apple-actions/index/class-delete.php';
 
 /**
  * This class is in charge of syncing posts creation, updates and deletions

--- a/admin/class-admin-apple-settings.php
+++ b/admin/class-admin-apple-settings.php
@@ -6,12 +6,12 @@
  */
 
 // Include dependencies.
-require_once plugin_dir_path( __FILE__ ) . '../includes/apple-exporter/class-settings.php';
-require_once plugin_dir_path( __FILE__ ) . 'settings/class-admin-apple-settings-section.php';
-require_once plugin_dir_path( __FILE__ ) . 'settings/class-admin-apple-settings-section-api.php';
-require_once plugin_dir_path( __FILE__ ) . 'settings/class-admin-apple-settings-section-advanced.php';
-require_once plugin_dir_path( __FILE__ ) . 'settings/class-admin-apple-settings-section-post-types.php';
-require_once plugin_dir_path( __FILE__ ) . 'settings/class-admin-apple-settings-section-developer-tools.php';
+require_once dirname( __DIR__ ) . '/includes/apple-exporter/class-settings.php';
+require_once __DIR__ . '/settings/class-admin-apple-settings-section.php';
+require_once __DIR__ . '/settings/class-admin-apple-settings-section-api.php';
+require_once __DIR__ . '/settings/class-admin-apple-settings-section-advanced.php';
+require_once __DIR__ . '/settings/class-admin-apple-settings-section-post-types.php';
+require_once __DIR__ . '/settings/class-admin-apple-settings-section-developer-tools.php';
 
 use Apple_Exporter\Settings;
 
@@ -168,7 +168,7 @@ class Admin_Apple_Settings extends Apple_News {
 
 		/* phpcs:enable */
 
-		include plugin_dir_path( __FILE__ ) . 'partials/page-options.php';
+		include __DIR__ . '/partials/page-options.php';
 	}
 
 	/**

--- a/admin/class-admin-apple-themes.php
+++ b/admin/class-admin-apple-themes.php
@@ -318,7 +318,7 @@ class Admin_Apple_Themes extends Apple_News {
 		/* phpcs:enable */
 
 		// Load the edit page.
-		include plugin_dir_path( __FILE__ ) . 'partials/page-theme-edit.php';
+		include __DIR__ . '/partials/page-theme-edit.php';
 	}
 
 	/**
@@ -332,7 +332,7 @@ class Admin_Apple_Themes extends Apple_News {
 			wp_die( esc_html__( 'You do not have permissions to access this page.', 'apple-news' ) );
 		}
 
-		include plugin_dir_path( __FILE__ ) . 'partials/page-themes.php';
+		include __DIR__ . '/partials/page-themes.php';
 	}
 
 	/**

--- a/admin/partials/metabox-publish.php
+++ b/admin/partials/metabox-publish.php
@@ -135,7 +135,7 @@ if ( ! \Apple_News::is_initialized() ) : ?>
 	</div>
 	<div id="apple-news-metabox-coverimage" class="apple-news-metabox-section apple-news-metabox-section-collapsable">
 		<h3><?php esc_html_e( 'Cover Image', 'apple-news' ); ?></h3>
-		<?php require plugin_dir_path( __FILE__ ) . 'cover-image.php'; ?>
+		<?php require __DIR__ . '/cover-image.php'; ?>
 	</div>
 	<?php
 	if ( 'yes' !== $this->settings->get( 'api_autosync' )

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -24,9 +24,9 @@
 			<?php $apple_section->before_section(); ?>
 			<?php
 			if ( $apple_section->is_hidden() ) {
-				include plugin_dir_path( __FILE__ ) . 'page-options-section-hidden.php';
+				include __DIR__ . '/page-options-section-hidden.php';
 			} else {
-				include plugin_dir_path( __FILE__ ) . 'page-options-section.php';
+				include __DIR__ . '/page-options-section.php';
 			}
 				$apple_section->after_section();
 			?>

--- a/apple-news.php
+++ b/apple-news.php
@@ -57,7 +57,7 @@ function apple_news_activate_wp_plugin() {
 	}
 }
 
-require plugin_dir_path( __FILE__ ) . 'includes/apple-exporter/class-settings.php';
+require __DIR__ . '/includes/apple-exporter/class-settings.php';
 
 /**
  * Deactivate the plugin.
@@ -76,8 +76,8 @@ if ( ! defined( 'WPCOM_IS_VIP_ENV' ) || ! WPCOM_IS_VIP_ENV ) {
 }
 
 // Initialize plugin class.
-require plugin_dir_path( __FILE__ ) . 'includes/class-apple-news.php';
-require plugin_dir_path( __FILE__ ) . 'admin/class-admin-apple-news.php';
+require __DIR__ . '/includes/class-apple-news.php';
+require __DIR__ . '/admin/class-admin-apple-news.php';
 
 /**
  * Load plugin textdomain.
@@ -85,7 +85,7 @@ require plugin_dir_path( __FILE__ ) . 'admin/class-admin-apple-news.php';
  * @since 0.9.0
  */
 function apple_news_load_textdomain() {
-	load_plugin_textdomain( 'apple-news', false, plugin_dir_path( __FILE__ ) . '/lang' );
+	load_plugin_textdomain( 'apple-news', false, __DIR__ . '/lang' );
 }
 add_action( 'plugins_loaded', 'apple_news_load_textdomain' );
 
@@ -101,7 +101,7 @@ function apple_news_get_plugin_data() {
 	if ( ! function_exists( 'get_plugin_data' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
-	return get_plugin_data( plugin_dir_path( __FILE__ ) . '/apple-news.php' );
+	return get_plugin_data( __DIR__ . '/apple-news.php' );
 }
 
 new Admin_Apple_News();

--- a/apple-news.php
+++ b/apple-news.php
@@ -40,7 +40,7 @@ function apple_news_date( $format, $timestamp = null, $timezone = null ) {
 	return date( $format, $timestamp ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 }
 
-require_once plugin_dir_path( __FILE__ ) . './includes/meta.php';
+require_once __DIR__ . '/includes/meta.php';
 
 if ( ! defined( 'WPINC' ) ) {
 	die;

--- a/includes/apple-exporter/autoload.php
+++ b/includes/apple-exporter/autoload.php
@@ -12,7 +12,7 @@ spl_autoload_register(
 		$path = explode( '\\', $path );
 		$file = array_pop( $path );
 		$path = implode( '/', $path ) . '/class-' . $file . '.php';
-		$path = realpath( __DIR__ . '/../' . $path );
+		$path = realpath( dirname( __DIR__ ) . '/' . $path );
 
 		if ( file_exists( $path ) ) {
 			require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable

--- a/includes/apple-exporter/builders/class-metadata.php
+++ b/includes/apple-exporter/builders/class-metadata.php
@@ -8,7 +8,7 @@
 
 namespace Apple_Exporter\Builders;
 
-require_once plugin_dir_path( __FILE__ ) . '../../../admin/class-admin-apple-news.php';
+require_once dirname( __DIR__, 3 ) . '/admin/class-admin-apple-news.php';
 
 use Admin_Apple_News;
 use Apple_Exporter\Exporter_Content;

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -362,7 +362,7 @@ class Theme {
 	 */
 	public static function get_fonts() {
 		// Get custom fonts from this channel.
-		require_once plugin_dir_path( __DIR__ ) . '../admin/apple-actions/index/class-channel.php';
+		require_once dirname( __DIR__, 2 ) . '/admin/apple-actions/index/class-channel.php';
 		$admin_settings = new \Admin_Apple_Settings();
 		$channel_api    = new \Apple_Actions\Index\Channel( $admin_settings->fetch_settings() );
 		$channel        = $channel_api->perform();
@@ -499,8 +499,7 @@ class Theme {
 		/* phpcs:enable */
 
 		// Load the template.
-		include dirname( dirname( plugin_dir_path( __FILE__ ) ) )
-			. '/admin/partials/field-meta-component-order.php';
+		include dirname( __DIR__, 2 ) . '/admin/partials/field-meta-component-order.php';
 	}
 
 	/**

--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -8,7 +8,7 @@
 
 namespace Apple_Exporter\Components;
 
-require_once __DIR__ . '/../class-markdown.php';
+require_once dirname( __DIR__ ) . '/class-markdown.php';
 
 use Apple_Exporter\Builders\Component_Layouts;
 use Apple_Exporter\Builders\Component_Styles;

--- a/includes/apple-push-api/autoload.php
+++ b/includes/apple-push-api/autoload.php
@@ -12,7 +12,7 @@ spl_autoload_register(
 		$path = explode( '\\', $path );
 		$file = array_pop( $path );
 		$path = implode( '/', $path ) . '/class-' . $file . '.php';
-		$path = realpath( __DIR__ . '/../' . $path );
+		$path = realpath( dirname( __DIR__ ) . '/' . $path );
 
 		if ( file_exists( $path ) ) {
 			require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -12,7 +12,7 @@ use Apple_Push_API\Credentials;
 use Apple_Push_API\MIME_Builder;
 use WP_Error;
 
-require_once __DIR__ . '/../class-mime-builder.php';
+require_once dirname( __DIR__ ) . '/class-mime-builder.php';
 
 /**
  * An object capable of sending signed HTTP requests to the Push API.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,7 +24,7 @@ function apple_news_require_file( string $file ) {
 }
 
 // Autoloading for prophecy.
-apple_news_require_file( dirname( __DIR__, 1 ) . '/vendor/autoload.php' );
+apple_news_require_file( dirname( __DIR__ ) . '/vendor/autoload.php' );
 
 /**
  * Install WordPress and load the plugin.
@@ -107,7 +107,7 @@ JSON;
 			set_transient( 'apple_news_channel', wp_json_encode( $channel_api_response ) );
 
 			// Load the plugin.
-			require dirname( __DIR__, 1 ) . '/apple-news.php';
+			require dirname( __DIR__ ) . '/apple-news.php';
 		}
 	)->install();
 


### PR DESCRIPTION
### Summary
Fixes #1002 - Addressing the Path Traversal issue in apple-news.php on line 43, as reported.

### Overview
Addresses the issue found in #1002 by going a step further and standardizing path computation across the codebase. Where files exist in the same folder or below the current file, `__DIR__` is used. Where they exist in part of the tree that branches above the current directory, `dirname` is used to traverse upwards rather than `..`.

### Background
Protection rules on the server do not allow for the plugin activation because of Path Traversal issue discovered in apple-news.php file on line 43.
Warning: require_once(/var/www/wp-content/plugins/publish-to-apple-news/./includes/meta.php): Failed to open stream: No such file or directory in /var/www/wp-content/plugins/publish-to-apple-news/apple-news.php on line 43
Fatal error: Uncaught Error: Failed opening required '/var/www/wp-content/plugins/publish-to-apple-news/./includes/meta.php' (include_path='.')
in /var/www/wp-content/plugins/publish-to-apple-news/apple-news.php on line 43

### Steps To Reproduce
Plugin activation action.