### PR TITLE
Issue-1026: Prevent Errors When Using VideoPress Videos

### DIFF
--- a/includes/apple-exporter/components/class-component.php
+++ b/includes/apple-exporter/components/class-component.php
@@ -882,39 +882,5 @@ abstract class Component {
 
 		return null;
 	}
-
-	/**
-	 * Get iframe/embed node.
-	 *
-	 * @param DOMElement $node The node to examine.
-	 *
-	 * @return bool True if the figure is an iframe.
-	 */
-	public static function is_embed_figure( $node ) {
-
-		// Return false if we don't have any child nodes.
-		if ( ! $node->hasChildNodes() ) {
-			return false;
-		}
-
-		// Loop those child nodes.
-		foreach ( $node->childNodes as $child ) {
-
-			// Return false if we don't have children, or if is an image.
-			if ( ! $child->hasChildNodes() || 'img' === $child->nodeName ) {
-				return false;
-			}
-
-			foreach ( $child->childNodes as $c ) {
-
-				// Return true if we're seeing an iframe.
-				if ( 'iframe' === $c->nodeName ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
 	/* phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
 }

--- a/includes/apple-exporter/components/class-image.php
+++ b/includes/apple-exporter/components/class-image.php
@@ -40,8 +40,7 @@ class Image extends Component {
 		if ( self::node_has_class( $node, 'wp-block-cover' )
 			|| 'img' === $node->nodeName
 			|| ( 'figure' === $node->nodeName
-				&& ( Component::is_embed_figure( $node )
-					|| self::node_has_class( $node, 'wp-caption' )
+				&& ( self::node_has_class( $node, 'wp-caption' )
 					|| $has_image_child
 				)
 			)


### PR DESCRIPTION
### Summary

Fixes #1026

This pull request addresses the issue with VideoPress embedded videos causing a `FAILED_TO_PARSE_IMAGE` error when publishing to Apple News. The fix involves removing the `is_embed_figure` check from the image parser and removing the associated function entirely, as it is incorrectly used and not appropriate for images.

### Changes Made

- Removed `is_embed_figure` check from the image parser.
- Deleted the `is_embed_figure` function, as it was only used in one incorrect instance.

### Steps to Test

1. Embed a video using VideoPress in WordPress.
2. Publish to Apple News.
3. Confirm that the `FAILED_TO_PARSE_IMAGE` error no longer occurs.

### Additional Notes

Because of how VideoPress works, it's not straightforward to implement first-class support for the videos (Apple News requires a Video component and a direct link to an MP4 file to play, whereas VideoPress relies on JavaScript and iframes to play videos). The goal for this PR is to stop getting component errors on the image component when a VideoPress embed is encountered.