### PR TITLE
Drop support for old versions of PHP (8.0, 8.1)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         multisite: [true, false]
-        php: ['8.3', '8.2', '8.1', '8.0']
+        php: ['8.3', '8.2']
         wordpress: ["latest"]
         include:
-          - php: '8.0'
+          - php: '8.2'
             wordpress: '6.3'
             multisite: false
     if: github.event.pull_request.draft == false

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license"    : "GPL-3.0-or-later",
   "require"    : {
     "composer/installers": "^1.12.0",
-    "php": ">=8.0"
+    "php": "^8.2"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0.1",

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: potatomaster, kevinfodness, jomurgel, tylermachado, benpbolton, al
 Donate link: https://wordpress.org
 Tags: publish, apple, news, iOS
 Requires at least: 6.3
-Tested up to: 6.8
-Requires PHP: 8.0
+Tested up to: 6.9
+Requires PHP: 8.2
 Stable tag: 2.7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html


### PR DESCRIPTION
## Summary

Including support for older versions of PHP is breaking tests, where libraries have moved to newer versions of PHP as minimum requirements. Since PHP 8.0 and 8.1 are no longer receiving security patches, this is a good time to update the minimum to the oldest actively supported release, which is 8.2.

Supersedes #1259 because this fix is narrower in scope. We will need to refactor the tests at some point, but this fix will unblock PR merges in the interim.