### PR TITLE
Issue-1153: Email Error Notifications

### DIFF
--- a/admin/apple-actions/index/class-push.php
+++ b/admin/apple-actions/index/class-push.php
@@ -451,6 +451,14 @@ class Push extends API_Action {
 				$error_message = __( 'There has been an error with the Apple News API: ', 'apple-news' ) . esc_html( $original_error_message );
 			}
 
+			/**
+			 * Actions to be taken after an article failed to be pushed to Apple News.
+			 *
+			 * @param int $post_id The ID of the post.
+			 * @param string $original_error_message The original error message.
+			 */
+			do_action( 'apple_news_after_push_failure', $this->id, $original_error_message );
+
 			throw new Action_Exception( esc_html( $error_message ) );
 		}
 

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -173,6 +173,7 @@ class Request {
 
 			// Get the admin email.
 			$admin_email = filter_var( $settings['apple_news_admin_email'], FILTER_VALIDATE_EMAIL );
+
 			if ( empty( $admin_email ) ) {
 				return; // TODO Fix inconsistent return value.
 			}
@@ -191,8 +192,8 @@ class Request {
 			if ( 'yes' === $settings['use_remote_images'] ) {
 				$body .= esc_html__( 'Use Remote images enabled ', 'apple-news' );
 			} elseif ( ! empty( $bundles ) ) {
-					$body .= "\n" . esc_html__( 'Bundled images', 'apple-news' ) . ":\n";
-					$body .= implode( "\n", $bundles );
+				$body .= "\n" . esc_html__( 'Bundled images', 'apple-news' ) . ":\n";
+				$body .= implode( "\n", $bundles );
 			} else {
 				$body .= esc_html__( 'No bundled images found.', 'apple-news' );
 			}
@@ -210,7 +211,7 @@ class Request {
 			 *
 			 * @since 1.4.4
 			 *
-			 * @param string|array $headers     Optional. Additional headers.
+			 * @param string|array $headers Optional. Additional headers.
 			 */
 			$headers = apply_filters( 'apple_news_notification_headers', '' );
 


### PR DESCRIPTION
### Summary

This PR introduces functionality to alert channel admins via email when a post fails to publish to Apple News. Fixes #1153

### Description

A new hook has been introduced that fires when a post fails to be pushed to Apple News. This enhancement addresses the need for beyond-dashboard failure notifications, allowing channel admins to be alerted via email.

### Related Issue

[Email Error Notifications](https://github.com/alleyinteractive/apple-news/issues/1153)