### PR TITLE
APPLE-185: Investigate Issue with Aside when Using Recipe Card Blocks (release/v2.5.0)

### DIFF
--- a/assets/js/theme-edit.js
+++ b/assets/js/theme-edit.js
@@ -76,6 +76,14 @@
 				$( '#pullquote_border_color, #pullquote_border_width' ).parent().show().next( 'br' ).show();
 			}
 		} ).change();
+
+		$( '#aside_border_style' ).on( 'change', function () {
+			if ( 'none' === $( this ).val() ) {
+				$( '#aside_border_color, #aside_border_width' ).parent().hide().next( 'br' ).hide();
+			} else {
+				$( '#aside_border_color, #aside_border_width' ).parent().show().next( 'br' ).show();
+			}
+		} ).change();
 	}
 
 	function appleNewsThemeEditSortInit( activeSelector, activeKey, inactiveSelector, inactiveKey, connectWith ) {

--- a/includes/apple-exporter/class-theme.php
+++ b/includes/apple-exporter/class-theme.php
@@ -2524,8 +2524,8 @@ class Theme {
 				'settings'    => [
 					'aside_alignment',
 					'aside_background_color',
-					'aside_border_color',
 					'aside_border_style',
+					'aside_border_color',
 					'aside_border_width',
 					'aside_padding',
 					'dark_mode_colors_heading',

--- a/includes/apple-exporter/components/class-aside.php
+++ b/includes/apple-exporter/components/class-aside.php
@@ -84,29 +84,59 @@ class Aside extends Component {
 			],
 		);
 
-		$aside_conditional_style = [];
-		if ( ! empty( $theme->get_value( 'aside_background_color_dark' ) ) || ! empty( $theme->get_value( 'aside_border_color_dark' ) ) ) {
-			$aside_conditional_style = [
-				'conditional' => [
-					'backgroundColor' => '#aside_background_color_dark#',
-					'border'          => [
-						'all' => [
-							'width' => '#blockquote_border_width#',
-							'style' => '#blockquote_border_style#',
-							'color' => '#aside_border_color_dark#',
-						],
-					],
-					'conditions'      => [
-						'minSpecVersion'       => '1.14',
-						'preferredColorScheme' => 'dark',
+		$aside_conditional_background_style = [];
+		if ( ! empty( $theme->get_value( 'aside_background_color_dark' ) ) ) {
+			$aside_conditional_background_style = [
+				'backgroundColor' => '#aside_background_color_dark#',
+			];
+		}
+	
+		$aside_conditional_border_style = [];
+		if ( ! empty( $theme->get_value( 'aside_border_color_dark' ) ) ) {
+			$aside_conditional_border_style = [
+				'border' => [
+					'all' => [
+						'width' => '#aside_border_width#',
+						'style' => '#aside_border_style#',
+						'color' => '#aside_border_color_dark#',
 					],
 				],
 			];
 		}
 
+		$aside_conditional_conditions = [
+			'conditions' => [
+				'minSpecVersion'       => '1.14',
+				'preferredColorScheme' => 'dark',
+			],
+		];
+
+		$aside_conditional_style_with_borders = ( ! empty( $aside_conditional_background_style ) || ! empty( $aside_conditional_border_style ) )
+			? [
+				'conditional' => [
+					array_merge(
+						$aside_conditional_background_style,
+						$aside_conditional_border_style,
+						$aside_conditional_conditions,
+					),
+				]
+			]
+			: [];
+
+		$aside_conditional_style_without_borders = ( ! empty( $aside_conditional_background_style ) || ! empty( $aside_conditional_border_style ) )
+			? [
+				'conditional' => [
+					array_merge(
+						$aside_conditional_background_style,
+						$aside_conditional_conditions,
+					),
+				]
+			]
+			: [];
+
 		$this->register_spec(
-			'default-aside',
-			__( 'Aside Style', 'apple-news' ),
+			'aside-with-border-json',
+			__( 'Aside With Border JSON', 'apple-news' ),
 			array_merge(
 				[
 					'backgroundColor' => '#aside_background_color#',
@@ -118,7 +148,18 @@ class Aside extends Component {
 						],
 					],
 				],
-				$aside_conditional_style
+				$aside_conditional_style_with_borders
+			)
+		);
+
+		$this->register_spec(
+			'aside-without-border-json',
+			__( 'Aside Without Border JSON', 'apple-news' ),
+			array_merge(
+				[
+					'backgroundColor' => '#aside_background_color#',
+				],
+				$aside_conditional_style_without_borders
 			)
 		);
 
@@ -178,9 +219,13 @@ class Aside extends Component {
 			],
 		);
 
+		$component_style = ( 'none' !== $theme->get_value( 'aside_border_style' ) )
+			? 'aside-with-border-json'
+			: 'aside-without-border-json';
+
 		$this->register_component_style(
 			'default-aside',
-			'default-aside',
+			$component_style,
 		);
 
 		$alignment   = $theme->get_value( 'aside_alignment' );

--- a/includes/apple-exporter/components/class-aside.php
+++ b/includes/apple-exporter/components/class-aside.php
@@ -119,7 +119,7 @@ class Aside extends Component {
 						$aside_conditional_border_style,
 						$aside_conditional_conditions,
 					),
-				]
+				],
 			]
 			: [];
 
@@ -130,7 +130,7 @@ class Aside extends Component {
 						$aside_conditional_background_style,
 						$aside_conditional_conditions,
 					),
-				]
+				],
 			]
 			: [];
 


### PR DESCRIPTION
## Summary

Investigate Issue with Aside when Using Recipe Card Blocks

## Notes for reviewers

This PR addresses an issue with the Aside feature not correctly handling styles when the border style is set to "none" in both light and dark modes. The changes include a fix for this issue and some code cleanup.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Fix for the Aside feature to handle styles when the border style is set to "none" in both light and dark mode.

### Security

## Ticket(s)

- [APPLE-185](https://alleyinteractive.atlassian.net/browse/APPLE-185)

[APPLE-185]: https://alleyinteractive.atlassian.net/browse/APPLE-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ