### PR TITLE
Re-add deployignore

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -13,7 +13,7 @@ tests
 vendor
 
 # Files
-.distignore
+.deployignore
 .editorconfig
 .eslintignore
 .eslintrc.json

--- a/.deployignore
+++ b/.deployignore
@@ -1,4 +1,5 @@
 # Exclusions when publishing to the develop-built branch
+# Notably, must include .github and .distignore so the next step has access to them
 
 # Directories
 .git

--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,33 @@
+# Exclusions when publishing to the develop-built branch
+
+# Directories
+.git
+assets/js/admin-settings
+assets/js/components
+assets/js/config
+assets/js/pluginsidebar
+assets/js/services
+assets/js/util
+node_modules
+tests
+vendor
+
+# Files
+.distignore
+.editorconfig
+.eslintignore
+.eslintrc.json
+.gitignore
+.nvmrc
+.phpcs.xml
+.phpcs-cache.json
+.phpunit.result.cache
+babel.config.json
+composer.json
+composer.lock
+DOCKER_ENV
+package.json
+package-lock.json
+phpunit.xml.dist
+README.md
+webpack.config.js


### PR DESCRIPTION
Temporarily re-adds the .deployignore file so that the GitHub Actions workflow for deploying to WordPress.org exists in the develop-built branch so that we can manually trigger a deploy. I will file an issue for the future to remove the deployignore file and retool the way we are handling deploys to wp.org to remove the built branch workflow entirely, so that the assets are built and the deploy happens all within the same workflow and we aren't committing built assets at all.