### PR TITLE
Fix bug with accessing settings on components

### DIFF
--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -275,7 +275,7 @@ abstract class Component {
 		if ( empty( $parser ) ) {
 
 			// Load format from settings.
-			$format = ( 'yes' === $this->settings->html_support )
+			$format = ( 'yes' === $this->settings?->html_support )
 				? 'html'
 				: 'markdown';
 


### PR DESCRIPTION
In some cases, we need to create an instance of a Component class without passing a Settings object (such as when we're getting specs from it for subcomponents). We need to make settings object access null-safe to avoid a warning.