### PR TITLE
Issue-1154: A different approach to reindex the deleted article

### DIFF
--- a/admin/apple-actions/index/class-get.php
+++ b/admin/apple-actions/index/class-get.php
@@ -52,16 +52,7 @@ class Get extends API_Action {
 		}
 
 		// Get the article from the API.
-		try {
-			$article = $this->get_api()->get_article( $apple_id );
-		} catch ( \Apple_Push_API\Request\Request_Exception $e ) {
-			$article = $e->getMessage();
-
-			// Reset the API postmeta if the article is deleted in Apple News.
-			if ( is_string( $article ) && str_contains( $article, 'NOT_FOUND (keyPath articleId)' ) ) {
-				$this->delete_post_meta( $this->id );
-			}
-		}
+		$article = $this->get_api()->get_article( $apple_id );
 
 		if ( empty( $article->data ) ) {
 			return null;

--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -14,10 +14,10 @@ require_once __DIR__ . '/class-export.php';
 use Admin_Apple_Async;
 use Admin_Apple_Notice;
 use Admin_Apple_Sections;
-use Apple_Actions\Action_Exception;
-use Apple_Actions\API_Action;
 use Apple_Exporter\Exporter;
 use Apple_Exporter\Settings;
+use Apple_Actions\API_Action;
+use Apple_Actions\Action_Exception;
 use Apple_Push_API\Request\Request_Exception;
 
 /**
@@ -212,11 +212,12 @@ class Push extends API_Action {
 	/**
 	 * Push the post using the API data.
 	 *
-	 * @param int $user_id Optional. The ID of the user performing the push. Defaults to current user.
+	 * @param int  $user_id Optional. The ID of the user performing the push. Defaults to current user.
+	 * @param bool $display_notices Optional. Whether to display notices. Defaults to true.
 	 *
 	 * @throws Action_Exception If unable to push.
 	 */
-	private function push( $user_id = null ): void {
+	private function push( $user_id = null, $display_notices = true ): void {
 		if ( ! $this->is_api_configuration_valid() ) {
 			throw new Action_Exception( esc_html__( 'Your Apple News API settings seem to be empty. Please fill in the API key, API secret and API channel fields in the plugin configuration page.', 'apple-news' ) );
 		}
@@ -387,6 +388,9 @@ class Push extends API_Action {
 			);
 		}
 
+		$original_error_message = null;
+		$error_message          = null;
+
 		try {
 			if ( $remote_id ) {
 				// Update the current article from the API in case the revision changed.
@@ -450,31 +454,51 @@ class Push extends API_Action {
 			} else {
 				$error_message = __( 'There has been an error with the Apple News API: ', 'apple-news' ) . esc_html( $original_error_message );
 			}
+		} finally {
+			/**
+			 * Reindex the article if it was deleted in the iCloud News Publisher dashboard.
+			 *
+			 * @see https://github.com/alleyinteractive/apple-news/issues/1154
+			 */
+			if ( $original_error_message && str_contains( $original_error_message, 'NOT_FOUND (keyPath articleId)' ) ) {
+				try {
+					self::push(
+						user_id: $user_id,
+						display_notices: false
+					);
+				} catch ( Action_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+					// Do nothing, even if the second push fails.
+				}
+			}
 
-			throw new Action_Exception( esc_html( $error_message ) );
+			if ( $error_message ) {
+				throw new Action_Exception( esc_html( $error_message ) );
+			}
+		}
+
+		// If we're not supposed to display notices, bail out.
+		if ( false === $display_notices ) {
+			return;
 		}
 
 		// Print success message.
 		$post = get_post( $this->id );
+
+		$success_message = sprintf(
+			// translators: token is the post title.
+			__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
+			$post->post_title
+		);
+
 		if ( $remote_id ) {
-			Admin_Apple_Notice::success(
-				sprintf(
+			$success_message = sprintf(
 				// translators: token is the post title.
-					__( 'Article %s has been successfully updated on Apple News!', 'apple-news' ),
-					$post->post_title
-				),
-				$user_id
-			);
-		} else {
-			Admin_Apple_Notice::success(
-				sprintf(
-				// translators: token is the post title.
-					__( 'Article %s has been pushed successfully to Apple News!', 'apple-news' ),
-					$post->post_title
-				),
-				$user_id
+				__( 'Article %s has been successfully updated on Apple News!', 'apple-news' ),
+				$post->post_title
 			);
 		}
+
+		Admin_Apple_Notice::success( $success_message, $user_id );
 
 		$this->clean_workspace();
 	}

--- a/tests/admin/apple-actions/index/test-class-get.php
+++ b/tests/admin/apple-actions/index/test-class-get.php
@@ -57,43 +57,4 @@ class Apple_News_Admin_Action_Index_Get_Test extends Apple_News_Testcase {
 		$this->assertSame( $response['data']['revision'], $data->data->revision );
 		$this->assertSame( $response['data']['type'], $data->data->type );
 	}
-
-	/**
-	 * Test the behavior of the get action with a deleted Apple News article assigned to the post.
-	 */
-	public function test_get_deleted_article(): void {
-		$api_id  = 'def456';
-		$post_id = self::factory()->post->create();
-		$action  = new Apple_Actions\Index\Get( $this->settings, $post_id );
-
-		$this->assertNull( $action->perform() );
-
-		add_post_meta( $post_id, 'apple_news_api_id', $api_id );
-
-		// Fake the API response for the GET request.
-		$this->add_http_response(
-			verb: 'GET',
-			url: 'https://news-api.apple.com/articles/' . $api_id,
-			body: wp_json_encode(
-				[
-					'errors' => [
-						[
-							'code'    => 'NOT_FOUND',
-							'keyPath' => [ 'articleId' ],
-							'value'   => $api_id,
-						],
-					],
-				]
-			),
-			response: [
-				'code'    => 404,
-				'message' => 'Not Found',
-			]
-		);
-
-		$action = new Apple_Actions\Index\Get( $this->settings, $post_id );
-
-		$this->assertNull( $action->perform() );
-		$this->assertEmpty( get_post_meta( $post_id, 'apple_news_api_id', true ) );
-	}
 }

--- a/tests/rest/test-class-rest-post-published-state.php
+++ b/tests/rest/test-class-rest-post-published-state.php
@@ -92,13 +92,12 @@ class Apple_News_Rest_Post_Published_State_Test extends Apple_News_Testcase {
 
 		$this->get( rest_url( '/apple-news/v1/get-published-state/' . $post_id ) )
 			->assertOk()
-			->assertJsonPath( 'publishState', 'N/A' );
+			->assertJsonPath( 'publishState', 'NOT_FOUND (keyPath articleId)' );
 
-		// Ensure that the API postmeta _was_ reset.
-		$this->assertEmpty( get_post_meta( $post_id, 'apple_news_api_created_at', true ) );
-		$this->assertEmpty( get_post_meta( $post_id, 'apple_news_api_id', true ) );
-		$this->assertEmpty( get_post_meta( $post_id, 'apple_news_api_modified_at', true ) );
-		$this->assertEmpty( get_post_meta( $post_id, 'apple_news_api_revision', true ) );
-		$this->assertEmpty( get_post_meta( $post_id, 'apple_news_api_share_url', true ) );
+		$this->assertEquals( 'abc123', get_post_meta( $post_id, 'apple_news_api_created_at', true ) );
+		$this->assertEquals( $api_id, get_post_meta( $post_id, 'apple_news_api_id', true ) );
+		$this->assertEquals( 'ghi789', get_post_meta( $post_id, 'apple_news_api_modified_at', true ) );
+		$this->assertEquals( 'jkl123', get_post_meta( $post_id, 'apple_news_api_revision', true ) );
+		$this->assertEquals( 'mno456', get_post_meta( $post_id, 'apple_news_api_share_url', true ) );
 	}
 }


### PR DESCRIPTION
This is a followup from #1176 
See #1154 

- Do not delete the meta on GET requests; 
- Reindex post in the same push request.

The new approach makes sure it works for both the classic editor and the block editor.