### PR TITLE
Issue-1189: Test Against WordPress 6.7

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -14,7 +14,7 @@
  * Plugin Name: Publish to Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.6.0
+ * Version:     2.6.1
  * Author:      Alley
  * Author URI:  https://alley.com
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -50,7 +50,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static string $version = '2.6.0';
+	public static string $version = '2.6.1';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: potatomaster, kevinfodness, jomurgel, tylermachado, benpbolton, al
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 6.3
-Tested up to: 6.6.2
+Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 2.6.0
+Stable tag: 2.6.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -44,6 +44,10 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.6.1 =
+
+* Enhancement: Ensured support for WordPress 6.7.
 
 = 2.6.0 =
 


### PR DESCRIPTION
### Summary

Fixes #1189

### Description

This pull request addresses the issue of testing against WordPress 6.7 as described in [Issue #1189](https://github.com/alleyinteractive/apple-news/issues/1189). The primary task is to ensure compatibility with the upcoming WordPress 6.7 release by testing the plugin against the latest release candidate and updating the "tested up to" version to 6.7 in the plugin's readme.

### Changes Made

- Tested the plugin against WordPress 6.7 release candidate.
- Updated the "tested up to" version to 6.7 in the plugin's readme.