### PR TITLE
Add `per_page` param to the Term search

### DIFF
--- a/assets/js/components/term-selector/index.jsx
+++ b/assets/js/components/term-selector/index.jsx
@@ -27,7 +27,7 @@ export default function TermSelector({
     const fetchTermData = async () => {
       if (debouncedSearchTerm) {
         const newSearchResults = await apiFetch({
-          path: `/${taxonomies[taxonomy].rest_namespace}/${taxonomies[taxonomy].rest_base}?search=${debouncedSearchTerm}&?per_page=50`,
+          path: `/${taxonomies[taxonomy].rest_namespace}/${taxonomies[taxonomy].rest_base}?search=${debouncedSearchTerm}&per_page=50`,
         });
         newSearchResults.forEach((result) => termCache.set(result));
         setSearchResults(newSearchResults);

--- a/assets/js/components/term-selector/index.jsx
+++ b/assets/js/components/term-selector/index.jsx
@@ -27,7 +27,7 @@ export default function TermSelector({
     const fetchTermData = async () => {
       if (debouncedSearchTerm) {
         const newSearchResults = await apiFetch({
-          path: `/${taxonomies[taxonomy].rest_namespace}/${taxonomies[taxonomy].rest_base}?search=${debouncedSearchTerm}`,
+          path: `/${taxonomies[taxonomy].rest_namespace}/${taxonomies[taxonomy].rest_base}?search=${debouncedSearchTerm}&?per_page=50`,
         });
         newSearchResults.forEach((result) => termCache.set(result));
         setSearchResults(newSearchResults);


### PR DESCRIPTION
The search is by default capped to just 10 results, this is problematic when you have a lot of terms with the search phrase you are using. In our case, we wanted to select the category "Reviews", however, we also have lots of other categories with that phrase (Book Reviews, Phone Review, Accessory Reviews, etc), and "Reviews" never showed up in the results.

We temporarily fixed this by passing the `per_page` param in our search phrase, but for larger sites, it would be nice if the per_page param was at least 50, and perhaps for the future, configurable in the settings.