### PR TITLE
Release v2.8.0

### DIFF
--- a/apple-news.php
+++ b/apple-news.php
@@ -3,7 +3,7 @@
  * Plugin Name: Publish To Apple News
  * Plugin URI:  http://github.com/alleyinteractive/apple-news
  * Description: Export and sync posts to Apple format.
- * Version:     2.7.2
+ * Version:     2.8.0
  * Author:      Alley
  * Author URI:  https://alley.com
  * Text Domain: apple-news

--- a/includes/class-apple-news.php
+++ b/includes/class-apple-news.php
@@ -50,7 +50,7 @@ class Apple_News {
 	 * @var string
 	 * @access public
 	 */
-	public static string $version = '2.7.2';
+	public static string $version = '2.8.0';
 
 	/**
 	 * Link to support for the plugin on WordPress.org.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-to-apple-news",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "hasInstallScript": true,
       "license": "GPLv3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-to-apple-news",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "license": "GPLv3",
   "main": "index.php",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: publish, apple, news, iOS
 Requires at least: 6.3
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 2.7.2
+Stable tag: 2.8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -44,6 +44,12 @@ Please visit our [wiki](https://github.com/alleyinteractive/apple-news/wiki) for
 4. Manage posts in Apple News right from the post edit screen
 
 == Changelog ==
+
+= 2.8.0 =
+
+* Breaking Change: Drops support for EOL PHP versions (8.0, 8.1). The minimum required PHP version is now 8.2. 
+* Enhancement: Adds a new filter, apple_news_embed_web_video_link, to filter the final video URL for an Embed Web Video component. Props to @dphiffer for the enhancement.
+* Bugfix: Fixes a conflict with the Yoast Video SEO plugin where videos that are lazy loaded weren't being properly converted to video elements in the Apple News output (e.g., YouTube).
 
 = 2.7.2 =
 


### PR DESCRIPTION
## Summary

Releases v2.8.0, which is a maintenance release that contains one enhancement, one bugfix, and includes one breaking change (setting the minimum required PHP version to 8.2).