### PR TITLE
Fix dates in byline

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -537,8 +537,8 @@ class Export extends Action {
 		$theme = \Apple_Exporter\Theme::get_used();
 
 		// Get the date.
-		if ( empty( $date ) && ! empty( $post->post_date ) ) {
-			$date = $post->post_date;
+		if ( empty( $date ) && ! empty( $post->post_date_gmt ) ) {
+			$date = $post->post_date_gmt;
 		}
 
 		// Check for a custom byline format.

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -163,32 +163,36 @@ class Apple_News_Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 	 * Tests generic byline formatting.
 	 */
 	public function test_byline_format() {
-		$this->set_theme_settings( [ 'meta_component_order' => [ 'byline' ] ] );
-		$user_id = $this->factory->user->create(
-			[
-				'role'         => 'administrator',
-				'display_name' => 'Testuser',
-			]
-		);
+		// Temporarily set the timezone Manaus (UTC-4 and does not have DST).
+		$this->with_timezone('America/Manaus', function() {
+			$this->set_theme_settings( [ 'meta_component_order' => [ 'byline' ] ] );
+			$user_id = $this->factory->user->create(
+				[
+					'role'         => 'administrator',
+					'display_name' => 'Testuser',
+				]
+			);
 
-		$title   = 'My Title';
-		$content = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue arcu. Curabitur lacus elit, venenatis a laoreet sit amet, imperdiet ac lorem. Curabitur sed leo sed ligula tempor feugiat. Cras in tellus et elit volutpat.</p>';
+			$title   = 'My Title';
+			$content = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tristique quis justo sit amet eleifend. Praesent id metus semper, fermentum nibh at, malesuada enim. Mauris eget faucibus lectus. Vivamus iaculis eget urna non porttitor. Donec in dignissim neque. Vivamus ut ornare magna. Nulla eros nisi, maximus nec neque at, condimentum lobortis leo. Fusce in augue arcu. Curabitur lacus elit, venenatis a laoreet sit amet, imperdiet ac lorem. Curabitur sed leo sed ligula tempor feugiat. Cras in tellus et elit volutpat.</p>';
 
-		$post_id = $this->factory->post->create(
-			[
-				'post_title'   => $title,
-				'post_content' => $content,
-				'post_excerpt' => '',
-				'post_author'  => $user_id,
-				'post_date'    => '2016-08-26 12:00',
-			]
-		);
+			$post_id = $this->factory->post->create(
+				[
+					'post_title'   => $title,
+					'post_content' => $content,
+					'post_excerpt' => '',
+					'post_author'  => $user_id,
+					'post_date_gmt'    => '2016-08-26 16:00', // 4 hours ahead of Manaus time.
+				]
+			);
 
-		$export           = new Export( $this->settings, $post_id );
-		$exporter         = $export->fetch_exporter();
-		$exporter_content = $exporter->get_content();
+			$export           = new Export( $this->settings, $post_id );
+			$exporter         = $export->fetch_exporter();
+			$exporter_content = $exporter->get_content();
 
-		$this->assertEquals( 'By Testuser | Aug 26, 2016 | 12:00 PM', $exporter_content->byline() );
+			$this->assertEquals( 'By Testuser | Aug 26, 2016 | 12:00 PM', $exporter_content->byline() );
+		});
+
 	}
 
 	/**

--- a/tests/admin/apple-actions/index/test-class-export.php
+++ b/tests/admin/apple-actions/index/test-class-export.php
@@ -164,7 +164,7 @@ class Apple_News_Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 	 */
 	public function test_byline_format() {
 		// Temporarily set the timezone Manaus (UTC-4 and does not have DST).
-		$this->with_timezone('America/Manaus', function() {
+		$this->with_timezone( 'America/Manaus', function () {
 			$this->set_theme_settings( [ 'meta_component_order' => [ 'byline' ] ] );
 			$user_id = $this->factory->user->create(
 				[
@@ -178,11 +178,11 @@ class Apple_News_Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 
 			$post_id = $this->factory->post->create(
 				[
-					'post_title'   => $title,
-					'post_content' => $content,
-					'post_excerpt' => '',
-					'post_author'  => $user_id,
-					'post_date_gmt'    => '2016-08-26 16:00', // 4 hours ahead of Manaus time.
+					'post_title'    => $title,
+					'post_content'  => $content,
+					'post_excerpt'  => '',
+					'post_author'   => $user_id,
+					'post_date_gmt' => '2016-08-26 16:00', // 4 hours ahead of Manaus time.
 				]
 			);
 
@@ -191,8 +191,7 @@ class Apple_News_Admin_Action_Index_Export_Test extends Apple_News_Testcase {
 			$exporter_content = $exporter->get_content();
 
 			$this->assertEquals( 'By Testuser | Aug 26, 2016 | 12:00 PM', $exporter_content->byline() );
-		});
-
+		} );
 	}
 
 	/**

--- a/tests/class-apple-news-testcase.php
+++ b/tests/class-apple-news-testcase.php
@@ -611,4 +611,26 @@ abstract class Apple_News_Testcase extends WP_UnitTestCase {
 	protected function set_workspace_post_id( $post_id ) {
 		$this->workspace = new Apple_Exporter\Workspace( $post_id );
 	}
+
+	/**
+	 * Helper that temporarily sets the timezone to the given timezone
+	 * string and runs the callback function.
+	 *
+	 * @param string   $timezone_string The timezone string to set.
+	 * @param callable $callback        The callback function to run with the new timezone.
+	 */
+	protected function with_timezone( $timezone_string, $callback ) {
+		$original_timezone_string = get_option( 'timezone_string' );
+		$original_gmt_offset      = get_option( 'gmt_offset' );
+
+		try {
+			update_option( 'timezone_string', $timezone_string );
+			update_option( 'gmt_offset', 0 );
+
+			$callback();
+		} finally {
+			update_option( 'timezone_string', $original_timezone_string );
+			update_option( 'gmt_offset', $original_gmt_offset );
+		}
+	}
 }


### PR DESCRIPTION
This fixes the dates in bylines. The were behind the site time by the UTC offset.

There is date handling in both `format_byline()` and `format_date()` and this makes them use the same date (post_date_gmt) to hand to `strtotime()` and `apple_news_date()` .

## How to reproduce

* I tested this on a fresh site where I didn't touch settings for Apple News at all.
* The site uses the timezone for Manaus, Brazil. 
* These are the dates on the post I tested on:

```
❯ wp post get 5 --fields=post_date_gmt,post_date
+---------------+---------------------+
| Field         | Value               |
+---------------+---------------------+
| post_date     | 2025-06-26 10:11:25 |
| post_date_gmt | 2025-06-26 14:11:25 |
+---------------+---------------------+
```
* Without the patch looking at the debug, the components -> byline said  "Jun 26, 2025 | 6:11 AM"
* With the patch it says:   "Jun 26, 2025 | 10:11 AM"

Note that this doesn't touch the other dates. This output is the same with and without the patch:
```
    "metadata": {
        "authors": [
            "Spongebob"
        ],
        "dateCreated": "2025-06-26T14:11:25+00:00",
        "dateModified": "2025-06-26T14:21:29+00:00",
        "datePublished": "2025-06-26T14:11:25+00:00",
        "canonicalURL": "https://fresh.test/?p=5",
        "generatorIdentifier": "publish-to-apple-news",
        "generatorName": "Publish To Apple News",
        "generatorVersion": "2.7.1"
    }
```

## Tests
I added a timezone-switcher to the tests. Not sure how robust that is, but it was quick :)

Fixes #1035 