### PR TITLE
Add URL filter for video embeds

### DIFF
--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -130,6 +130,7 @@ class Embed_Web_Video extends Component {
 					$src = 'https://player.vimeo.com/video/' . end( $matches );
 				}
 
+				// Handle any edge cases e.g., unlisted videos.
 				$src = apply_filters( 'apple_news_embed_web_video_link', $src, $url );
 
 				// If we got a hit, register the JSON and bail out.

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -24,6 +24,11 @@ class Embed_Web_Video extends Component {
 	const VIMEO_MATCH = '#^(https?:)?//(?:.+\.)?vimeo\.com/(:?.+/)?(\d+)(?:\?.*)*$#';
 
 	/**
+	 * Regex pattern for a Vimeo unlisted video query arg.
+	 */
+	const VIMEO_UNLISTED_QUERY_MATCH = '#(\?h=[a-z0-9]+)#';
+
+	/**
 	 * Regex pattern for a YouTube video.
 	 */
 	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/((watch\?v=)|(embed/))([\w\-]+)|youtu\.be/([\w\-]+))[^ ]*$#';
@@ -128,6 +133,9 @@ class Embed_Web_Video extends Component {
 					$src = 'https://www.youtube.com/embed/' . end( $matches );
 				} elseif ( preg_match( self::VIMEO_MATCH, $url, $matches ) ) {
 					$src = 'https://player.vimeo.com/video/' . end( $matches );
+					if ( preg_match( self::VIMEO_UNLISTED_QUERY_MATCH, $matches[0], $unlisted_arg ) ) {
+						$src .= $unlisted_arg[0];
+					}
 				}
 
 				// If we got a hit, register the JSON and bail out.

--- a/includes/apple-exporter/components/class-embed-web-video.php
+++ b/includes/apple-exporter/components/class-embed-web-video.php
@@ -24,11 +24,6 @@ class Embed_Web_Video extends Component {
 	const VIMEO_MATCH = '#^(https?:)?//(?:.+\.)?vimeo\.com/(:?.+/)?(\d+)(?:\?.*)*$#';
 
 	/**
-	 * Regex pattern for a Vimeo unlisted video query arg.
-	 */
-	const VIMEO_UNLISTED_QUERY_MATCH = '#(\?h=[a-z0-9]+)#';
-
-	/**
 	 * Regex pattern for a YouTube video.
 	 */
 	const YOUTUBE_MATCH = '#^https?://(?:www\.)?(?:youtube\.com/((watch\?v=)|(embed/))([\w\-]+)|youtu\.be/([\w\-]+))[^ ]*$#';
@@ -133,10 +128,9 @@ class Embed_Web_Video extends Component {
 					$src = 'https://www.youtube.com/embed/' . end( $matches );
 				} elseif ( preg_match( self::VIMEO_MATCH, $url, $matches ) ) {
 					$src = 'https://player.vimeo.com/video/' . end( $matches );
-					if ( preg_match( self::VIMEO_UNLISTED_QUERY_MATCH, $matches[0], $unlisted_arg ) ) {
-						$src .= $unlisted_arg[0];
-					}
 				}
+
+				$src = apply_filters( 'apple_news_embed_web_video_link', $src, $url );
 
 				// If we got a hit, register the JSON and bail out.
 				if ( ! empty( $src ) ) {

--- a/tests/apple-exporter/components/test-class-embed-web-video.php
+++ b/tests/apple-exporter/components/test-class-embed-web-video.php
@@ -32,11 +32,6 @@ class Apple_News_Embed_Web_Video_Test extends Apple_News_Testcase {
 				'http://vimeo.com/12819723',
 				'https://player.vimeo.com/video/12819723',
 			],
-			'Vimeo unlisted watch URL'                     => [
-				'vimeo',
-				'http://vimeo.com/100473313/463385d6a5',
-				'https://player.vimeo.com/video/100473313?h=463385d6a5',
-			],
 			'YouTube standard watch URL'                   => [
 				'youtube',
 				'https://www.youtube.com/watch?v=0qwALOOvUik',

--- a/tests/apple-exporter/components/test-class-embed-web-video.php
+++ b/tests/apple-exporter/components/test-class-embed-web-video.php
@@ -32,6 +32,11 @@ class Apple_News_Embed_Web_Video_Test extends Apple_News_Testcase {
 				'http://vimeo.com/12819723',
 				'https://player.vimeo.com/video/12819723',
 			],
+			'Vimeo unlisted watch URL'                     => [
+				'vimeo',
+				'http://vimeo.com/100473313/463385d6a5',
+				'https://player.vimeo.com/video/100473313?h=463385d6a5',
+			],
 			'YouTube standard watch URL'                   => [
 				'youtube',
 				'https://www.youtube.com/watch?v=0qwALOOvUik',


### PR DESCRIPTION
This filter is meant to address a problem where [some of our Vimeo videos](https://vimeo.com/1142235727/6f40a6d82d) aren't getting included in Apple News exports. I think because they're unlisted? Taking the second alphanumeric part of the URL path and appending it to the embed URL as `?h=[hash]` fixes the problem, which this filter enables us to do.