### PR TITLE
Issue-1161:  Debugging Settings: support sending notification to multiple email accounts

### DIFF
--- a/admin/settings/class-admin-apple-settings-section-developer-tools.php
+++ b/admin/settings/class-admin-apple-settings-section-developer-tools.php
@@ -41,10 +41,11 @@ class Admin_Apple_Settings_Section_Developer_Tools extends Admin_Apple_Settings_
 				'type'  => [ 'no', 'yes' ],
 			],
 			'apple_news_admin_email'      => [
-				'label'    => __( 'Administrator Email', 'apple-news' ),
+				'label'    => __( 'Email(s)', 'apple-news' ),
 				'required' => false,
-				'type'     => 'string',
+				'type'     => 'email',
 				'size'     => 40,
+				'multiple' => true,
 			],
 		];
 
@@ -70,7 +71,7 @@ class Admin_Apple_Settings_Section_Developer_Tools extends Admin_Apple_Settings_
 	 */
 	public function get_section_info() {
 		return __(
-			'If debugging is enabled, emails will be sent to an administrator for every publish, update or delete action with a detailed API response.',
+			'If debugging is enabled (and valid emails are provided), emails will be sent for every publish, update or delete action with a detailed API response.',
 			'apple-news'
 		);
 	}

--- a/admin/settings/class-admin-apple-settings-section.php
+++ b/admin/settings/class-admin-apple-settings-section.php
@@ -126,6 +126,7 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			'max'         => [],
 			'step'        => [],
 			'type'        => [],
+			'multiple'    => [],
 			'required'    => [],
 			'size'        => [],
 			'id'          => [],
@@ -324,6 +325,14 @@ class Admin_Apple_Settings_Section extends Apple_News {
 			$field = '<textarea id="%s" name="%s">%s</textarea>';
 		} elseif ( 'number' === $type ) {
 			$field = '<input type="number" id="%s" name="%s" value="%s" size="%s" min="%s" max="%s" step="%s" %s>';
+		} elseif ( 'email' === $type ) {
+			$field = '<input type="email" id="%s" name="%s" value="%s" size="%s"';
+
+			if ( $this->is_multiple( $name ) ) {
+				$field .= ' multiple %s>';
+			} else {
+				$field .= ' %s>';
+			}
 		} else {
 			// If nothing else matches, it's a string.
 			$field = '<input type="text" id="%s" name="%s" value="%s" size="%s" %s>';
@@ -403,9 +412,9 @@ class Admin_Apple_Settings_Section extends Apple_News {
 	protected function get_type_for( $name ) {
 		if ( $this->hidden ) {
 			return 'hidden';
-		} else {
-			return empty( $this->settings[ $name ]['type'] ) ? 'string' : $this->settings[ $name ]['type'];
 		}
+
+		return empty( $this->settings[ $name ]['type'] ) ? 'string' : $this->settings[ $name ]['type'];
 	}
 
 	/**

--- a/includes/apple-push-api/request/class-request.php
+++ b/includes/apple-push-api/request/class-request.php
@@ -171,9 +171,17 @@ class Request {
 			&& 'yes' === $settings['apple_news_enable_debugging']
 			&& 'get' !== $type ) {
 
-			// Get the admin email.
-			$admin_email = filter_var( $settings['apple_news_admin_email'], FILTER_VALIDATE_EMAIL );
-			if ( empty( $admin_email ) ) {
+			$emails = $settings['apple_news_admin_email'] ?? '';
+
+			if ( str_contains( $emails, ',' ) ) {
+				$emails = array_map( 'trim', explode( ',', $emails ) );
+			} else {
+				$emails = [ $emails ];
+			}
+
+			$to = array_filter( $emails, 'is_email' );
+
+			if ( empty( $to ) ) {
 				return; // TODO Fix inconsistent return value.
 			}
 
@@ -217,7 +225,7 @@ class Request {
 			// Send the email.
 			if ( ! empty( $body ) ) {
 				wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-					$admin_email,
+					$to,
 					esc_html__( 'Apple News Notification', 'apple-news' ),
 					$body,
 					$headers


### PR DESCRIPTION
### Summary

Fixes #1161

This PR addresses the need to support sending debugging notifications to multiple email accounts as outlined in the [issue #1161](https://github.com/alleyinteractive/apple-news/issues/1161). It introduces functionality allowing the addition of multiple email addresses in the Developer Tools settings.

### Description

The Developer Tools currently only support sending debugging information to a single email address. This enhancement allows for multiple users, each with different email addresses, to receive debugging notifications.

### Use Case

This change is crucial for teams where multiple individuals need access to debugging notifications to ensure smooth development and troubleshooting processes.

### Changes Made

- Modified the handling of the debugging notifications setting to support multiple email addresses.
- Updated the UI in the Developer Tools section to allow for the entry of multiple email addresses.

### Acceptance Criteria

- Allow adding, and sending, debugging notifications to multiple email addresses.

### Testing

1. Navigate to the Developer Tools settings.
2. Add multiple email addresses to the debugging notifications field.
3. Trigger a debugging event.
4. Verify that all specified email addresses receive the debugging notification.

### Additional Notes

A `apple_news_notification_headers` hook exists for developers, but this update provides a more user-friendly approach for non-technical users as well.