### PR TITLE
Issue-1164: REST Endpoints actually return a `WP_Error` if Apple News *is not* initialized

### DIFF
--- a/includes/REST/apple-news-delete.php
+++ b/includes/REST/apple-news-delete.php
@@ -9,17 +9,8 @@ namespace Apple_News\REST;
 
 use WP_Error;
 use WP_REST_Request;
-
-/**
- * Handle a REST POST request to the /apple-news/v1/delete endpoint.
- *
- * @param WP_REST_Request $data Data from query args.
- *
- * @return array|WP_Error Response to the request - either data about a successfully deleted article, or error.
- */
-function rest_post_delete( $data ) {
-	return modify_post( (int) $data->get_param( 'id' ), 'delete' );
-}
+use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * Initialize this REST Endpoint.
@@ -27,15 +18,30 @@ function rest_post_delete( $data ) {
 add_action(
 	'rest_api_init',
 	function () {
-		// Register route count argument.
 		register_rest_route(
 			'apple-news/v1',
 			'/delete',
 			[
-				'methods'             => 'POST',
+				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => __NAMESPACE__ . '\rest_post_delete',
 				'permission_callback' => '__return_true',
 			]
 		);
 	}
 );
+
+/**
+ * Handle a REST POST request to the /apple-news/v1/delete endpoint.
+ *
+ * @param WP_REST_Request $request Full details about the request.
+ * @return WP_REST_Response|WP_Error
+ */
+function rest_post_delete( $request ): WP_REST_Response|WP_Error {
+	$post = modify_post( (int) $request->get_param( 'id' ), 'delete' );
+
+	if ( is_wp_error( $post ) ) {
+		return $post;
+	}
+
+	return rest_ensure_response( $post );
+}

--- a/includes/REST/apple-news-get-published-state.php
+++ b/includes/REST/apple-news-get-published-state.php
@@ -44,7 +44,7 @@ add_action(
  * Get the published state of a post.
  *
  * @param WP_REST_Request $request Full details about the request.
- * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+ * @return WP_REST_Response|WP_Error
  */
 function get_published_state_response( $request ): WP_REST_Response|WP_Error {
 	$id = $request->get_param( 'id' );

--- a/includes/REST/apple-news-modify-post.php
+++ b/includes/REST/apple-news-modify-post.php
@@ -23,9 +23,13 @@ use WP_Error;
  *
  * @return array|WP_Error Response to the request - either data about a successful operation, or error.
  */
-function modify_post( $post_id, $operation ) {
+function modify_post( $post_id, $operation ): array|WP_Error {
 	// Ensure Apple News is first initialized.
-	\Apple_News::has_uninitialized_error();
+	$retval = \Apple_News::has_uninitialized_error();
+
+	if ( is_wp_error( $retval ) ) {
+		return $retval;
+	}
 
 	// Ensure there is a post ID provided in the data.
 	if ( empty( $post_id ) ) {
@@ -85,6 +89,7 @@ function modify_post( $post_id, $operation ) {
 				]
 			);
 	}
+
 	try {
 		$action->perform();
 

--- a/includes/REST/apple-news-publish.php
+++ b/includes/REST/apple-news-publish.php
@@ -9,17 +9,8 @@ namespace Apple_News\REST;
 
 use WP_Error;
 use WP_REST_Request;
-
-/**
- * Handle a REST POST request to the /apple-news/v1/publish endpoint.
- *
- * @param WP_REST_Request $data Data from query args.
- *
- * @return array|WP_Error Response to the request - either data about a successfully published article, or error.
- */
-function rest_post_publish( $data ) {
-	return modify_post( (int) $data->get_param( 'id' ), 'publish' );
-}
+use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * Initialize this REST Endpoint.
@@ -27,15 +18,30 @@ function rest_post_publish( $data ) {
 add_action(
 	'rest_api_init',
 	function () {
-		// Register route count argument.
 		register_rest_route(
 			'apple-news/v1',
 			'/publish',
 			[
-				'methods'             => 'POST',
+				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => __NAMESPACE__ . '\rest_post_publish',
 				'permission_callback' => '__return_true',
 			]
 		);
 	}
 );
+
+/**
+ * Handle a REST POST request to the /apple-news/v1/publish endpoint.
+ *
+ * @param WP_REST_Request $request Full details about the request.
+ * @return WP_REST_Response|WP_Error
+ */
+function rest_post_publish( $request ): WP_REST_Response|WP_Error {
+	$post = modify_post( (int) $request->get_param( 'id' ), 'publish' );
+
+	if ( is_wp_error( $post ) ) {
+		return $post;
+	}
+
+	return rest_ensure_response( $post );
+}

--- a/includes/REST/apple-news-sections.php
+++ b/includes/REST/apple-news-sections.php
@@ -7,14 +7,40 @@
 
 namespace Apple_News\REST;
 
+use WP_Error;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Initialize this REST Endpoint.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'apple-news/v1',
+			'/sections',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __NAMESPACE__ . '\get_sections_response',
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+);
+
 /**
  * Get API response.
  *
- * @return array An array of information about sections.
+ * @return WP_REST_Response|WP_Error
  */
-function get_sections_response() {
+function get_sections_response(): WP_REST_Response|WP_Error {
 	// Ensure Apple News is first initialized.
-	\Apple_News::has_uninitialized_error();
+	$retval = \Apple_News::has_uninitialized_error();
+
+	if ( is_wp_error( $retval ) ) {
+		return $retval;
+	}
 
 	$sections = \Admin_Apple_Sections::get_sections();
 	$response = [];
@@ -28,24 +54,5 @@ function get_sections_response() {
 		}
 	}
 
-	return $response;
+	return rest_ensure_response( $response );
 }
-
-/**
- * Initialize this REST Endpoint.
- */
-add_action(
-	'rest_api_init',
-	function () {
-		// Register route count argument.
-		register_rest_route(
-			'apple-news/v1',
-			'/sections',
-			[
-				'methods'             => 'GET',
-				'callback'            => __NAMESPACE__ . '\get_sections_response',
-				'permission_callback' => '__return_true',
-			]
-		);
-	}
-);

--- a/includes/REST/apple-news-update.php
+++ b/includes/REST/apple-news-update.php
@@ -9,17 +9,8 @@ namespace Apple_News\REST;
 
 use WP_Error;
 use WP_REST_Request;
-
-/**
- * Handle a REST POST request to the /apple-news/v1/update endpoint.
- *
- * @param WP_REST_Request $data Data from query args.
- *
- * @return array|WP_Error Response to the request - either data about a successfully updated article, or error.
- */
-function rest_post_update( $data ) {
-	return modify_post( (int) $data->get_param( 'id' ), 'update' );
-}
+use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * Initialize this REST Endpoint.
@@ -27,15 +18,30 @@ function rest_post_update( $data ) {
 add_action(
 	'rest_api_init',
 	function () {
-		// Register route count argument.
 		register_rest_route(
 			'apple-news/v1',
 			'/update',
 			[
-				'methods'             => 'POST',
+				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => __NAMESPACE__ . '\rest_post_update',
 				'permission_callback' => '__return_true',
 			]
 		);
 	}
 );
+
+/**
+ * Handle a REST POST request to the /apple-news/v1/update endpoint.
+ *
+ * @param WP_REST_Request $request Full details about the request.
+ * @return WP_REST_Response|WP_Error
+ */
+function rest_post_update( $request ): WP_REST_Response|WP_Error {
+	$post = modify_post( (int) $request->get_param( 'id' ), 'update' );
+
+	if ( is_wp_error( $post ) ) {
+		return $post;
+	}
+
+	return rest_ensure_response( $post );
+}

--- a/includes/REST/apple-news-user-can-publish.php
+++ b/includes/REST/apple-news-user-can-publish.php
@@ -8,34 +8,57 @@
 namespace Apple_News\REST;
 
 use Apple_News;
+use WP_Error;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Initialize this REST Endpoint.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'apple-news/v1',
+			'/user-can-publish/(?P<id>\d+)',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __NAMESPACE__ . '\get_user_can_publish',
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+);
 
 /**
  * Get API response.
  *
- * @param array $args Args present in the URL.
- *
- * @return array An array that contains the key 'userCanPublish' which is true if the user can publish, false if not.
+ * @param WP_REST_Request $request Full details about the request.
+ * @return WP_REST_Response|WP_Error
  */
-function get_user_can_publish( $args ) {
+function get_user_can_publish( $request ): WP_REST_Response|WP_Error {
+	// Ensure Apple News is first initialized.
+	$retval = Apple_News::has_uninitialized_error();
+
+	if ( is_wp_error( $retval ) ) {
+		return $retval;
+	}
 
 	// Ensure there is a post ID provided in the data.
-	$id = ! empty( $args['id'] ) ? (int) $args['id'] : 0;
+	$id = (int) $request->get_param( 'id' );
+
 	if ( empty( $id ) ) {
-		return [
-			'userCanPublish' => false,
-		];
+		return rest_ensure_response( [ 'userCanPublish' => false ] );
 	}
 
 	// Try to get the post by ID.
 	$post = get_post( $id );
 	if ( empty( $post ) ) {
-		return [
-			'userCanPublish' => false,
-		];
+		return rest_ensure_response( [ 'userCanPublish' => false ] );
 	}
 
 	// Ensure the user is authorized to make changes to Apple News posts.
-	return [
+	$response = [
 		'userCanPublish' => current_user_can(
 			/** This filter is documented in admin/class-admin-apple-post-sync.php */
 			apply_filters(
@@ -44,23 +67,6 @@ function get_user_can_publish( $args ) {
 			)
 		),
 	];
-}
 
-/**
- * Initialize this REST Endpoint.
- */
-add_action(
-	'rest_api_init',
-	function () {
-		// Register route count argument.
-		register_rest_route(
-			'apple-news/v1',
-			'/user-can-publish/(?P<id>\d+)',
-			[
-				'methods'             => 'GET',
-				'callback'            => __NAMESPACE__ . '\get_user_can_publish',
-				'permission_callback' => '__return_true',
-			]
-		);
-	}
-);
+	return rest_ensure_response( $response );
+}


### PR DESCRIPTION
### Summary

Fixes #1164

This PR addresses the issue where REST endpoints do not return a `WP_Error` if Apple News is not initialized. It includes the necessary code adjustments and unit tests to ensure the expected behavior is achieved.

### Description

Improvements have been made to the REST endpoints to ensure they properly return a `WP_Error` when Apple News is not initialized. The codebase has been updated accordingly.

See https://github.com/search?q=repo%3Aalleyinteractive%2Fapple-news%20%5CApple_News%3A%3Ahas_uninitialized_error()%3B&type=code

Please, add unit tests.

### Use Case

If Apple News is not initialized with the minimum settings, the REST API needs to return an error.