### PR TITLE
Issue-1178: API Settings: the latest `value` is rendered after an update 

### DIFF
--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -643,5 +643,13 @@ class Admin_Apple_Settings_Section extends Apple_News {
 
 		// Save to options.
 		update_option( self::$section_option_name, $settings, 'no' );
+
+		/**
+		 * Update the cached settings with new one after an update.
+		 *
+		 * The `self::get_value` method uses this cached data. By resetting it, we ensure
+		 * that the new value is used after an update instead of the old value.
+		 */
+		self::$loaded_settings = $settings;
 	}
 }


### PR DESCRIPTION
### Summary

Fixes #1178

This pull request addresses the issue where `self::$loaded_settings` are not reset after an update, causing `self::get_value` to use stale data. This fix ensures that after updating any settings, the new data will be correctly used by the `self::get_value` method. The implementation now includes updating the cached settings immediately after any settings change to ensure the `self::get_value` method uses the most current data.

### Description

We need to reset the `self::$loaded_settings` after an update. When we perform an update to any of the settings, the new data is not used by the `self::get_value` method because the data is statically cached. The update ensures that the cache is refreshed immediately after a settings change, addressing the issue of stale data.

[Relevant code section](https://github.com/alleyinteractive/apple-news/blob/a30a699e232303fdd7eef3d8f48b894ddcb092b2/admin/settings/class-admin-apple-settings-section.php#L180)

### Steps To Reproduce

[Steps for reproduction](https://github.com/user-attachments/assets/964a888a-fd51-468d-b50c-300477ffde14)

### Additional Information

_No response_