### PR TITLE
Fix undefined array key in Gallery caption check

### DIFF
--- a/includes/apple-exporter/components/class-gallery.php
+++ b/includes/apple-exporter/components/class-gallery.php
@@ -165,7 +165,7 @@ class Gallery extends Component {
 			$caption_regex = '/<(dd|figcaption).*?>(.*)<\/\g1>/s';
 			preg_match( $caption_regex, $item_html, $matches );
 			$this->register_json(
-				! empty( trim( $matches[2] ) ) ? 'item-with-caption-json' : 'item-json',
+				! empty( trim( $matches[2] ?? '' ) ) ? 'item-with-caption-json' : 'item-json',
 				[
 					'#caption_font#'                       => $theme->get_value( 'caption_font' ),
 					'#gallery_item_accessibility_caption#' => sanitize_text_field( $accessibility_caption ),


### PR DESCRIPTION
## Summary

Fixes #1267

- Adds null coalesce operator (`?? ''`) to `$matches[2]` on line 168 of `class-gallery.php` to match the existing guard on line 172
- Prevents "Undefined array key 2" PHP warning when gallery items lack a `<dd>` or `<figcaption>` caption element

## Test plan

- [ ] Create a post with a gallery block containing images without captions
- [ ] Trigger Apple News export (save/publish the post)
- [ ] Verify no PHP warning about "Undefined array key 2" in `class-gallery.php`
- [ ] Verify gallery items without captions still export correctly using `item-json` template