### PR TITLE
Fix Error when Using Gutenberg Cover Block with Caption

### DIFF
--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -256,10 +256,7 @@ class Image extends Component {
 		$caption_regex = $is_cover_block ? '#<div.*?>?\n(.*)#m' : '#<figcaption.*?>(.*?)</figcaption>#ms';
 		if ( preg_match( $caption_regex, $html, $matches ) ) {
 			$caption                  = trim( $matches[1] );
-			$values['#caption#']      = ! $is_cover_block ? $caption : [
-				'text'   => $caption,
-				'format' => 'html',
-			];
+			$values['#caption#']      = $caption;
 			$values['#caption_text#'] = $caption;
 			$values                   = $this->group_component( $values['#caption#'], $values );
 			$spec_name                = 'json-with-caption';

--- a/tests/apple-exporter/components/test-class-image.php
+++ b/tests/apple-exporter/components/test-class-image.php
@@ -60,6 +60,64 @@ class Apple_News_Image_Test extends Apple_News_Component_TestCase {
 	}
 
 	/**
+	 * Tests the process of transforming a Cover block into an image.
+	 */
+	public function test_transform_cover() {
+		$featured_image = $this->get_new_attachment();
+		$image_id       = $this->get_new_attachment();
+		$image_url      = wp_get_attachment_image_url( $image_id, 'full' );
+		$post_content   = <<<HTML
+<!-- wp:cover {"url":"$image_url","id":$image_id,"dimRatio":50,"customOverlayColor":"#e9e9e9","isDark":false,"layout":{"type":"constrained"}} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#e9e9e9"></span><img class="wp-block-cover__image-background wp-image-$image_id" alt="" src="$image_url" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size">Testing cover block.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->
+HTML;
+		$post_id        = self::factory()->post->create( [ 'post_content' => $post_content ] );
+		update_post_meta( $post_id, '_thumbnail_id', $featured_image );
+		$json = $this->get_json_for_post( $post_id );
+		$this->assertEquals(
+			[
+				'role'       => 'container',
+				'components' => [
+					[
+						'role'    => 'photo',
+						'URL'     => $image_url,
+						'layout'  => 'full-width-image-with-caption',
+						'caption' => [
+							'format'    => 'html',
+							'text'      => '<p class="has-text-align-center has-large-font-size">Testing cover block.</p>',
+							'textStyle' => [
+								'fontName' => 'AvenirNext-Italic',
+							],
+						],
+					],
+					[
+						'role'      => 'caption',
+						'text'      => '<p class="has-text-align-center has-large-font-size">Testing cover block.</p>',
+						'format'    => 'html',
+						'textStyle' => [
+							'textAlignment' => 'left',
+							'fontName'      => 'AvenirNext-Italic',
+							'fontSize'      => 16,
+							'tracking'      => 0,
+							'lineHeight'    => 24,
+							'textColor'     => '#4f4f4f',
+						],
+						'layout'    => [
+							'margin' => [
+								'bottom' => 25,
+							],
+						],
+					],
+				],
+				'layout'     => [],
+			],
+			$json['components'][1]['components'][3]
+		);
+	}
+
+	/**
 	 * Test Image component matching and JSON
 	 * output with HTML markup for an image.
 	 */


### PR DESCRIPTION
### Summary

Fixes #1117

### Description

Fixes a bug where attempting to convert a post containing a Cover block with a caption results in an incorrect caption format which throws an error on publish in Apple News.

### Changes Made

- Added a test for the cover block that reproduces the issue.
- Fixed the issue by not handling captions in a special way for cover blocks.

### How to Test

1. Create a post with a Cover block. Assign the Cover block an image and a caption.
2. Attempt to publish to Apple News.
3. Confirm that the error previously encountered does not occur and that the article, including the cover block, is correctly formatted in Apple News.

### Additional Notes

This fix aims to improve the compatibility of WordPress Gutenberg blocks with Apple News, enhancing the publishing workflow for content creators.

### Related Links

- Issue: [Gutenberg Cover pattern causing error when publishing to Apple News](https://github.com/alleyinteractive/apple-news/issues/1117)
- Screenshot of the error: ![Screenshot 2024-05-06 at 5 40 18 PM](https://github.com/alleyinteractive/apple-news/assets/169101691/862c654a-4c0e-460f-9550-af13d6b9996a)
- Example of affected article JSON: [article-104610.json](https://github.com/alleyinteractive/apple-news/files/15226864/article-104610.json)
- Related story: [It was once his family's farm...](https://www.cvilletomorrow.org/it-was-once-his-familys-farm-the-largest-black-owned-farm-in-albemarle-county-but-now-we-all-own-part-of-it/)
