### PR TITLE
Issue-1247: Issue with wrapped Affiliate links in Apple News

### DIFF
--- a/includes/apple-exporter/components/class-link-button.php
+++ b/includes/apple-exporter/components/class-link-button.php
@@ -116,6 +116,7 @@ class Link_Button extends Component {
 			} elseif ( 0 === strpos( $url, '#' ) ) {
 				$url = trailingslashit( get_the_permalink() ) . $url;
 			}
+			$url = html_entity_decode( $url, ENT_QUOTES, 'UTF-8' );
 
 			// Register JSON for this component.
 			$this->register_json(


### PR DESCRIPTION
### Summary

Fixes #1247

This pull request addresses an issue where wrapped Affiliate links in Apple News are generating errors when clicked. The root cause appears to be the encoding of ampersands (`&`) as HTML entities (`&amp;`) within URLs, which interferes with the expected parameters and causes errors such as "missing hash." This PR modifies the URL handling to ensure ampersands are correctly represented, allowing the hash and other parameters to be properly parsed in Apple News.

### Related Issue

[Issue #1247: Issue with wrapped Affiliate links in Apple News](https://github.com/alleyinteractive/apple-news/issues/1247)

### How to Test

1. Publish an article with a wrapped Affiliate link similar to the example in the issue.
2. Open the article in the Apple News reader.
3. Click on the CTA link and verify that the link redirects correctly without errors.
4. Inspect the link in the Apple News feed and confirm that all `&` characters are correctly encoded (not as `&amp;`).
5. Compare the Apple News URL to the original website URL to ensure consistency.

### Additional Context

- Original website link example:
  ```
  https://kcm.prsm1.com/r?url=https%3A%2F%2Fwww.dpbolvw.net%2Fclick-100797580-15734817%3Furl%3Dhttps%253A%252F%252Fwww.jcrew.com%252Fp%252Fwomens%252Fcategories%252Fclothing%252Fsweaters%252Fpullovers%252Fribbed-boatneck-sweater-in-vintage-wool%252FCM686%253Fdisplay%253Dstandard%2526fit%253DClassic%2526color_name%253Dhthr-grey%2526colorProductCode%253DCM686%26sid%3Dfall-sales25&h=d58e391befc2b171e82313b4c7007eff06788654fcbd5364be38ad9d95d2ff88&click_data_01=fashion-w-style
  ```
- Apple News link example (problematic):
  ```
  https://kcm.prsm1.com/r?url=https%3A%2F%2Fwww.dpbolvw.net%2Fclick-100797580-15734817%3Furl%3Dhttps%253A%252F%252Fwww.jcrew.com%252Fp%252Fwomens%252Fcategories%252Fclothing%252Fsweaters%252Fpullovers%252Fribbed-boatneck-sweater-in-vintage-wool%252FCM686%253Fdisplay%253Dstandard%2526fit%253DClassic%2526color_name%253Dhthr-grey%2526colorProductCode%253DCM686%26sid%3Dfall-sales25&amp;h=d58e391befc2b171e82313b4c7007eff06788654fcbd5364be38ad9d95d2ff88&amp;click_data_01=fashion-w-style
  ```
- The issue was confirmed by comparing the URLs and identifying the HTML entity encoding as the cause.

### Checklist

- [ ] All URLs are checked for proper encoding.
- [ ] Tests added or updated as necessary.
- [ ] Documentation updated if needed.
