### PR TITLE
Prevent delete for revisions

### DIFF
--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -188,6 +188,7 @@ class Admin_Apple_Post_Sync {
 	public function do_delete( $id ) {
 		$post = get_post( $id );
 		if ( empty( $post->post_type )
+			|| wp_is_post_autosave( $id )
 			|| ! current_user_can(
 				/**
 				 * Filters the delete capability required to delete posts from Apple News.

--- a/admin/class-admin-apple-post-sync.php
+++ b/admin/class-admin-apple-post-sync.php
@@ -188,7 +188,7 @@ class Admin_Apple_Post_Sync {
 	public function do_delete( $id ) {
 		$post = get_post( $id );
 		if ( empty( $post->post_type )
-			|| wp_is_post_autosave( $id )
+			|| wp_is_post_revision( $id )
 			|| ! current_user_can(
 				/**
 				 * Filters the delete capability required to delete posts from Apple News.

--- a/apple-news.php
+++ b/apple-news.php
@@ -3,7 +3,7 @@
  * Plugin Name: Publish To Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.6.2
+ * Version:     2.6.3
  * Author:      Alley
  * Author URI:  https://alley.com
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -50,7 +50,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static string $version = '2.6.2';
+	public static string $version = '2.6.3';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 6.3
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 2.6.2
+Stable tag: 2.6.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 


### PR DESCRIPTION
We've discovered an issue where the deletion of an autosave can trigger the Apple News article to be deleted.

Typically, autosaves don't have post meta, so this isn't a widespread issue.
