### PR TITLE
Don't fatal on channel read failure

### DIFF
--- a/admin/apple-actions/index/class-channel.php
+++ b/admin/apple-actions/index/class-channel.php
@@ -9,7 +9,9 @@ namespace Apple_Actions\Index;
 
 require_once dirname( __DIR__ ) . '/class-api-action.php';
 
+use Admin_Apple_Notice;
 use Apple_Actions\API_Action;
+use Apple_Push_API\Request\Request_Exception;
 
 /**
  * A class to handle a channel request from the admin.
@@ -26,9 +28,19 @@ class Channel extends API_Action {
 		$channel = get_transient( 'apple_news_channel' );
 		if ( false === $channel ) {
 			if ( $this->is_api_configuration_valid() ) {
-				$channel = $this->get_api()->get_channel( $this->get_setting( 'api_channel' ) );
-				set_transient( 'apple_news_channel', $channel, 300 );
+				try {
+					$channel = $this->get_api()->get_channel( $this->get_setting( 'api_channel' ) );
+				} catch ( Request_Exception $e ) {
+					$channel = '';
+				}
 			}
+		}
+
+		set_transient( 'apple_news_channel', $channel, 300 );
+
+		if ( '' === $channel ) {
+			// Unable to get channel information. This likely means the user entered their API credentials incorrectly.
+			Admin_Apple_Notice::error( __( 'Publish to Apple News error: Unable to get channel information. Please check your API credentials.', 'apple-news' ) );
 		}
 
 		return ! empty( $channel ) ? $channel : null;

--- a/admin/partials/page-options.php
+++ b/admin/partials/page-options.php
@@ -9,10 +9,12 @@
  * @package Apple_News
  */
 
+$apple_news_successful_update = isset( $_POST['action'] ) && 'apple_news_options' === $_POST['action'] && Apple_News::is_initialized(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
 ?>
 <div class="wrap apple-news-settings">
 	<h1><?php esc_html_e( 'Manage Settings', 'apple-news' ); ?></h1>
-	<?php if ( Apple_News::is_initialized() ) : ?>
+	<?php if ( $apple_news_successful_update ) : ?>
 		<div class="notice notice-success">
 			<p><?php esc_html_e( 'The Apple News channel config has been successfully added.', 'apple-news' ); ?></p>
 		</div>

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -638,6 +638,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 		}
 
 		// Clear certain caches.
+		delete_transient( 'apple_news_channel' );
 		delete_transient( 'apple_news_sections' );
 
 		// Save to options.

--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.5.0
+ * Version:     2.5.1
  * Author:      Alley
  * Author URI:  https://alley.com
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -50,7 +50,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static string $version = '2.5.0';
+	public static string $version = '2.5.1';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: potatomaster, kevinfodness, jomurgel, tylermachado, benpbolton, al
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 6.3
-Tested up to: 6.5.3
+Tested up to: 6.6.1
 Requires PHP: 8.0
-Stable tag: 2.5.0
+Stable tag: 2.5.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -44,6 +44,9 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.5.1 =
+* Bugfix: Fixed an issue where the plugin would crash if the Apple News API returned an error when fetching information about the configured channel. Now surfaces an admin notice with the error message instead.
 
 = 2.5.0 =
 


### PR DESCRIPTION
- Prevents a fatal on channel read failure and replaces it with an admin notice.
- Clears the channel transient if settings are updated to allow users to fix bad API credentials and try again.
- Selectively displays the success message on the settings screen based on whether the user has just submitted the form or not.

Fixes #1150 