### PR TITLE
Add feature to prevent wp seo video from breaking video embeds

### DIFF
--- a/admin/apple-actions/index/class-export.php
+++ b/admin/apple-actions/index/class-export.php
@@ -19,6 +19,7 @@ use Apple_Exporter\Exporter_Content;
 use Apple_Exporter\Exporter_Content_Settings;
 use Apple_Exporter\Theme;
 use Apple_Exporter\Third_Party\Jetpack_Tiled_Gallery;
+use Apple_Exporter\Third_Party\WP_SEO_Video;
 use Apple_News;
 use BC_Setup;
 
@@ -59,6 +60,7 @@ class Export extends Action {
 		$this->id = $id;
 		$this->set_theme();
 		Jetpack_Tiled_Gallery::instance();
+		WP_SEO_Video::instance();
 	}
 
 	/**

--- a/includes/apple-exporter/third-party/class-wp-seo-video.php
+++ b/includes/apple-exporter/third-party/class-wp-seo-video.php
@@ -51,7 +51,7 @@ class WP_SEO_Video {
 	 */
 	public function unhook_replace_youtube_block_html() {
 		global $wpseo_video_embed;
-		if (  isset( $wpseo_video_embed ) && $wpseo_video_embed instanceof \WPSEO_Video_Embed ) {
+		if ( isset( $wpseo_video_embed ) && $wpseo_video_embed instanceof \WPSEO_Video_Embed ) {
 			remove_filter( 'render_block', [ $wpseo_video_embed, 'replace_youtube_block_html' ], 10, 2 );
 		}
 	}

--- a/includes/apple-exporter/third-party/class-wp-seo-video.php
+++ b/includes/apple-exporter/third-party/class-wp-seo-video.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Publish to Apple News: \Apple_Exporter\Third_Party\WP_SEO_Video class
+ *
+ * @package Apple_News
+ * @subpackage Apple_Exporter\Third_Party
+ */
+
+namespace Apple_Exporter\Third_Party;
+
+/**
+ * Custom video embed handling.
+ * This unhooks the WP SEO video embed handler
+ * during Apple News exports.
+ *
+ * @since 2.7.3
+ */
+class WP_SEO_Video {
+
+	/**
+	 * Instance of the class.
+	 *
+	 * @var WP_SEO_Video
+	 */
+	private static $instance;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return WP_SEO_Video
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new WP_SEO_Video();
+			self::$instance->setup();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Setup of the singleton instance.
+	 */
+	private function setup() {
+		// Only do this on export in Apple News context.
+		add_action( 'apple_news_do_fetch_exporter', [ $this, 'unhook_replace_youtube_block_html' ] );
+	}
+
+	/**
+	 * Disable WP SEO Video's deferred embed loading feature when exporting.
+	 */
+	public function unhook_replace_youtube_block_html() {
+		global $wpseo_video_embed;
+		if (  isset( $wpseo_video_embed ) && $wpseo_video_embed instanceof \WPSEO_Video_Embed ) {
+			remove_filter( 'render_block', [ $wpseo_video_embed, 'replace_youtube_block_html' ], 10, 2 );
+		}
+	}
+}


### PR DESCRIPTION
Addresses #1260 by removing the hook Yoast's WP SEO Video plugin uses to defer video loading when the plugin is generating an export.

If the Yoast WP Video SEO plugin isn't installed or its feature for delaying video loading isn't enabled, this feature doesn't do anything but ask to remove a filter that isn't present. If the request isn't an export, this feature doesn't do anything at all.