### PR TITLE
APPLE-182: Make Aside Class Field Not Required

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-advanced.php
+++ b/admin/settings/class-admin-apple-settings-section-advanced.php
@@ -69,6 +69,7 @@ class Admin_Apple_Settings_Section_Advanced extends Admin_Apple_Settings_Section
 				'label'       => __( 'Aside Content CSS Class', 'apple-news' ),
 				'type'        => 'text',
 				'description' => __( 'Enter a CSS class name that will be used to generate the Aside component. Do not prefix with a period.', 'apple-news' ),
+				'required'    => false,
 			],
 		];
 


### PR DESCRIPTION
## Summary

Makes the aside class field optional in settings, in case publishers don't want to use that feature, or in case they aren't ready to populate that field when adding their channel credentials during initial setup.

## Changelog entries

### Changed

- Made Aside Class Field not required on the settings screen.

## Tickets

Fixes #1124 